### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+
+git:
+  depth: 5
+
+cache:
+  directories:
+    - /tmp/texlive
+
+before_install:
+  # Thanks to http://stackoverflow.com/a/32358866
+  # Install modules into ~/perl5 using system perl
+  - curl -L https://cpanmin.us | perl - App::cpanminus
+  - export PATH=$PATH:~/perl5/bin/
+  - cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+  - cpanm JSON
+  - cpanm --notest https://github.com/brucemiller/LaTeXML.git
+
+install:
+  # Thanks to https://github.com/ustctug/ustcthesis
+  - source ./.travis_install.sh
+
+script:
+  - make
+
+notifications:
+  email: false

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export PATH="/tmp/texlive/bin/x86_64-linux:$PATH"
+
+if ! command -v tlmgr > /dev/null; then
+    REMOTE="http://mirror.ctan.org/systems/texlive/tlnet";
+    INSTALL="/tmp/install-texlive";
+    mkdir -p $INSTALL;
+    curl -sSL $REMOTE/install-tl-unx.tar.gz | tar -xzv -C $INSTALL --strip-components=1;
+    $INSTALL/install-tl -profile ./.travis_texlive.profile;
+fi
+
+tlmgr update --self --all --reinstall-forcibly-removed;
+tlmgr install listings xcolor float;

--- a/.travis_texlive.profile
+++ b/.travis_texlive.profile
@@ -1,0 +1,8 @@
+selected_scheme scheme-basic
+TEXDIR /tmp/texlive
+TEXMFLOCAL /tmp/texlive/texmf-local
+TEXMFSYSCONFIG /tmp/texlive/texmf-config
+TEXMFSYSVAR /tmp/texlive/texmf-var
+tlpdbopt_autobackup 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 ﻿# ModelicaSpecification
 This repository contains the Modelica Language Specification, hosted at https://github.com/modelica/ModelicaSpecification.
 
-Modelica® https://modelica.org/ is a non-proprietary, object-oriented, equation based language to conveniently model complex physical systems containing, e.g., mechanical, electrical, electronic, hydraulic, thermal, control, electric power or process-oriented subcomponents.
+## Build status
+[![Build Status](https://travis-ci.org/modelica/ModelicaSpecification.svg)](https://travis-ci.org/modelica/ModelicaSpecification)
 
+## Description
 
-How to contribute:
+Modelica® https://modelica.org/ is a non-proprietary, object-oriented, equation based language to conveniently model complex physical systems containing, e.g., mechanical, electrical, electronic, magnetic, hydraulic, thermal, control, electric power or process-oriented subcomponents.
+
+## Contribution
 1. If you find an error and are not certain that you can correct it, first check that it is not already reported and then open an [issue](https://github.com/modelica/ModelicaSpecification/issues) describing it in detail - focusing on why it should be changed.
 2. If you are confident that you can correct the issue, fork this repository and create a pull-request and in the pull-request explain the issue and the correction; you will also have to sign a CLA.
 3. Significant extensions are handled as Modelica Change Proposals. (Template to follow.) This can start as a simple description of the proposed extension. It will then be worked on to have a rationale explaining how the change help users, and demonstrating that it can be implemented efficiently; and finally a pull-request with the changes.


### PR DESCRIPTION
Build (of both pdf and html) takes about 6 min at Travis CI.

Took me some [iterations](https://travis-ci.org/beutlich/ModelicaSpecification/builds) to get both builds running. TexLive 2013 (which comes with trusty) is not suitable since it misses the `\textsubscript` command. Thus, at least TexLive 2015 is required (if TeX sources must not be touched).