### PR TITLE
Add Selective model extension.

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -1,3 +1,4 @@
+
 # MCP Rationale
 This directory should contain the rationale behind Modelica Change Proposals, MCPs,
 (and possibly rationale behind other decisions as well). The proposals shall adhere to the [guiding principles](GuidingPrinciples.MD).
@@ -21,6 +22,7 @@ New MCP should be added to the following list - on the main branch to keep track
 but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
+- MCP0032 Selective Model Extension
 - MCP0031 Flat Modelica and MLS modularization
 - MCP0030 IsClocked Operator ([#2238](https://github.com/modelica/ModelicaSpecification/issues/2238))
 - MCP0029 License Export ([#2217](https://github.com/modelica/ModelicaSpecification/issues/2217))


### PR DESCRIPTION
Discussion in design group:

**General discussion:**

Some preference for "break" inside extends-modifier - and ignore the multiple-inheritance issue (i.e. it is necessary to repeat it for each extends clause if deselected component is inherited several times).
That also supports hierarchical deselection - but you also need to add new components which is not possible; so it doesn't really work.
Thus only allow it directly inside extends-modifier, and "break" is good enough.
Skip fine-grained connect deselection (i.e. removing part of connection).
Subtyping similar as conditional declaration.
Possibly related to removing binding equation (MCP0009) - but not the same (using "undefined"). MCP0009 would remove the binding for the parameter - this would remove the parameter itself.
Henrik: Show how constrainedby is already different from extends.

**Poll for potentially introducing selective model extension in Modelica (using MCP-process):**

- **Favor: 12**
- Against: 0
- Abstain: 3

**Syntax discussion:**

Brainstorm alternative keywords: "not" (break is good for connect - but less for components), 
remove, ignore, or "redeclare Clutch clutch1 if false" after component.
"notPresent", "deselect" (but seems like de-selecting in GUI), "without", "undeclare".
Or use new character "$ignore clutch".
Or use some new function syntax?

**Poll for keyword (as modifier inside extends):**

- **break: 10**
- not: 2
- remove: 4
- ignore: 2
- "redeclare ... if false": 1
- notPresent: 0
- deselect: 3
- without:  3
- undeclare: 4
- $something: 1
- new function syntax: 2