### PR TITLE
Removed deprecated assignments from function declaration template

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -20,10 +20,10 @@ the following schematic function example:}
 function  !\emph{functionname}!
   input  TypeI1 in1;
   input  TypeI2 in2;
-  input  TypeI3 in3 := !\emph{default\_expr1}! "Comment" annotation(...);
+  input  TypeI3 in3 = !\emph{default\_expr1}! "Comment" annotation(...);
   ...
   output TypeO1 out1;
-  output TypeO2 out2 :=  !\emph{default\_expr2}!;
+  output TypeO2 out2 =  !\emph{default\_expr2}!;
   ...
 protected
   !\emph{\textless{}local variables\textgreater{}}!


### PR DESCRIPTION
Section 12.2 states explicitly that the assignment operator is deprecated in input and output bindings.

So be it.