### PR TITLE
clarify: no connectors in functions

### DIFF
--- a/functions.tex
+++ b/functions.tex
@@ -150,7 +150,7 @@ Modelica class:
   body of the function.
 \item
   A function may only contain components of the restricted classes type,
-  record, operator record, and function; i.e. no model or block
+  record, operator record, and function; i.e. no model, block or connector
   components.
 \item
   The elements of a function may not have prefixes inner, or outer.


### PR DESCRIPTION
Are connectors allowed in functions? They should be mentioned in either the may or may not group. 
https://stackoverflow.com/questions/52756479/connector-as-function-input-argument-in-modelica