### PR TITLE
Description of handling of unknown dimensions added to differences.md

### DIFF
--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -22,4 +22,59 @@ In Modelica a separate issue is that `if`-equations may contain connect and simi
 that cannot easily be counted; but they are gone in Flat Modelica.
 
 ## Array dimensions with parameter variability
-In Flat Modelica, an array dimension is allowed to have `parameter` variability, that is, the dimension isn't known until after solving the initialization problem in the simulation.  _TO BE ELABORATED…_
+In Flat Modelica, an array dimension is allowed to have `parameter` variability, that is, the dimension isn't known until after solving the initialization problem in the simulation. 
+Such dimension has to be specified using `:` when declaring a variable, e.g. `Real a[3,:,5];`
+For short they are referred as _unknown dimension_.
+
+Such arrays have following properties:
+- There can be more then one unknown dimension.
+- When checking balancing of equations and variables, they are seen as opaque and counted as one, starting from the highest (left most) unknown dimension. 
+- They can be passed as arguments to functions and returned from them.
+- They can be elements of records. _[this makes it really complicated]_
+- Equations between them are allowed, provided the dimensions match. `:` matches only with itself.
+- Unknown dimensions cannot be used to determine the iteration range of a `for`-equation, because the compiler is not able to evaluate the `size(...)` operator.
+- In equations subscription into an unknown dimension is an error.
+- Inside algorithms full access to the elements by subscription is possible.
+- Assignments from fixed to unknown dimension is allowed, vice versa not.
+- `equation` and `algorithm` sections cannot have unknown dimensions.
+
+E.g.
+```
+model UnknownDimTest
+Real a[3,:,5],a2[3,:,5]; // counted as 3
+Real b[:,5]; // counted as 1
+Real c[:]; // counted as 1
+Real d[5]; // counted as 5
+
+equation
+	a=array_returning_function_call(...); // fine
+	pass_array_as_function_arg(a);
+	a=a2; // fine, counted as 3 equations
+	b=a[1]; // fine, counted as 1 equations
+	c=a2[2,:,1] // error , access into unknown dimension
+	
+	for i in 1:size(a,1) loop // fine
+		a2[i]=a[i];  // subscription possible, but error more then one equation for a2[i] (see above a=a2)
+	end for;
+	
+	for i in 1:size(b,1) loop // error, cannot evaluate size(b,1) at compile time
+	end for;
+	for i in 1:3 loop 
+		c[i]=i; // error , access into unknown dimension
+	end for;
+	
+	c=d; // error, dimension does not match
+	
+algorithm
+	for i in 1:size(b,1) loop // fine,  size(b,1) evaluated at run time
+		c[i]:=b[i,2]; // fine
+	end for;
+	c:=d; // fine, dimension of c will be [5] for now
+	d:=c; // error, dimension does not match (assignment from unknown to fixed dimension)
+end UnknownDimTest;
+```
+### Change and reason for the change
+In Modelica variables are also allowed to have unknown to dimensions, but the handling of such is not defined. It seems to be restricted to inside functions, but this is not clearly stated.
+So this is basically a clarification or maybe an extension of the Modelica specification.
+
+The feature is useful when reading data from files (e.g. tables). These tables have to be stored in variables (i.e. initial parameters) to be used in algorithms later, but their size in not known in advance.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -28,7 +28,7 @@ In Flat Modelica, array size is part of an array type.  Each dimension has a siz
 
 When determining expression types, every array dimension must be unambiguously typed as either constant or flexible.  Where there are constraints on array sizes, for instance when adding two arrays, a flexible array size is only compatible with another flexible array size.  It is a runtime error if the two flexible array sizes are found to be incompatible at runtime (a tool can optimize runtime checks away if it can prove that the sizes will be compatible).
 
-In an array equation, the array type must have constant sizes.
+In an array equation, the array type must have constant sizes.  On the other hand, a flexible size on the left hand size of an array assignment does not impose any size constraint on the right hand size, and is allowed.
 
 When determining the type of a function call, the sizes of output array variables are determined based on the input expressions and the function's declarations of input and output components.  An output array size is constant (for the function call at hand) if it can be determined based on the types of input expressions and the constant variability values of input expressions.  When an array size cannot be determined based on this information (including the trivial case of a function output component declared with `:` size), the size is flexible.
 
