### PR TITLE
Correct import-clause for .*

### DIFF
--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -148,7 +148,7 @@ element :
    [ constraining-clause comment ] )
 
 import-clause :
-   import ( IDENT "=" name | name ["." ( "*" | "{" import-list "}" ) ] ) comment
+   import ( IDENT "=" name | name [ ".*" | "." ( "*" | "{" import-list "}" ) ] ) comment
 
 import-list :
    IDENT { "," IDENT }


### PR DESCRIPTION
Allow .* as one element for import, due to maximum munch.
Closes #2430