### PR TITLE
Allocate MCP number for 'Ternary'

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -17,6 +17,7 @@ New MCP should be added to the following list - on the main branch to keep track
 but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
+- MCP0034 Ternary ([MCP/0034](https://github.com/modelica/ModelicaSpecification/tree/MCP/0034/RationaleMCP/0034))
 - MCP0033 Annotations for Predefined Plots ([MCP/0033](https://github.com/modelica/ModelicaSpecification/tree/MCP/0033/RationaleMCP/0033))
 - MCP0032 Selective Model Extension ([MCP/0032](https://github.com/modelica/ModelicaSpecification/tree/MCP/0032/RationaleMCP/0032))
 - MCP0031 Flat Modelica and MLS modularization ([MCP/0031](https://github.com/modelica/ModelicaSpecification/tree/MCP/0031/RationaleMCP/0031))


### PR DESCRIPTION
It was concluded in #2211 that an MCP for _Ternary_ (3-valued logic) in Modelica should be created, and here it is.

For those who don't want to read through #2211 to get the background, the application of ternary logic there is to have a `Dialog` annotation member called `visible`.  The problem with using `Boolean` is that as soon as an expression is given, it is no longer possible to say _default behavior_ (which is neither `true` nor `false`, but depends on tool-specific logic).  With a third truth value, _unknown_, it becomes possible to give an expression for selecting between:
- `false` — force hiding
- `unknown` — follow tool-specific logic (same as not specifying `visible` at all)
- `true` — force showing

I'd like to initiate this work by proposing an MCP based on the following principles:
- A new built in type, `Ternary`.
- A new literal constant `unknown` for the third truth value.
- Explicit as well as implicit conversion from `Boolean`.
- No implicit conversion to `Boolean`.

I'd just like to shed a glimpse on light on how this is supposed to work, just so that people can vote for or against the MCP number allocation.  For now, please try to only raise concerns that are against the MCP number allocation based on the principles above.  Please delay any concerns about details around the principles until an MCP number has been allocated, so that such discussion can be held in the context of an actual MCP, rather than ending up in the discussion of this PR for the mere MCP number allocation.

With the explicit conversion from `Boolean`, the other two `Ternary` values besides `unknown` can be expressed as `Ternary(false)` and `Ternary(true)`.  This is preferred over a solution with three new literal constants (such as {`False`, `Unknown`, `True`}), where it would be a constant source of confusion that there would be two different literals for _false_ and two different literals for _true_.

The implicit conversion from `Boolean` to `Ternary` would be very similar to the implicit conversion from `Integer` to `Real` — a well established and everywhere used feature of Modelica.  To start with, it would mean that one would never need to write `Ternary(false)` or `Ternary(true)`; just writing `false` in a context where a `Ternary` is expected would be equivalent to writing out `Ternary(false)`, just like writing `1` is equivalent to writing `1.0` in a context where a `Real` is expected.  Then, it would also make mixing `Ternary` and `Boolean` logic seamless, so the user doesn't have to explicitly choose between either `Boolean` or `Ternary` logic for all the subexpressions that don't make use of the third truth value.  For example:
```
  parameter Ternary t;
  Real x;
  Ternary y = t or (time > 1 and x < 5); /* No need to explicitly convert conjunction to Ternary. */
```

To not have implicit conversion from `Ternary` to `Boolean` means that the user will always have to make an explicit choice of how to interpret a `Ternary` where a `Boolean` is required, for example in `if` conditions.  There will be no surprises of _unknown_ being treated as either `true` or `false` instead of being reported as an error.  Exactly how to do the conversion is an interesting design problem, and not in the scope of this PR.