@@ -39,6 +39,10 @@ model M
     input Integer n;
     input Real[:] x;
     output Real[n + size(x, 1)] y;
+  protected
+    Real[:] a;
+  algorithm
+    a := {0.5}; /* OK: Constant size can be assigned to flexible size. */
     ...
   end f;
   parameter Integer p = 2;

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -21,9 +21,39 @@ Flat Modelica is designed to avoid such implicit evaluation of parameters, and t
 In Modelica a separate issue is that `if`-equations may contain connect and similar primitives
 that cannot easily be counted; but they are gone in Flat Modelica.
 
-## Array dimensions with parameter variability
-In Flat Modelica array dimensions with `parameter` variability outside of functions are not allowed. Such dimensions have to be constant and evaluatable during compile time.
+## Array size
 
-### Change and reason for the change
-In Modelica, array dimensions with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined.
+### Variability of size-expressions
+The variability of an `ndims` expression is constant, as it only depends on the type of the argument and is unaffected by flexible array sizes.
+
+The variability of a `size` expression depends on the presence of flexible array sizes in the argument.  If the result depends on a flexible array size, the variability of the array argument is preserved, otherwise, the variability of the `size` expression is constant.
+
+#### Change and reason for the change
+In Modelica, size-expressions are described as function calls, meaning that they cannot be seen as acting on the type of the argument.  This had to be changed in order to give size-expressions constant variability for non-flexible array sizes.
+
+### Array sizes with parameter variability
+In Flat Modelica, component declarations outside functions may only specify non-flexible array sizes with `constant` variability.
+
+**Is there a need to also restruct array constructor functions when used outside functions?**  Being built-in functions, the array constructor functions such as `fill` don't automatically play by the same rules as user functions (see below), meaning that the following would currently be allowed:
+```
+model FlexibleIntermediateResult
+  parameter Integer n;
+  Real x = sum(fill(1.0, n));
+end FlexibleIntermediateResult;
+```
+
+#### Change and reason for the change
+In Modelica, array sizes with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined.
 So it is easier to forbid this feature for now. If introduced in Modelica, it is still possible to introduce them here with the same semantics. It would be impossible the other way around.
+
+### Flexible array sizes and function signatures
+In Flat Modelica, an input component may be declared with a variability prefix to constrain the allowed variability of expressions given for this argument.  Inside the function the input component has the declared variability declared except that it cannot exceed discrete-time.  (It follows that it is only useful to specify the `constant` or `parameter` prefix.)
+
+In Flat Modelica, the only component declarations that may specify a flexible array size (specified with `:`) are the inputs or protected components of a function.
+
+Array dimensions index by `Integer` in output components of a function must be given by expressions that turn into constant expressions if all flexible array sizes in the input components are replaced by `Integer` values.
+
+#### Change and reason for the change
+In Modelica, a function output may be declared to have flexible array size, as demonstrated by the dreaded `collectPositive` example in the specification.  With the change, it is ensured that a function cannot be the origin of flexible array size, and that the function signature obtained by just considering the function input and output component declarations is sufficient to derive the result type of any function call.  The result type of a function call may contain flexible array sizes, but only when flexible array sizes are present in the types of the argument expressions.  Further, when flexible array sizes are present in the function call argument expressions, it will be possible to determine the concrete sizes of all array dimensions of the result at runtime, allowing output arrays to be allocated by the caller.
+
+Combined with additional restrictions on the variability of sizing arguments to built-in array constructor functions such as `fill`, it can be ensured that types with flexible array sizes can only appear inside functions.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -22,59 +22,8 @@ In Modelica a separate issue is that `if`-equations may contain connect and simi
 that cannot easily be counted; but they are gone in Flat Modelica.
 
 ## Array dimensions with parameter variability
-In Flat Modelica, an array dimension is allowed to have `parameter` variability, that is, the dimension isn't known until after solving the initialization problem in the simulation. 
-Such dimension has to be specified using `:` when declaring a variable, e.g. `Real a[3,:,5];`
-For short they are referred as _unknown dimension_.
+In Flat Modelica array dimensions with `parameter` variability outside of functions are not allowed. Such dimensions have to be constant and evaluatable during compile time.
 
