### PR TITLE
This fixes the ugly table from section 7.1.3

### DIFF
--- a/inheritance.tex
+++ b/inheritance.tex
@@ -103,7 +103,7 @@ Otherwise the model is incorrect.
 \begin{lstlisting}[language=modelica]
 function A
   input Real a;
-  input Real b; 
+  input Real b;
 end A;
 
 function B
@@ -146,54 +146,51 @@ can be used in an extends clause of another kind of specialized class
 (the ``grey'' cells mark the few exceptional cases, where a specialized
 class can be derived from a specialized class of another kind):
 
-{\tiny
-\begin{longtable}[]{|l|l|l|l|l|l|l|l|l|l|l|l|l|} 
-\hline \endhead 
-& \multicolumn{12}{l|}{\textbf{Base} \textbf{Class}}\\ \hline
-\begin{tabular}{@{}l@{}}
-\textbf{Derived}\\
-\textbf{Class}
-\end{tabular} & package & 
-operator
-& 
-function & \begin{tabular}{@{}l@{}}
-operator\\
-function
-\end{tabular} & 
-type & 
-record & \begin{tabular}{@{}l@{}}
-operator\\
-record\end{tabular} & \begin{tabular}{@{}l@{}}
-expandable\\
-connector\end{tabular} & 
-connector & 
-block & 
-model & 
-class\\ \hline
-package & yes & & & & & & & & & & & \cellcolor{gray}yes\\ \hline
-operator & & yes & & & & & & & & & & \cellcolor{gray}yes\\ \hline
-function & & & yes & & & & & & & & &\cellcolor{gray} yes\\ \hline
-\begin{tabular}{@{}l@{}}
-operator\\
-function
-\end{tabular}
- & & & \cellcolor{gray} yes & yes & & & & & & & & yes\\ \hline
-type & & & & & yes & & & & & & & yes\\ \hline
-record & & & & & & yes & & & & & & yes\\ \hline
-\begin{tabular}{@{}l@{}}
-operator\\
-record
-\end{tabular} & & & & & & & yes & & & & & yes \\ \hline
-\begin{tabular}{@{}l@{}}
-expandable\\
-connector
-\end{tabular} & & & & & & & & yes & & & & yes \\ \hline
-connector & & & & & \cellcolor{gray}yes &\cellcolor{gray} yes &\cellcolor{gray} yes &\cellcolor{gray} yes & yes & & & \cellcolor{gray}yes\\ \hline
-block & & & & & &\cellcolor{gray} yes & & & & yes & & \cellcolor{gray}yes\\ \hline
-model & & & & & & \cellcolor{gray}yes & & & & \cellcolor{gray}yes & yes & \cellcolor{gray}yes\\ \hline
-class & & & & & & & & & & & & yes\\ \hline
-\end{longtable}
-}
+% LaTeXML does not handle resizebox. So don't use it for HTML
+
+\begin{table}[H]
+% latexml does not like resizebox
+  \ifpdf\resizebox{\textwidth}{!}{\else\fi%
+
+\begin{tabular}{|c|c|c|c|c|c|c|c|c|c|c|c|c|}
+    \hline
+                      & \multicolumn{12}{c|}{\textbf{Base Class}}                                                                                                                                                                                                                                                                                                                          \\
+    \hline
+     \textbf{Derived} & \multirow{2}{*}{package} & \multirow{2}{*}{operator} & \multirow{2}{*}{function}                  & operator             & \multirow{2}{*}{type}    & \multirow{2}{*}{record}  & operator                 & expandable               & \multirow{2}{*}{connector} & \multirow{2}{*}{block}   & \multirow{2}{*}{model} & \multirow{2}{*}{class}                     \\
+     \textbf{Class}   &                          &                           &                                            & function             &                          &                          & record                   & connector                &                            &                          &                        &                                            \\
+     \hline
+    package           & yes                      &                           &                                            &                      &                          &                          &                          &                          &                            &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    operator          &                          & yes                       &                                            &                      &                          &                          &                          &                          &                            &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    function          &                          &                           & yes                                        &                      &                          &                          &                          &                          &                            &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    operator          &                          &                           & \cellcolor{lightgray}                      & \multirow{2}{*}{yes} &                          &                          &                          &                          &                            &                          &                        & \cellcolor{lightgray}                      \\
+    function          &                          &                           & \multirow{-2}{*}{\cellcolor{lightgray}yes} &                      &                          &                          &                          &                          &                            &                          &                        & \multirow{-2}{*}{\cellcolor{lightgray}yes}  \\
+    \hline
+    type              &                          &                           &                                            &                      & yes                      &                          &                          &                          &                            &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    record            &                          &                           &                                            &                      &                          & yes                      &                          &                          &                            &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    operator          &                          &                           &                                            &                      &                          &                          & \multirow{2}{*}{yes}     &                          &                            &                          &                        & \cellcolor{lightgray}                      \\
+    record            &                          &                           &                                            &                      &                          &                          &                          &                          &                            &                          &                        & \multirow{-2}{*}{\cellcolor{lightgray}yes} \\
+    \hline
+    expandable        &                          &                           &                                            &                      &                          &                          &                          & \multirow{2}{*}{yes}     &                            &                          &                        & \cellcolor{lightgray}                      \\
+    connector         &                          &                           &                                            &                      &                          &                          &                          &                          &                            &                          &                        & \multirow{-2}{*}{\cellcolor{lightgray}yes} \\
+    \hline
+    connector         &                          &                           &                                            &                      & \cellcolor{lightgray}yes & \cellcolor{lightgray}yes & \cellcolor{lightgray}yes & \cellcolor{lightgray}yes & yes                        &                          &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    block             &                          &                           &                                            &                      &                          & \cellcolor{lightgray}yes &                          &                          &                            & yes                      &                        & \cellcolor{lightgray}yes                   \\
+    \hline
+    model             &                          &                           &                                            &                      &                          & \cellcolor{lightgray}yes &                          &                          &                            & \cellcolor{lightgray}yes & yes                    & \cellcolor{lightgray}yes                   \\
+    \hline
+    class             &                          &                           &                                            &                      &                          &                          &                          &                          &                            &                          &                        & yes                                        \\
+    \hline
+  \end{tabular}
+% close resizebox
+  \ifpdf}\else\fi%
+\end{table}
+
 
 If a derived class is inherited from another type of specialized class,
 then the result is a specialized class of the derived class type.
