### PR TITLE
Give precendence for convertModifiers.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1571,8 +1571,14 @@ Behaviour in unusual cases:
 \item
   If OldModifier\_i is cardinality(a)=1 the conversion will only be
   applied for a component comp if there is are any inside connections to
-  comp.a
+  comp.
 \end{itemize}
+
+The converted modifiers and existing modifiers are merged such that existing modifiers takes precedence over the result of convertModifiers. 
+A diagnostics is recommended if this merging removes some modifiers unless those modifiers are identical or it is the special case of empty OldModifier list.
+\begin{nonnormative}
+This can be used to handle the case where the default value was changed.
+\end{nonnormative}
 
 Converting modifiers with cardinality is used to remove the deprecated
 operator cardinality from model libraries, and replace tests on

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1565,7 +1565,7 @@ Behaviour in unusual cases:
   If OldModifer list is empty it is added for all uses of the class
 \item
   If OldModifier\_i is cardinality(a)=0 the conversion will only be
-  applied for a component comp if there are no inside connection to
+  applied for a component comp if there are no inside connections to
   comp.a. This can be combined with other modifiers that are handled in
   the usual way.
 \item

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1574,7 +1574,7 @@ Behaviour in unusual cases:
   comp.a.
 \end{itemize}
 
-The converted modifiers and existing modifiers are merged such that existing modifiers take precedence over the result of convertModifiers.
+The converted modifiers and existing modifiers are merged such that the existing modifiers take precedence over the result of convertModifiers.
 A diagnostics is recommended if this merging removes some modifiers unless those modifiers are identical or it is the special case of an empty OldModifier list.
 \begin{nonnormative}
 This can be used to handle the case where the default value was changed.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1570,8 +1570,8 @@ Behaviour in unusual cases:
   the usual way.
 \item
   If OldModifier\_i is cardinality(a)=1 the conversion will only be
-  applied for a component comp if there is are any inside connections to
-  comp.
+  applied for a component comp if there are any inside connections to
+  comp.a.
 \end{itemize}
 
 The converted modifiers and existing modifiers are merged such that existing modifiers take precedence over the result of convertModifiers.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1574,7 +1574,7 @@ Behaviour in unusual cases:
   comp.
 \end{itemize}
 
-The converted modifiers and existing modifiers are merged such that existing modifiers takes precedence over the result of convertModifiers. 
+The converted modifiers and existing modifiers are merged such that existing modifiers takes precedence over the result of convertModifiers.
 A diagnostics is recommended if this merging removes some modifiers unless those modifiers are identical or it is the special case of empty OldModifier list.
 \begin{nonnormative}
 This can be used to handle the case where the default value was changed.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1565,7 +1565,7 @@ Behaviour in unusual cases:
   If OldModifer list is empty it is added for all uses of the class
 \item
   If OldModifier\_i is cardinality(a)=0 the conversion will only be
-  applied for a component comp if there is no inside connection to
+  applied for a component comp if there are no inside connection to
   comp.a. This can be combined with other modifiers that are handled in
   the usual way.
 \item
@@ -1574,8 +1574,8 @@ Behaviour in unusual cases:
   comp.
 \end{itemize}
 
-The converted modifiers and existing modifiers are merged such that existing modifiers takes precedence over the result of convertModifiers.
-A diagnostics is recommended if this merging removes some modifiers unless those modifiers are identical or it is the special case of empty OldModifier list.
+The converted modifiers and existing modifiers are merged such that existing modifiers take precedence over the result of convertModifiers.
+A diagnostics is recommended if this merging removes some modifiers unless those modifiers are identical or it is the special case of an empty OldModifier list.
 \begin{nonnormative}
 This can be used to handle the case where the default value was changed.
 \end{nonnormative}


### PR DESCRIPTION
Give precedence for convertModifiers; to remove ambiguity.
See https://github.com/modelica/ModelicaStandardLibrary/pull/3086#pullrequestreview-278443918