### PR TITLE
Allocating MCP number for "Annotations for Predefined Plots"

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -22,6 +22,7 @@ New MCP should be added to the following list - on the main branch to keep track
 but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
+- MCP0033 Annotations for Predefined Plots
 - MCP0032 Selective Model Extension
 - MCP0031 Flat Modelica and MLS modularization ([MCP/0031](https://github.com/modelica/ModelicaSpecification/tree/MCP/0031))
 - MCP0030 IsClocked Operator ([#2238](https://github.com/modelica/ModelicaSpecification/issues/2238))


### PR DESCRIPTION
There are now at least three parties interested in driving this idea forward (MAP-Lib, MathCore, and OpenModelica users), so it is time to get the work to prepare an MCP started.