### PR TITLE
Proper references

### DIFF
--- a/chapters/glossary.tex
+++ b/chapters/glossary.tex
@@ -17,8 +17,7 @@ element in the sequence of components of an array x is the array element
   type. An array element may again be an array, i.e. arrays can be nested.
 An array element is hence referenced using n indices in general, where n
 is the number of dimensions of the array. Special cases are matrix (n=2)
-and vector (n=1). Integer indices start with 1, not zero. (See Chapter
-10.)
+and vector (n=1). Integer indices start with 1, not zero. (See \autoref{arrays}.)
 
 \textbf{array constructor}: an array can be built using the
 array-function -- with the shorthand \{a, b, \ldots{}\}, and can also
@@ -131,7 +130,7 @@ the condition occurring in a when clause, if clause, or if expression.
 
 \textbf{expression}: a term built from operators, function references,
 components, or component references (referring to components) and
-literals. Each expression has a type and a variability. (See Chapter 3.)
+literals. Each expression has a type and a variability. (See \autoref{operators-and-expressions}.)
 
 \textbf{extends clause}: an unnamed element of a class definition that
 uses a name and an optional modification to specify a base class of the
@@ -142,8 +141,7 @@ given class, where all inheritance, modification, etc. has been
 performed and all names resolved, consisting of a flat set of equations,
 algorithm sections, component declarations, and functions. (See \autoref{flattening-process}.)
 
-\textbf{function}: a class of the specialized class function. (See
-Chapter 12.)
+\textbf{function}: a class of the specialized class function. (See \autoref{functions}.)
 
 \textbf{function subtype} or \textbf{function compatible interface}: A
 is a function subtype of B iff A is a subtype of B and the additional

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -100,7 +100,7 @@ A \emph{name} is an identifier with a certain interpretation or meaning.
 For example, a name may denote an Integer variable, a Real variable, a
 function, a type, etc. A name may have different meanings in different
 parts of the code, i.e., different scopes. The interpretation of
-identifiers as names is described in more detail in Chapter 5. The
+identifiers as names is described in more detail in \autoref{scoping-name-lookup-and-flattening}. The
 meaning of package names is described in more detail in \autoref{packages}.
 
 \subsection{Modelica Keywords}\doublelabel{modelica-keywords}


### PR DESCRIPTION
Don't use "Chapter 5" to reference "Chapter 5". 

As far as I can tell the only remaining absolute chapter/section reference is the one referring to a specific section in the C-standard.