### PR TITLE
Change SIunits to Units.SI as is the case as of MSL v4.0.0

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1092,7 +1092,7 @@ absolute quantity. {[}\emph{When converting between units (in the
 user-interface for plotting and entering parameters), the offset must be
 ignored, for a variable defined with annotation absoluteValue = false.
 This annotation is used in the Modelica Standard Library for example in
-Modelica.SIunits for the type definition TemperatureDifference.}{]}
+Modelica.Units.SI for the type definition TemperatureDifference.}{]}
 
 A model or block definition may contain:
 \begin{lstlisting}[language=modelica]
@@ -1150,7 +1150,7 @@ messages.}{]}
 \begin{lstlisting}[language=modelica]
 connector Frame "Frame of a mechanical system"
   ...
-  flow Modelica.SIunits.Force f[3]
+  flow Modelica.Units.SI.Force f[3]
   annotation(unassignedMessage =
       "All Forces cannot be uniquely calculated. The reason could be that the
      mechanism contains a planar loop or that joints constrain the same motion.
@@ -1249,7 +1249,7 @@ writing.
 \begin{lstlisting}[language=modelica]
 model DialogDemo
   parameter Boolean b = true "Boolean parameter";
-  parameter Modelica.SIunits.Length length "Real parameter with unit";
+  parameter Modelica.Units.SI.Length length "Real parameter with unit";
   parameter Integer nInports=0
      annotation(Dialog(connectorSizing=true));
   parameter Real r1 "Real parameter in Group 1"

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1229,7 +1229,7 @@ globally non-singular model.}{]}
 
 \emph{Example 3:}
 \begin{lstlisting}[language=modelica]
-import SI = Modelica.SIunits;
+import Modelica.Units.SI;
 
 partial model BaseProperties
   "Interface of medium model for all type of media"
@@ -1314,7 +1314,7 @@ is:}
 volume or a fixed boundary condition:}
 
 \begin{lstlisting}[language=modelica]
-import SI = Modelica.SIunits;
+import Modelica.Units.SI;
 
 connector FluidPort
   replaceable model Medium = BaseProperties;

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -203,7 +203,7 @@ end Engine;
 {[}\emph{Example}:
 \begin{lstlisting}[language=modelica]
 expandable connector EngineBus // has predefined signals
-  import SI=Modelica.SIunits;
+  import Modelica.Units.SI;
   SI.AngularVelocity speed;
   SI.Temperature T;
 end EngineBus;
@@ -233,7 +233,7 @@ end Engine;
 import Interfaces=Modelica.Electrical.Analog.Interfaces;
 expandable connector ElectricalBus
   Interfaces.PositivePin p12, n12; // OK
-  flow Modelica.SIunits.Current i; // not allowed
+  flow Modelica.Units.SI.Current i; // not allowed
 end ElectricalBus;
 
 model Battery
@@ -312,7 +312,7 @@ account during elaboration}.
 \emph{Engine system with sensors, controllers, actuator and plant that
 exchange information via a bus (i.e. via expandable connectors):}
 \begin{lstlisting}[language=modelica]
-import SI=Modelica.SIunits;
+import Modelica.Units.SI;
 import Modelica.Blocks.Interfaces.RealInput;
 // Plant Side
 model SparkPlug
@@ -765,14 +765,14 @@ connector InputReal = input Real; // A causal input connector
 connector OutputReal = output Real; // A causal output connector
 
 connector Frame_Illegal
-  Modelica.SIunits.Position r0[3] "Position vector of frame origin";
+  Modelica.Units.SI.Position r0[3] "Position vector of frame origin";
   Real S[3, 3] "Rotation matrix of frame";
-  Modelica.SIunits.Velocity v[3] "Abs. velocity of frame origin";
-  Modelica.SIunits.AngularVelocity w[3] "Abs. angular velocity of frame";
-  Modelica.SIunits.Acceleration a[3] "Abs. acc. of frame origin";
-  Modelica.SIunits.AngularAcceleration z[3] "Abs. angular acc. of frame";
-  flow Modelica.SIunits.Force f[3] "Cut force";
-  flow Modelica.SIunits.Torque t[3] "Cut torque";
+  Modelica.Units.SI.Velocity v[3] "Abs. velocity of frame origin";
+  Modelica.Units.SI.AngularVelocity w[3] "Abs. angular velocity of frame";
+  Modelica.Units.SI.Acceleration a[3] "Abs. acc. of frame origin";
+  Modelica.Units.SI.AngularAcceleration z[3] "Abs. angular acc. of frame";
+  flow Modelica.Units.SI.Force f[3] "Cut force";
+  flow Modelica.Units.SI.Torque t[3] "Cut torque";
 end Frame_Illegal;
 \end{lstlisting}
 
@@ -787,25 +787,25 @@ every closed kinematic loop:}
 
 \begin{lstlisting}[language=modelica]
 connector Frame_a "correct connector"
-  input Modelica.SIunits.Position r0[3];
+  input Modelica.Units.SI.Position r0[3];
   input Real S[3, 3];
-  input Modelica.SIunits.Velocity v[3];
-  input Modelica.SIunits.AngularVelocity w[3];
-  Modelica.SIunits.Acceleration a[3];
-  Modelica.SIunits.AngularAcceleration z[3];
-  flow Modelica.SIunits.Force f[3];
-  flow Modelica.SIunits.Torque t[3];
+  input Modelica.Units.SI.Velocity v[3];
+  input Modelica.Units.SI.AngularVelocity w[3];
+  Modelica.Units.SI.Acceleration a[3];
+  Modelica.Units.SI.AngularAcceleration z[3];
+  flow Modelica.Units.SI.Force f[3];
+  flow Modelica.Units.SI.Torque t[3];
 end Frame_a;
 
 connector Frame_b "correct connector"
