### PR TITLE
Remove double text.

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -546,8 +546,7 @@ and the condition attribute is kept from the original declaration (see
 
 If the Boolean expression is false the component (including its
 modifier) is removed from the flattened DAE , and connections to/from
-the component are removed and connections to/from the component are
-removed. {[}\emph{Adding the component and then removing it ensures that
+the component are removed. {[}\emph{Adding the component and then removing it ensures that
 the component is valid.}{]}A component declared with a
 condition-attribute can only be modified and/or used in connections
 {[}\emph{If a connect statement defines the connection of a


### PR DESCRIPTION
Closes #2266
(minor part; for the main part it was decided to not make any change).