### PR TITLE
Find files with trailing whitespace

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -4,6 +4,17 @@ pipeline {
     disableConcurrentBuilds()
   }
   stages {
+  stage('checks') {
+    agent {
+      docker {
+        image 'alpine:3.9'
+        label 'linux'
+      }
+    }
+    steps {
+      sh label: "Find files with trailing whitespace", script: '! grep -n "[ \t]$" *.tex chapters/*.tex'
+    }
+  }
   stage('build') {
     agent {
       docker {


### PR DESCRIPTION
The CI should fail if we find any LaTeX file with trailing whitespace.

Note: This should not be possible to merge until all whitespace has been removed (which we should not do until #2353 is fixed).