### PR TITLE
Restrict declaration equations and lhs in algorithms

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -224,6 +224,9 @@ said to define a declaration equation associated with the declared
 component. For declarations of vectors and matrices, declaration
 equations are associated with each element.
 
+Only components of the restricted classes type, record, operator record, and connector, or components of classes inheriting from ExternalObject
+may have declaration equations. See also the corresponding rule for algorithms, \autoref{restrictions-on-assigned-variables}.
+
 \subsubsection{Prefix Rules}\doublelabel{prefix-rules}
 
 Variables declared with the \lstinline!flow! or the \lstinline!stream! type prefix shall be a

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -169,6 +169,10 @@ multiple results is as follows:
 {[}\emph{Also see \autoref{simple-equality-equations} regarding calling functions with
 multiple results within equations.}{]}
 
+\subsubsection{Restrictions on assigned variables}\doublelabel{restrictions-on-assigned-variables}
+Only components of the restricted classes type, record, operator record, and connector may appear as left-hand-side in algorithms.
+This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple results.
+
 \subsection{For-statement}\doublelabel{for-statement}
 
 The syntax of a for-statement is as follows:


### PR DESCRIPTION
Restrict declaration equations and lhs in algorithms to not allow for components of models and blocks.
Note that the algorithm-restriction was moved to a new subsubsection in the algorithm-chapter.
Closes #2385