### PR TITLE
Clarification for ModelicaAllocateString(len)

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2420,11 +2420,11 @@ And then the string handling functions:
 ModelicaAllocateString & 
 \begin{tabular}{@{}p{8.cm}@{}}
 \emph{char* ModelicaAllocateString(size\_t len)} \\
-Allocate memory for a Modelica string which is used as return argument
-of an external Modelica function. Note, that the storage for string
-arrays (= pointer to string array) is still provided by the calling
-program, as for any other array. If an error occurs, this function does
-not return, but calls "ModelicaError".
+Allocate memory for a Modelica string (i.e., \emph{len}+1 bytes)
+which is used as return argumentof an external Modelica function.
+Note, that the storage for string arrays (= pointer to string array)
+is still provided by the calling program, as for any other array.
+If an error occurs, this function does not return, but calls "ModelicaError".
 \end{tabular}\\ \hline
 ModelicaAllocateStringWithErrorReturn & 
 \begin{tabular}{@{}p{8.cm}@{}}


### PR DESCRIPTION
ModelicaAllocateString(len) should allocate len+1 bytes to accomodate a trailing '\0' character.
However, this was not stated explicitly in the text. It is made explicit in this change.