-Such arrays have following properties:
-- There can be more then one unknown dimension.
-- When checking balancing of equations and variables, they are seen as opaque and counted as one, starting from the highest (left most) unknown dimension. 
-- They can be passed as arguments to functions and returned from them.
-- They can be elements of records. _[this makes it really complicated]_
-- Equations between them are allowed, provided the dimensions match. `:` matches only with itself.
-- Unknown dimensions cannot be used to determine the iteration range of a `for`-equation, because the compiler is not able to evaluate the `size(...)` operator.
-- In equations subscription into an unknown dimension is an error.
-- Inside algorithms full access to the elements by subscription is possible.
-- Assignments from fixed to unknown dimension is allowed, vice versa not.
-- `equation` and `algorithm` sections cannot have unknown dimensions.
-
-E.g.
-```
-model UnknownDimTest
-Real a[3,:,5],a2[3,:,5]; // counted as 3
-Real b[:,5]; // counted as 1
-Real c[:]; // counted as 1
-Real d[5]; // counted as 5
-
-equation
-	a=array_returning_function_call(...); // fine
-	pass_array_as_function_arg(a);
-	a=a2; // fine, counted as 3 equations
-	b=a[1]; // fine, counted as 1 equations
-	c=a2[2,:,1] // error , access into unknown dimension
-	
-	for i in 1:size(a,1) loop // fine
-		a2[i]=a[i];  // subscription possible, but error more then one equation for a2[i] (see above a=a2)
-	end for;
-	
-	for i in 1:size(b,1) loop // error, cannot evaluate size(b,1) at compile time
-	end for;
-	for i in 1:3 loop 
-		c[i]=i; // error , access into unknown dimension
-	end for;
-	
-	c=d; // error, dimension does not match
-	
-algorithm
-	for i in 1:size(b,1) loop // fine,  size(b,1) evaluated at run time
-		c[i]:=b[i,2]; // fine
-	end for;
-	c:=d; // fine, dimension of c will be [5] for now
-	d:=c; // error, dimension does not match (assignment from unknown to fixed dimension)
-end UnknownDimTest;
-```
 ### Change and reason for the change
-In Modelica variables are also allowed to have unknown to dimensions, but the handling of such is not defined. It seems to be restricted to inside functions, but this is not clearly stated.
-So this is basically a clarification or maybe an extension of the Modelica specification.
-
-The feature is useful when reading data from files (e.g. tables). These tables have to be stored in variables (i.e. initial parameters) to be used in algorithms later, but their size in not known in advance.
+In Modelica, array dimensions with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined. 
+So it is easier to forbid this feature for now. If introduced in Modelica, it is still possible to introduce them here with the same semantics. It would be impossible the other way around.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -92,15 +92,64 @@ end M;
 
 Note: The `constsize` definition also applies to array dimensions with non-`Integer` upper bounds.  For example, any `Boolean` array dimension in `arrExp` must be matched by 2 in the `constsize` expression.
 
-Note: The current forms of `constsize` does not allow leaving some leading sizes flexible, while making other sizes constant.  To support this, one could also add a third form where two constant variability `Integer` arrays of equal size are given, where the first array specifies dimensions, and the second array specifies the corresponding sizes:
+#### Limitation
+Note: The current forms of `constsize` don't allow leaving some leading sizes flexible, while making other sizes constant.  It means that some full Modelica function algorithms cannot be directly converted to Flat Modelica:
+```
+function flexibleTrouble
+protected
+  Real[:, :] a; /* (That the second dimension doesn't have constant size matching 'b' is probably a sign of bad design.) */
+  Real[2] b;
+  Real[:] y;
+algorithm
+  /* Allowed in full Modelica, but not in Flat Modelica.
+   * Size mismatch in array multiplication: ':' is not compatible with constant size.
+   */
+  y := a * b;
+  /* Trying to address Flat Modelica type error.
+   * Well-typed, but will generally fail at runtime, as 42 has nothing to do with the first size of 'a'.
+   */
+  y := constsize(a, 42, 2) * b;
+end flexibleTrouble;
+```
+
+To support this, one could also add a third form where two constant variability `Integer` arrays of equal size are given, where the first array specifies dimensions, and the second array specifies the corresponding sizes:
 ```
 constsize(arrExp, {d1, d2, ..., dn}, {sd1, sd2, ..., sdn})
 ```
 
