### PR TITLE
When using default inner/outer we shouldn't change component name

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1054,7 +1054,8 @@ The following prefixes may be included in the string prefixes: inner,
 outer, replaceable, constant, parameter, discrete. {[}\emph{In
 combination with} defaultComponentName \emph{it can be used to make it
 easy for users to create} inner \emph{components matching the} outer
-\emph{declarations; see also example below}{]}
+\emph{declarations; see also example below. If the prefixes contain} inner \emph{or} outer
+\emph{and the default name cannot be used (e.g., since it is already in use) it is recommended to give a diagnostic.}{]}
 \begin{lstlisting}[language=modelica]
   annotation(missingInnerMessage = "message")
 \end{lstlisting}


### PR DESCRIPTION
Formulate that not using default name for component in combination with inner/outer is bad (non-normative).
Closes #2398