@@ -281,7 +278,7 @@ if the modified variable is a non-parameter (here: c1.x) variable.
 {[}\emph{This equation is created, if the modified component (here: c1)
 is also created (see \ref{class-declarations}). In most cases a
 modification equation for a non-parameter variable requires that the
-variable was declared with a declaration equation, see \ref{balanced-models}; 
+variable was declared with a declaration equation, see \ref{balanced-models};
 in those cases the declaration equation is replaced by the
 modification equation.}{]}
 
@@ -427,7 +424,7 @@ end C4;
 \emph{A flattening of class} C4 \emph{will give an object with the
 following variables: }
 
-\begin{longtable}[]{|@{}l|l@{}|} 
+\begin{longtable}[]{|@{}l|l@{}|}
 \hline \endhead
 \emph{Variable} & \emph{Default value}\\ \hline
 \emph{x1} & \emph{none}\\ \hline
@@ -709,7 +706,7 @@ class-specifier nonterminal (see also class declarations in \ref{class-declarati
 class-definition :
    [ encapsulated ] class-prefixes
    class-specifier
-   
+
 class-specifier : long-class-specifier | ...
 
 long-class-specifier : ...
@@ -764,11 +761,11 @@ end PartialMedium;
 
 package MoistAir "Special type of medium"
   extends PartialMedium(nX=2);
-  
+
   redeclare model extends BaseProperties(T(stateSelect=StateSelect.prefer))
     // replaces BaseProperties by a new implementation and // extends from Baseproperties with modification
     // note, nX = 2 (!)
-  equation 
+  equation
     X = {0,1};
     ...
   end BaseProperties;
@@ -776,7 +773,7 @@ package MoistAir "Special type of medium"
   redeclare function extends dynamicViscosity
     // replaces dynamicViscosity by a new implementation and
     // extends from dynamicViscosity
-  algorithm 
+  algorithm
     eta := 2*p;
   end dynamicViscosity;
 end MoistAir;
@@ -802,17 +799,17 @@ package MoistAir2 "Alternative definition that does not work"
   extends PartialMedium(nX=2,
     redeclare model BaseProperties = MoistAir_BaseProperties,
     redeclare function dynamicViscosity = MoistAir_dynamicViscosity);
-    
+
   model MoistAir_BaseProperties
     // wrong model since nX has no value
     extends PartialMedium.BaseProperties;
-  equation 
+  equation
     X = {1,0};
   end MoistAir_BaseProperties;
 
   model MoistAir_dynamicViscosity
     extends PartialMedium.dynamicViscosity;
-  algorithm 
+  algorithm
     eta := p;
   end MoistAir_dynamicViscosity;
 end MoistAir2;
@@ -841,7 +838,7 @@ practically useful definition is the complicated construction in the
 previous example with ``\textbf{redeclare model extends}
 BaseProperties''.
 
-To detect this issue the rule on lookup of composite names (\ref{composite-name-lookup}) 
+To detect this issue the rule on lookup of composite names (\ref{composite-name-lookup})
 ensures that `PartialMedium\allowbreak{}.dynamicViscosity' is incorrect in a
 simulation model.
 
@@ -878,7 +875,7 @@ constraining-clause :
 class A
   parameter Real x;
 end A;
-  
+
 class B
   parameter Real x=3.14, y; // B is a subtype of A
 end B;
@@ -1011,7 +1008,7 @@ replaceable model Load2=Resistor "The Load" constrainedby TwoPin; //Identical to
 replaceable model Load3=Resistor "The Load" constrainedby TwoPin "The Load"; //Error
 
 replaceable Resistor load1 constrainedby TwoPin "The Load"; //Recommended
-replaceable Resistor load2 "The Load" constrainedby TwoPin; //Identical to load1 
+replaceable Resistor load2 "The Load" constrainedby TwoPin; //Identical to load1
 replaceable Resistor load3 "The Load" constrainedby TwoPin "The Load!"; //Error
 \end{lstlisting}
 
@@ -1077,20 +1074,20 @@ replaceable model MyResistor=Resistor
   annotation(choices(
                choice(redeclare model MyResistor=lib2.Resistor(a={2}) "..."),
                choice(redeclare model MyResistor=lib2.Resistor2 "...")));
-	       
+
 replaceable Resistor Load(R=2) constrainedby TwoPin
   annotation(choices(
                choice(redeclare lib2.Resistor Load(a={2}) "..."),
                choice(redeclare Capacitor Load(L=3) "...")));
-	       
+
 replaceable FrictionFunction a(func=exp) constrainedby Friction
   annotation(choices(
                choice(redeclare ConstantFriction a(c=1) "..."),
                choice(redeclare TableFriction a(table="...") "..."),
                choice(redeclare FunctionFriction a(func=exp) "..."))));
-	       
+
 replaceable package Medium = Modelica.Media.Water.ConstantPropertyLiquidWater
-          constrainedby Modelica.Media.Interfaces.PartialMedium 
+          constrainedby Modelica.Media.Interfaces.PartialMedium
 	     annotation (choicesAllMatching=true);
 \end{lstlisting}
 
@@ -1102,7 +1099,7 @@ type KindOfController=Integer(min=1,max=3)
               choice=1 "P",
               choice=2 "PI",
               choice=3 "PID"));
-	      
+
 model A
   KindOfController x;
 end A;

--- a/preamble.tex
+++ b/preamble.tex
@@ -8,7 +8,7 @@
 \usepackage{amsmath}
 \allowdisplaybreaks
 
-%For non-floating figures:
+% For non-floating figures:
 \usepackage{float}
 
 % Prefer pdf for pdf
@@ -25,7 +25,7 @@
 \usepackage[margin=1in]{geometry}
 
 %\usepackage{t1enc}
-\usepackage[dvips]{graphicx}
+\usepackage{graphicx}
 \usepackage{verbatim}
 % The fixltx2e that was used for textsubscript is no longer needed for pdf, but is needed by latexml
 \ifpdf

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,8 +1,8 @@
 
 % This suppresses warnings about most overfull hboxes.
-% Clearly it would be better to fix them, but if we anyway want to 
+% Clearly it would be better to fix them, but if we anyway want to
 % change the layout that can wait
-\hfuzz=50pt 
+\hfuzz=50pt
 
 % Uses some packages:
 \usepackage{amsmath}
@@ -16,7 +16,7 @@
 \usepackage{ifpdf}
 \ifpdf
 \makeatletter
-\let\orig@Gin@extensions\Gin@extensions 
+\let\orig@Gin@extensions\Gin@extensions
 \def\Gin@extensions{.pdf,\orig@Gin@extensions} %prepend .pdf before .png
 \makeatother
 \fi
@@ -55,7 +55,8 @@
 % Note that this can often lead to overfull vbox
 % See https://tex.stackexchange.com/questions/71096/underfull-vbox-in-each-longtable-can-it-be-fixed-or-must-it-be-ignored
 \usepackage{longtable}
-\usepackage{listings} 
+\usepackage{multirow} % for multirow entries in tables
+\usepackage{listings}
 \usepackage{color}
 \usepackage[table]{xcolor}
 %\def\doublelabel#1{\label{#1}\hypertarget{#1}{}}
@@ -81,9 +82,9 @@
 }
 \setcounter{secnumdepth}{5}
 % Note: Toc changed for appendex
-\setcounter{tocdepth}{1} 
-\definecolor{keywordcolor1}{rgb}{0,0,.4} 
-\definecolor{keywordcolor2}{rgb}{.90,0,0} 
+\setcounter{tocdepth}{1}
+\definecolor{keywordcolor1}{rgb}{0,0,.4}
+\definecolor{keywordcolor2}{rgb}{.90,0,0}
 % See https://github.com/modelica-tools/listings-modelica/blob/master/listings-modelica.cfg
 % Note: Changed comment color from green to [rgb]{0,0.4,0} - since the other variant was too distracting
 % And added pure,impure,stream as keywords
@@ -115,23 +116,23 @@ breakatwhitespace=true,
 morekeywords=[2]{letters}
 morekeywords=[1]{|}
 }[keywords,comments,strings]
-\lstset{ % 
-  backgroundcolor=\color{white},   % choose the background color 
-  basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code 
-  breaklines=true,                % automatic line breaking only at whitespace 
-  captionpos=b,                    % sets the caption-position to bottom 
-  commentstyle=\color[rgb]{0,0.4,0}\sffamily,    % comment style 
-  keywordstyle=\color{blue}\ttfamily\bfseries,       % keyword style 
-  keywordstyle=[1]\color{keywordcolor1}, 
-  keywordstyle=[2]\color{keywordcolor1}\bfseries, 
-  keywordstyle=[3]\color{keywordcolor2}, 
-  stringstyle=\color{black},     % string literal style 
-  language=modelica,             % Set your language (you can change the language for each code-block optionally) 
+\lstset{ %
+  backgroundcolor=\color{white},   % choose the background color
+  basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
+  breaklines=true,                % automatic line breaking only at whitespace
+  captionpos=b,                    % sets the caption-position to bottom
+  commentstyle=\color[rgb]{0,0.4,0}\sffamily,    % comment style
+  keywordstyle=\color{blue}\ttfamily\bfseries,       % keyword style
+  keywordstyle=[1]\color{keywordcolor1},
+  keywordstyle=[2]\color{keywordcolor1}\bfseries,
+  keywordstyle=[3]\color{keywordcolor2},
+  stringstyle=\color{black},     % string literal style
+  language=modelica,             % Set your language (you can change the language for each code-block optionally)
   showstringspaces=false,
-  frame=lrtb, % 
-  xleftmargin=\fboxsep, % 
-  xrightmargin=-\fboxsep, % 
-} 
+  frame=lrtb, %
+  xleftmargin=\fboxsep, %
+  xrightmargin=-\fboxsep, %
+}
 
 % Duplicate this definition here to avoid issue - and name it "fortran77" to avoid problem in LatexML
 \lstdefinelanguage{fortran77}%
@@ -172,7 +173,7 @@ morekeywords=[1]{|}
    moredirectives={define,elif,else,endif,error,if,ifdef,ifndef,line,%
       include,pragma,undef,warning}%
   }[keywords,comments,strings,directives]%
-  
+
 % Note: \lstinline!...! used for inline Modelica
 \title{Modelica® - A Unified Object-Oriented Language for Systems
 Modeling\\[2\baselineskip]Language


### PR DESCRIPTION
The (probably auto generated) table looked awful. This PR converts it from:
![image](https://user-images.githubusercontent.com/9332/49601784-0edbff00-f987-11e8-953d-b959d2aa883e.png)

to 

![image](https://user-images.githubusercontent.com/9332/49601975-a3466180-f987-11e8-8c3a-5ac1cf2ed91c.png)

Tested on PDF and HTML output.