-  output Modelica.SIunits.Position r0[3];
+  output Modelica.Units.SI.Position r0[3];
   output Real S[3, 3];
-  output Modelica.SIunits.Velocity v[3];
-  output Modelica.SIunits.AngularVelocity w[3];
-  Modelica.SIunits.Acceleration a[3];
-  Modelica.SIunits.AngularAcceleration z[3];
-  flow Modelica.SIunits.Force f[3];
-  flow Modelica.SIunits.Torque t[3];
+  output Modelica.Units.SI.Velocity v[3];
+  output Modelica.Units.SI.AngularVelocity w[3];
+  Modelica.Units.SI.Acceleration a[3];
+  Modelica.Units.SI.AngularAcceleration z[3];
+  flow Modelica.Units.SI.Force f[3];
+  flow Modelica.Units.SI.Torque t[3];
 end Frame_b;
 \end{lstlisting}
 
@@ -1086,7 +1086,7 @@ transformation theory of Park may be defined as:}
 
 \begin{lstlisting}[language=modelica]
 type AC_Angle "Angle of source, e.g., rotor of generator"
-  extends Modelica.SIunits.Angle; // AC_Angle is a Real number
+  extends Modelica.Units.SI.Angle; // AC_Angle is a Real number
   // with unit = "rad"
   function equalityConstraint
     input AC_Angle theta1;
@@ -1099,7 +1099,7 @@ type AC_Angle "Angle of source, e.g., rotor of generator"
 end AC_Angle;
 
 connector AC_Plug "3-phase alternating current connector"
-  import SI = Modelica.SIunits;
+  import Modelica.Units.SI;
   AC_Angle theta;
   SI.Voltage v[3] "Voltages resolved in AC_Angle frame";
   flow SI.Current i[3] "Currents resolved in AC_Angle
@@ -1180,7 +1180,7 @@ modify the result for small angles.
   end Orientation;
 
   connector Frame "3-dimensional mechanical connector"
-    import SI = Modelica.SIunits;
+    import Modelica.Units.SI;
     SI.Position r[3] "Vector from inertial frame to Frame";
     Orientation R "Orientation from inertial frame to Frame";
     flow SI.Force f[3] "Cut-force resolved in Frame";
@@ -1192,7 +1192,7 @@ be defined as}:
 
 \begin{lstlisting}[language=modelica]
 model FixedTranslation
-  parameter Modelica.SIunits.Position r[3];
+  parameter Modelica.Units.SI.Position r[3];
   Frame frame_a, frame_b;
 equation
   Connections.branch(frame_a.R, frame_b.R);

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -657,7 +657,7 @@ end HeatExchanger;
 
   HeatExchanger(
     /*redeclare*/ replaceable /*parameter */ GeoHorizontal geometry,
-    redeclare /* input */ Modelica.SIunits.Angle u /*[2]*/);
+    redeclare /* input */ Modelica.Units.SI.Angle u /*[2]*/);
   // The semantics ensure that parts in /*.*/ are automatically added
    // from the declarations in HeatExchanger.
 \end{lstlisting}
@@ -669,7 +669,7 @@ model M
   // Seen as syntactic sugar for "replaceable Real x[2,4];"
   // Note the order.
 end M;
-M m(redeclare Modelica.SIunits.Length x[2,4]); // Valid redeclare of the type
+M m(redeclare Modelica.Units.SI.Length x[2,4]); // Valid redeclare of the type
 \end{lstlisting}
 
 {]}

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -591,13 +591,13 @@ Based on the above definition the following restriction holds:
 function-compatible function}
 \begin{lstlisting}[language=modelica]
 function GravityInterface
-  input Modelica.SIunits.Position position[3];
-  output Modelica.SIunits.Acceleration acceleration[3];
+  input Modelica.Units.SI.Position position[3];
+  output Modelica.Units.SI.Acceleration acceleration[3];
 end GravityInterface;
 
 function PointMassGravity
   extends GravityInterface;
-  input Modelica.SIunits.Mass m;
+  input Modelica.Units.SI.Mass m;
 algorithm
   acceleration := -Modelica.Constants.G*m*position/(position*position)^1.5;
 end PointMassGravity;

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -934,7 +934,7 @@ typical voltage source would then be defined as:}
 \begin{lstlisting}[language=modelica]
 model ConstantVoltageSource
   extends Modelica.Electrical.Analog.Interfaces.OnePort;
-  parameter Modelica.SIunits.Voltage V;
+  parameter Modelica.Units.SI.Voltage V;
 equation
   v = homotopy(actual=V, simplified=0.0);
 end ConstantVoltageSource;
@@ -951,7 +951,7 @@ are used here in order to further improve the readability.}
 
 \begin{lstlisting}[language=modelica]
 model PressureLoss
-  import SI = Modelica.SIunits;
+  import Modelica.Units.SI;
   ...
   parameter SI.MassFlowRate m_flow_nominal "Nominal mass flow rate";
   parameter SI.Pressure dp_nominal "Nominal pressure drop";


### PR DESCRIPTION
Question is that since MSL 4.0.0 is based on MLS v3.4 if this might also be backported to 3.4 spec, *if* there will be   maintenance update. 
