### PR TITLE
Decide on just one way to specify array dimensions

### DIFF
--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -104,7 +104,7 @@ end _F;
 
 > _short-class-specifier_ →\
 > &emsp; _IDENT_ **=**\
-> &emsp; ( _base-prefix_? _type-specifier_ _array-subscripts_? _class-modification_?\
+> &emsp; ( _base-prefix_? _array-subscripts_? _type-specifier_ _class-modification_?\
 > &emsp; | **enumeration** `[(]` ( _enum-list_? | **:** ) `[)]`\
 > &emsp; )\
 > &emsp; _comment_
@@ -162,7 +162,7 @@ end _F;
 
 
 ## B24 Component**clause**
-> _component-clause_ → _type-prefix_ _type-specifier_ _array-subscripts_? _component-list_
+> _component-clause_ → _type-prefix_ _array-subscripts_? _type-specifier_ _component-list_
 
 > _type-prefix_ →\
 > &emsp; ( **flow** | **stream** )?\

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -175,7 +175,7 @@ end _F;
 
 > _condition-attribute_ → **if** _expression_
 
-> _declaration_ → _IDENT_ _array-subscripts_? _modification_?
+> _declaration_ → _IDENT_ ~~_array-subscripts_?~~ _modification_?
 
 
 ## B25 Modification

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -107,7 +107,7 @@ end _F;
 
 > _short-class-specifier_ →\
 > &emsp; _IDENT_ **=**\
-> &emsp; ( _base-prefix_? _array-subscripts_? _type-specifier_ _class-modification_?\
+> &emsp; ( _base-prefix_? _type-specifier_ ~~_array-subscripts_?~~ _class-modification_?\
 > &emsp; | **enumeration** `[(]` ( _enum-list_? | **:** ) `[)]`\
 > &emsp; )\
 > &emsp; _comment_
@@ -165,7 +165,7 @@ end _F;
 
 
 ## B24 Component clause
-> _component-clause_ → _type-prefix_ _array-subscripts_? _type-specifier_ _component-list_
+> _component-clause_ → _type-prefix_ _type-specifier_ ~~_array-subscripts_?~~ _component-list_
 
 > _type-prefix_ →\
 > &emsp; ( **flow** | **stream** )?\
@@ -178,7 +178,7 @@ end _F;
 
 > _condition-attribute_ → **if** _expression_
 
-> _declaration_ → _IDENT_ ~~_array-subscripts_?~~ _modification_?
+> _declaration_ → _IDENT_ _array-subscripts_? _modification_?
 
 
 ## B25 Modification


### PR DESCRIPTION
Opening PR according to road map item scheduled at last web meeting.

Marking as draft PR, as I understand that diverging from the Modelica grammar is controversial.  My reasoning is that just settling for one of the ways to define array dimensions is disruptive enough to make an opportunity for also fixing the issue with the non-intuitiveness of Modelica array dimension concatenation.

This PR builds upon https://github.com/modelica/ModelicaSpecification/pull/2465, so it should remain in draft state at least until that has been merged.