### PR TITLE
RestoreLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ModelicaSpecification
-This repository contains the Modelica Language Specification.
+﻿# ModelicaSpecification
+This repository contains the Modelica Language Specification, hosted at https://github.com/modelica/ModelicaSpecification.
 
 Modelica® https://modelica.org/ is a non-proprietary, object-oriented, equation based language to conveniently model complex physical systems containing, e.g., mechanical, electrical, electronic, hydraulic, thermal, control, electric power or process-oriented subcomponents.
 
 
 How to contribute:
-1. If you find an error and are not certain that you can correct it, first check that it is not already reported and then open an issue describing it in detail - focusing on why it should be changed.
+1. If you find an error and are not certain that you can correct it, first check that it is not already reported and then open an [issue](https://github.com/modelica/ModelicaSpecification/issues) describing it in detail - focusing on why it should be changed.
 2. If you are confident that you can correct the issue, fork this repository and create a pull-request and in the pull-request explain the issue and the correction; you will also have to sign a CLA.
 3. Significant extensions are handled as Modelica Change Proposals. (Template to follow.) This can start as a simple description of the proposed extension. It will then be worked on to have a rationale explaining how the change help users, and demonstrating that it can be implemented efficiently; and finally a pull-request with the changes.
 


### PR DESCRIPTION
As discussed with Martin, the reason for having the link to the master is to avoid accidental confusion for forks.