### PR TITLE
Correcting lookup regressions

### DIFF
--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -49,25 +49,31 @@ Names are looked up at class flattening to find names of base classes,
 component types, etc. Implicitly defined names of record constructor
 functions and enumeration type conversion functions are ignored during
 type name lookup {[}\emph{since a record and the implicitly created
-record constructor function, see \autoref{record-constructor-functions}, , and an
+record constructor function, see \autoref{record-constructor-functions}, and an
 enumeration type and the implicitly created conversion function
 (\autoref{type-conversion-of-integer-to-enumeration-values}), have the same name}{]}. Names of record
 classes and enumeration types are ignored during function name lookup.
 
 \subsection{Simple Name Lookup}\doublelabel{simple-name-lookup}
 
+
 When an element, equation, or section is flattened, any simple name
-  {[}not composed using dot notation{]} is looked up sequentially in each
+  {[}not composed using dot notation{]} is first looked up sequentially among
+iteration variables (if any; see below), and then looked up sequentially in each
 member of the ordered set \textbf{of instance scopes (see
 \autoref{the-class-tree}) corresponding to lexically enclosing classes} until a
 match is found or an enclosing class is encapsulated. In the latter case
 the lookup stops except for the predefined types, functions and
-operators defined in this specification.
+operators defined in this specification. For these cases the lookup continues in the global scope, where they are defined.
+
+The iteration variables are the implicitly declared iteration variable(s) if inside
+the body of a for-loop, \autoref{for-equations-repetitive-equation-structures} and \autoref{for-statement},
+or the body of a reduction expression, \autoref{reduction-functions-and-operators}.
 
 Reference to variables successfully looked up in an enclosing class is
 only allowed for variables declared as constant. The values of modifiers
 are thus resolved in the \textbf{instance} scope of which the modifier
-appears; if the use is in a modifier on a short class definition,
+appears; if the use is in a modifier on a short class definition, see \autoref{short-class-definition}.
 
 This lookup in each \textbf{instance} scope is performed as follows
 


### PR DESCRIPTION
Note that the iterator-part may not be ideal; I understand that removing iterators from
the start of simple name lookup was a deliberate decision and I don't want to revert all of that.
Thus the new text is somewhat awkward; and may need improvement.
Closes #2175