### PR TITLE
Find files with trailing whitespace

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
       beforeAgent true
     }
     steps {
+      sh label: "Find files with trailing whitespace", script: 'find * -type f -name "*.tex" -exec egrep -l " +$" {} \;'
       sh 'python3 .CI/index.py'
       sshPublisher(publishers: [sshPublisherDesc(configName: 'ModelicaSpecification', transfers: [sshTransfer(sourceFiles: 'index.html')])])
     }


### PR DESCRIPTION
Note: This should not be possible to merge until all whitespace has been removed (which we should not do until #2353 is fixed).