-Alternative design: Use some variant of type conversion syntax, for instance:
+Alternatively, one could make `constsize` a keyword and change the grammar to also allow `:` instead of a constant `Integer` (possibly causing some confusion for human readers that don't understand why a `:` is allowed in a place that looks like a function call argument):
 ```
-  Real[2, 3] a = Real[2, 3](f());
+constsize(arrExp, :, s2, ..., sn)
 ```
+
+For now, however, we don't expect this to be a problem for real-world examples.  Regarding the example given above, the variable `a` should probably have been declared as `Real[:, 2]` to start with, and then the matrix multiplication would be fine also in Flat Modelica.  For this reason, and knowing that there are ways that the current `constsize` expressions can be generalized in the future, we leave the design of `constsize` for now with this known limitation.
+
+Finally, note that a very cumbersome workaround that doesn't require generalization of `constsize` is to introduce a new function to do the job:
+```
+function _constsize_Real_flexible_2
+  input Real[:, :] x;
+  output Real[size(x, 1), 2] y;
+algorithm
+  assert(size(x, 2) == 2, "Expected second array dimension to have size 2.");
+  for i in 1 : size(y, 1) loop
+    for j in 1 : size(y, 2) loop
+      y[i, j] := x[i, j];
+    end for;
+  end for;
+end _constsize_Real_flexible_2;
+```
+
+#### Alternative syntax
+Another syntax for `constsize` was also considered to make it easier to address the limitation of not being able to leave some leading sizes flexible.  Here, a `constsize` expression uses special syntax instead of taking the form of a normal function call:
+```
+constsize[s1, s2, ..., sn](arrExp)  /* "Square bracket form" reminding of component declaration. */
+constsize(dimsExp)(arrExp)          /* dimsExp is a constant Integer array expression, such as size(...). */
+```
+
+Pros and cons leading to the current decision of going with the function call syntax instead:
+- Syntax (square bracket form) is easily and naturally extended to also allow `:` sizes where the resulting size must not be constant (the use of `:` in a list of sizes given between square brackets is already established).
+- Not using function call syntax means grammar has to be extended (with `constsize` as Flat Modelica keyword), without added value until generalized to also allow `:`.
+- The currently proposed function call syntax would also be possible to extend, see above.
 
 ### Variability of size-expressions
 The variability of an `ndims` expression is constant, as it only depends on the type of the argument and is unaffected by flexible array sizes.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -7,23 +7,23 @@ Absence of an else branch is equivalent to having an empty else branch with equa
 
 An `if`-equation without `else` is useful for a conditional `assert` and similar checks.
 
-Note: _The "equation size" count the number of equations as if the equations were expanded into scalar equations, 
+Note: _The "equation size" count the number of equations as if the equations were expanded into scalar equations,
 but does not require that the equations can be expanded in this way._
 
 ### Change and reason for the change
 In Modelica this restriction only applies for `if`-equations with non-parameter conditions.
 For `if`-equations with parameter condition it does not hold, and if the equation sizes
-differ those parameters have to be evaluated. In practice it can be complicated to separate those cases, 
+differ those parameters have to be evaluated. In practice it can be complicated to separate those cases,
 and some tools attempt to evaluate the parameters even if the branches have the same equation size.
 
 Flat Modelica is designed to avoid such implicit evaluation of parameters, and thus this restriction is necessary.
 
-In Modelica a separate issue is that `if`-equations may contain connect and similar primitives 
+In Modelica a separate issue is that `if`-equations may contain connect and similar primitives
 that cannot easily be counted; but they are gone in Flat Modelica.
 
 ## Array dimensions with parameter variability
 In Flat Modelica array dimensions with `parameter` variability outside of functions are not allowed. Such dimensions have to be constant and evaluatable during compile time.
 
 ### Change and reason for the change
-In Modelica, array dimensions with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined. 
+In Modelica, array dimensions with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined.
 So it is easier to forbid this feature for now. If introduced in Modelica, it is still possible to introduce them here with the same semantics. It would be impossible the other way around.


### PR DESCRIPTION
As planned I added a description of dimensions with parameter variablility to differences.md.
If something is missing, unclear or wrong please comment on this PR.

This is not a real difference, because it is somehow allowed in Modelica too but it is not really described in the specification. So it might be a clarification or an extension of Modelica, which should be handeled with another MCP and differences.md in not the right place for that.