### PR TITLE
Clarify the consequence of using impure function in binding equation for parameter

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -319,11 +319,14 @@ from within:
 \item
   in initial equations and initial algorithms,
 \item
-  in bindings for variables declared as parameter -- which is seen as
-  syntactic sugar for having a parameter with fixed=false and the
-  binding as an initial equation \emph{{[}thus there is no guarantee
-  that parameter is equal to the impure function call after
-  initialization{]}} -- and in constructing external objects.
+  in binding equations for components declared as parameter -- which is seen as
+  syntactic sugar for having a parameter with \lstinline!fixed=false! and the
+  binding as an initial equation \emph{{[}thus, evaluation of the same function
+  call at a later time during simulation is not guaranteed to result in the same
+  value as when the parameter was initialized, seemingly breaking the declaration
+  equation{]}}
+\item
+  in binding equations for external objects.
 \end{itemize}
 
 For initial equations, initial algorithms, and bindings it is an error


### PR DESCRIPTION
The old formulation sounded almost as if the value of the impure function call wasn't even respected at initialization.