### PR TITLE
Short modelica listings

### DIFF
--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -57,7 +57,7 @@ Note:
   comments.
 \item
   Description strings (= production ``string-comment'' in the grammar)
-  and strings in annotations (= STRING with production annotation in the
+  and strings in annotations (= STRING with production annotation-comment in the
   grammar) may contain any member of the Unicode character set. All
   other strings have to contain only the sub-set of Unicode characters
   identical with the 7-bit US-ASCII character set. {[}\emph{As a
@@ -125,8 +125,8 @@ composition :
      algorithm-section
    }
    [ external [ language-specification ]
-   [ external-function-call ] [ annotation ] ";" ]
-   [ annotation ";" ]
+   [ external-function-call ] [ annotation-comment ] ";" ]
+   [ annotation-comment ";" ]
 
 language-specification :
    STRING
@@ -411,11 +411,11 @@ subscript :
    ":" | expression
    
 comment :
-   string-comment [ annotation ]
+   string-comment [ annotation-comment ]
    
 string-comment :
 [ STRING { "+" STRING } ]
 
-annotation :
+annotation-comment :
    annotation class-modification
 \end{lstlisting}

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,4 +1,4 @@
-
+﻿
 % This suppresses warnings about most overfull hboxes.
 % Clearly it would be better to fix them, but if we anyway want to
 % change the layout that can wait
@@ -159,8 +159,8 @@ morekeywords=[2]{letters,
         function,if,in,inner,initial,input,import,loop,model,nondiscrete,operator,outer,%
         output,package,parameter,partial,record,redeclare,replaceable,return,%
         size,stream,terminate,then,type,when,while,algorithm,equation,%
-        protected,public,and,false,not,or,true,pure,impure,stream,transition,initialState,
-		within}
+        protected,public,and,false,not,or,true,pure,impure,stream,transition,initialState,%
+        within},
 morekeywords=[1]{|}
 }[keywords,comments,strings]
 \lstset{ %

--- a/preamble.tex
+++ b/preamble.tex
@@ -108,9 +108,9 @@
     %otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
     morekeywords=[1]{},% blue Keywords
     morekeywords=[2]{% blue + bold keywords
-        annotation,assert,block,break,class,connector,constant,discrete,%
-        encapsulated,else,elseif,elsewhen,end,exit,extends,external,final,flow,for,%
-        function,if,in,inner,initial,input,import,loop,model,nondiscrete,outer,%
+        annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
+        each,encapsulated,else,elseif,elsewhen,end,exit,expandable,extends,external,final,flow,for,%
+        function,if,in,inner,initial,input,import,loop,model,nondiscrete,operator,outer,%
         output,package,parameter,partial,record,redeclare,replaceable,return,%
         size,stream,terminate,then,type,when,while,algorithm,equation,%
         protected,public,and,false,not,or,true,pure,impure,transition,initialState},%
@@ -130,9 +130,9 @@
     %otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
     morekeywords=[1]{},% blue Keywords
     morekeywords=[2]{% blue + bold keywords
-        annotation,assert,block,break,class,connector,constant,discrete,%
-        encapsulated,else,elseif,elsewhen,end,exit,extends,external,final,flow,for,%
-        function,if,in,inner,initial,input,import,loop,model,nondiscrete,outer,%
+        annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
+        each,encapsulated,else,elseif,elsewhen,end,exit,expandable,extends,external,final,flow,for,%
+        function,if,in,inner,initial,input,import,loop,model,nondiscrete,operator,outer,%
         output,package,parameter,partial,record,redeclare,replaceable,return,%
         size,stream,terminate,then,type,when,while,algorithm,equation,%
         protected,public,and,false,not,or,true,pure,impure,transition,initialState},%
@@ -146,6 +146,7 @@
     morestring=[b]{'}, %
     morestring=[b]{"},
 }[keywords,comments,strings]
+% Note: within only a keyword in grammar
 \lstdefinelanguage{grammar}{
 alsoletter={...},
 alsodigit={-},
@@ -153,12 +154,13 @@ basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
 breaklines=true,
 breakatwhitespace=true,
 morekeywords=[2]{letters,
-        annotation,assert,block,break,class,connector,constant,discrete,%
-        encapsulated,else,elseif,elsewhen,end,exit,extends,external,final,flow,for,%
-        function,if,in,inner,initial,input,import,loop,model,nondiscrete,outer,%
+        annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
+        each,encapsulated,else,elseif,elsewhen,end,exit,expandable,extends,external,final,flow,for,%
+        function,if,in,inner,initial,input,import,loop,model,nondiscrete,operator,outer,%
         output,package,parameter,partial,record,redeclare,replaceable,return,%
         size,stream,terminate,then,type,when,while,algorithm,equation,%
-        protected,public,and,false,not,or,true,pure,impure,stream,transition,initialState}
+        protected,public,and,false,not,or,true,pure,impure,stream,transition,initialState,
+		within}
 morekeywords=[1]{|}
 }[keywords,comments,strings]
 \lstset{ %

--- a/preamble.tex
+++ b/preamble.tex
@@ -99,8 +99,34 @@
 % Note: Changed comment color from green to [rgb]{0,0.4,0} - since the other variant was too distracting
 % And added pure,impure,stream as keywords
 % Remove cross as red
+% Note: have basicstyle=\footnotesize\ttfamily in all languages,
+% except the dialect [short]modelica - which is used for inline listings.
+% Apart from that change that dialect should be identical to modelica
 \lstdefinelanguage{modelica}{%
     alsoletter={...},%
+	basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
+    %otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
+    morekeywords=[1]{},% blue Keywords
+    morekeywords=[2]{% blue + bold keywords
+        annotation,assert,block,break,class,connector,constant,discrete,%
+        encapsulated,else,elseif,elsewhen,end,exit,extends,external,final,flow,for,%
+        function,if,in,inner,initial,input,import,loop,model,nondiscrete,outer,%
+        output,package,parameter,partial,record,redeclare,replaceable,return,%
+        size,stream,terminate,then,type,when,while,algorithm,equation,%
+        protected,public,and,false,not,or,true,pure,impure,transition,initialState},%
+    % Note: initial is in both variants - depending on context, use first variant
+    morekeywords=[3]{% red keywords
+        abs,acos,asin,atan,atan2,connect,cos,cosh,der,edge,exp,%
+        noEvent,pre,reinit,sample,sign,sin,sinh,tan,tanh,terminal,%
+        start,Real,Integer,Boolean,String,homotopy,spatialDistribution,cardinality},%
+    comment=[l]{//}, % comment lines
+    morecomment=[s]{/*}{*/}, % comment blocs
+    morestring=[b]{'}, %
+    morestring=[b]{"},
+}[keywords,comments,strings]
+\lstdefinelanguage[short]{modelica}{%
+    alsoletter={...},%
+	basicstyle=\ttfamily,        % size of fonts used for the code
     %otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
     morekeywords=[1]{},% blue Keywords
     morekeywords=[2]{% blue + bold keywords
@@ -123,6 +149,7 @@
 \lstdefinelanguage{grammar}{
 alsoletter={...},
 alsodigit={-},
+basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
 breaklines=true,
 breakatwhitespace=true,
 morekeywords=[2]{letters,
@@ -136,7 +163,7 @@ morekeywords=[1]{|}
 }[keywords,comments,strings]
 \lstset{ %
   backgroundcolor=\color{white},   % choose the background color
-  basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
+  %basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
   breaklines=true,                % automatic line breaking only at whitespace
   captionpos=b,                    % sets the caption-position to bottom
   commentstyle=\color[rgb]{0,0.4,0}\sffamily,    % comment style
@@ -145,7 +172,7 @@ morekeywords=[1]{|}
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
   keywordstyle=[3]\color{keywordcolor2},
   stringstyle=\color{black},     % string literal style
-  language=modelica,             % Set your language (you can change the language for each code-block optionally)
+  language=[short]modelica,             % Set your language (you can change the language for each code-block optionally)
   showstringspaces=false,
   frame=lrtb, %
   xleftmargin=\fboxsep, %
@@ -154,7 +181,8 @@ morekeywords=[1]{|}
 
 % Duplicate this definition here to avoid issue - and name it "fortran77" to avoid problem in LatexML
 \lstdefinelanguage{fortran77}%
-  {morekeywords={ASSIGN,BACKSPACE,CALL,CHARACTER,%
+  {basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
+   morekeywords={ASSIGN,BACKSPACE,CALL,CHARACTER,%
       CLOSE,COMMON,COMPLEX,CONTINUE,DATA,DIMENSION,DO,DOUBLE,%
       ELSE,ELSEIF,END,ENDIF,ENDDO,ENTRY,EQUIVALENCE,EXTERNAL,%
       FILE,FORMAT,FUNCTION,GO,TO,GOTO,IF,IMPLICIT,%
@@ -178,7 +206,8 @@ morekeywords=[1]{|}
    morestring=[d]'%
   }[keywords,comments,strings]%
 \lstdefinelanguage{C}%
-  {morekeywords={auto,break,case,char,const,continue,default,do,double,%
+  {basicstyle=\footnotesize\ttfamily,        % size of fonts used for the code
+   morekeywords={auto,break,case,char,const,continue,default,do,double,%
       else,enum,extern,float,for,goto,if,int,long,register,return,%
       short,signed,sizeof,static,struct,switch,typedef,union,unsigned,%
       void,volatile,while},%
@@ -192,7 +221,7 @@ morekeywords=[1]{|}
       include,pragma,undef,warning}%
   }[keywords,comments,strings,directives]%
 
-% Note: \lstinline!...! used for inline Modelica
+% Note: \lstinline!...! used for inline Modelica using [short]modelica
 \title{Modelica® - A Unified Object-Oriented Language for Systems
 Modeling\\[2\baselineskip]Language
 Specification\\[2\baselineskip]Version 3.5-dev}


### PR DESCRIPTION
Use smaller font for normal listings, but not for inline ones.
To make existing listing more consistent: add all keywords, and change grammar so that it isn't "annotation: annotation modifier"