### PR TITLE
Update for-statement to refer to for-equation and clarify evaluation.

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -103,15 +103,17 @@ The following is one example of a prefix of a for-equation:
 for IDENT in expression loop
 \end{lstlisting}
 
-The \lstinline!expression! of a for-equation shall be a vector expression. It is
-evaluated once for each for-equation, and is evaluated in the scope
+\subsubsection{Explicit Iteration Ranges of For-Equations}\doublelabel{explicit-iteration-ranges-of-for-equations}
+The \lstinline!expression! of a for-equation shall be a vector expression,
+where more general array expressions are treated as vector of vectors or vector of matrices.
+It is evaluated once for each for-equation, and is evaluated in the scope
 immediately enclosing the for-equation. The expression of a for-equation
 shall be a parameter expression. The iteration range of a for-equation
 can also be specified as Boolean or as an enumeration type, see
 \autoref{types-as-iteration-ranges} for more information. The loop-variable (\lstinline!IDENT!) is in scope
-inside the loop-construct and shall not be assigned to. The
-loop-variable has the same type as the type of the elements of the
-vector expression.
+inside the loop-construct and shall not be assigned to.
+For each element of the evaluated vector expression, in the normal order, the loop-variable
+gets the value of that element and that is used to evaluate the body of the for-loop.
 
 {[}\emph{Example}:
 \begin{lstlisting}[language=modelica]
@@ -135,6 +137,7 @@ equation
   end for;
 \end{lstlisting}
 {]}
+
 
 \subsubsection{Implicit Iteration Ranges of For-Equations}\doublelabel{implicit-iteration-ranges-of-for-equations}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -193,7 +193,7 @@ The following is an example of a prefix of a for-statement:
 \begin{lstlisting}[language=modelica]
 for IDENT in expression loop
 \end{lstlisting}
-The rules for-statements are the same as for for-expressions in \autoref{explicit-iteration-ranges-of-for-equations} -
+The rules for for-statements are the same as for for-expressions in \autoref{explicit-iteration-ranges-of-for-equations} -
 except that the \lstinline!expression! of a for-statement is not restricted to a parameter-expression.
 
 {[}\emph{Example}:

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -193,12 +193,8 @@ The following is an example of a prefix of a for-statement:
 \begin{lstlisting}[language=modelica]
 for IDENT in expression loop
 \end{lstlisting}
-The \lstinline!expression! of a for-statement shall be a vector expression. It is
-evaluated once for each for-statement, and is evaluated in the scope
-immediately enclosing the for-statement. The loop-variable (\lstinline!IDENT!) is in
-scope inside the loop-construct and shall not be assigned to. The
-loop-variable has the same type as the type of the elements of the
-vector expression.
+The rules for-statements are the same as for for-expressions in \autoref{explicit-iteration-ranges-of-for-equations} -
+except that the \lstinline!expression! of a for-statement is not restricted to a parameter-expression.
 
 {[}\emph{Example}:
 


### PR DESCRIPTION
Clarify evaluation of for-equations so that it is clear that matrix is handled as vector of vectors, and that the variable gets each vector element and then the body of the for-loop is evaluated when the for-variable has the value of that element. (I found that the previous clarification could be misinterpreted in a number of ways.)
Closes #2205