### PR TITLE
Forbid hiding loop variables in nested for-equations

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -111,7 +111,7 @@ immediately enclosing the for-equation. The expression of a for-equation
 shall be a parameter expression. The iteration range of a for-equation
 can also be specified as Boolean or as an enumeration type, see
 \autoref{types-as-iteration-ranges} for more information. The loop-variable (\lstinline!IDENT!) is in scope
-inside the loop-construct and shall not be assigned to.
+inside the loop-construct and shall not be assigned to. In case of nested for-equations, a loop-variable defined in an outer loop cannot be re-used as as loop-variable for an inner loop.
 For each element of the evaluated vector expression, in the normal order, the loop-variable
 gets the value of that element and that is used to evaluate the body of the for-loop.
 
@@ -124,7 +124,7 @@ for i in TwoEnums loop         // i takes the values TwoEnums.one, TwoEnums.two
                                // for TwoEnums = enumeration(one,two)
 \end{lstlisting}
 
-\emph{The loop-variable may hide other variables as in the following
+\emph{The loop-variable may hide other non-loop variables as in the following
 example. Using another name for the loop-variable is, however, strongly
 recommended.}
 


### PR DESCRIPTION
Consider the following example model
```
  model Example
    "Example model with nested for loops"
    final parameter Integer M = 3 "problem height";
    final parameter Integer N = 4 "problem width";
    Real[M,N] A "matrix";
    Real[M] x "vector";
    Real[N] y "vector";
  equation
    x = {sin(2*3.1415926*time*i) for i in 1:M};
    y = {cos(2*3.1415926*time*i) for i in 1:N};
    for i in 1:M loop
      for i in 1:N loop
        A[i,i] = x[i]*y[i];
      end for;
    end for;
  end Example;
```
Apparently [Section 8.3.2](https://specification.modelica.org/master/Ch8.html#for-equations-repetitive-equation-structures) of the specification doesn't explicitly forbid this kind of model, so in principle the `i` in the second nested loop could hide the `i` of the first one.  While hiding non-loop variables (which is allowed though discouraged) may make sense, if they are irrelevant in within the scope of the for-equations, hiding loop variables looks like a recipe for disaster, and in most cases will be the result of a plain typing error. The compiler should reject model Example without hesitation.