### PR TITLE
Don't allow language version comment anywhere except at top level

### DIFF
--- a/RationaleMCP/0015/spec-changes.md
+++ b/RationaleMCP/0015/spec-changes.md
@@ -1,7 +1,7 @@
 #  Proposed Changes in Specification
 
 ## Overview
-We propose the use of a language version comment directly following the optional byte order mark at the first line of a Modelica source file.  It is mandatory that the language version is specified for every Modelica source file, but the version information is inherited within a package hierarchy, alleviating the need for a language version comment in every Modelica sourc efile.  The entire line containing the language version comment shall match the follow regular expression where `\U+FEFF` denotes the byte order mark:
+We propose the use of a language version comment directly following the optional byte order mark at the first line of a Modelica source file.  The language version is the same throughout any class or package, is required to be declared in the file of the top level class, and must not appear in any other file of the same class or package.  That is, the one and only place where the language version shall be specified is either a top level _A.mo_ or a top level _A/package.mo_ file.  The entire line containing the language version comment shall match the follow regular expression where `\U+FEFF` denotes the byte order mark:
 ```
 ^\U+FEFF?//![ ] \d+[.]\d+[r.]\d+$
 ```


### PR DESCRIPTION
At the 100th design meeting, @HansOlsson wanted us to rethink the earlier decision to allow language version to be specified at different levels of a package hierarchy.  The purpose of this PR is to invite for discussion of this topic, so that we can settle it (again) at the next design meeting.