### PR TITLE
Define standard type coercion.

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -910,12 +910,8 @@ nested array subscripts it refers to the most closely nested array.
 The mathematical operations defined on scalars, vectors, and matrices
 are the subject of linear algebra.
 
-In all contexts that require an expression which is a subtype of Real,
-an expression which is a subtype of Integer can also be used; the
-Integer expression is automatically converted to Real.
-
 The term numeric or numeric class is used below for a subtype of the
-Real or Integer type classes.
+Real or Integer type classes. The standard type coercion defined in \autoref{standard-type-coercion} apply.
 
 \subsection{Equality and Assignment}\doublelabel{equality-and-assignment}
 
@@ -1253,6 +1249,28 @@ evaluation of \lstinline!and! and \lstinline!or! see \autoref{evaluation-order}.
 
 See \autoref{scalar-functions-applied-to-array-arguments}.
 
+\subsection{Standard Type Coercion}\doublelabel{standard-type-coercion}
+In all contexts that require an expression which is a subtype of Real,
+an expression which is a subtype of Integer can also be used; the
+Integer expression is automatically converted to Real.
+
+This also applies to arrays of Reals, and for fields of record expressions
+There is no similar rule for sub-typing.
+
+{[}\emph{Example:}
+\begin{lstlisting}[language=modelica]
+   record RealR
+     Real x,y;
+   end RealR;
+   record IntegerR
+     Integer x,y;
+   end IntegerR;
+   parameter Integer a=1;
+   Real y(start=a);        // Ok, a is automatically coerced to Real
+   RealR r1=IntegerR(a,a); // Ok, record is automatically coerced
+   RealR r2=RealR(a,a);    // Ok, a is automatically coerced to Real
+\end{lstlisting}
+{]}
 \section{Empty Arrays}\doublelabel{empty-arrays}
 
 Arrays may have dimension sizes of 0. E.g.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -453,7 +453,7 @@ specification may not be called with named arguments, unless otherwise
 noted.
 
 The type of each argument must agree with the type of the corresponding
-parameter, except where the standard type coercions can be used to make
+parameter, except where the standard type coercion, \autoref{standard-type-coercion}, can be used to make
 the types agree. (See also \autoref{scalar-functions-applied-to-array-arguments} on applying scalar functions
 to arrays.)
 

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -658,13 +658,14 @@ compatible subexpressions A and B is defined as follows:
   expression of a simple type.
 \item
   If A is a Real expression then B must be a Real or Integer expression
-  and the type compatible expression is Real.
+  and the type compatible expression is Real, compare \autoref{standard-type-coercion}.
 \item
   If A is an Integer expression then B must be a Real or Integer
   expression. For exponentiation and division the type compatible
-  expression is Real (even if both A and B are Integer) see 10.610.6, in
+  expression is Real (even if both A and B are Integer) see \autoref{exponentiation-of-scalars-of-numeric-elements}
+  and \autoref{division-of-scalars-or-numeric-arrays-by-numeric-scalars}, in
   other cases the type compatible expression is Real or Integer (same as
-  B).
+  B), compare \autoref{standard-type-coercion}.
 \item
   If A is a Boolean expression then B must be a Boolean expression and
   the type compatible expression is Boolean.


### PR DESCRIPTION
Create a separate sub-section to make it easy to refer to, and add an example.
Also fix some remaining issue for Word->LaTeX conversion.
Closes #2326