### PR TITLE
Correct short-circuit example

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -125,8 +125,8 @@ evaluation, it should be guarded by an if:}
   Boolean b;
   Integer I;
 equation
-  x=v[I] and (I>=1 and I<=n); // Invalid
-  x=if (I>=1 and I<=n) then v[I] else false; // Correct
+  b=(I>=1 and I<=n) and v[I]; // Invalid
+  b=if (I>=1 and I<=n) then v[I] else false; // Correct
 \end{lstlisting}
 
 \emph{To guard square against square root of negative number use}


### PR DESCRIPTION
Reorder operands for short-circuit evaluation of boolean expressions, and use declared variable.

Closes #2442