### PR TITLE
Allocate MCP number for "Generalized Modelica URIs for external resources"

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -22,6 +22,7 @@ New MCP should be added to the following list - on the main branch to keep track
 but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
+- MCP0034 Generalized Modelica URIs for external resources
 - MCP0033 Annotations for Predefined Plots ([MCP/0033](https://github.com/modelica/ModelicaSpecification/tree/MCP/0033/RationaleMCP/0033))
 - MCP0032 Selective Model Extension ([MCP/0032](https://github.com/modelica/ModelicaSpecification/tree/MCP/0032/RationaleMCP/0032))
 - MCP0031 Flat Modelica and MLS modularization ([MCP/0031](https://github.com/modelica/ModelicaSpecification/tree/MCP/0031/RationaleMCP/0031))


### PR DESCRIPTION
The email thread _Problems with section 13.2.3_ initiated by @mtiller is becoming too long to remain outside the tracking system.  Opening this draft PR so that we can continue the discussion whether to initiate a new MCP here.
