### PR TITLE
Move the logo from abstract to title page

### DIFF
--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -5,6 +5,14 @@
 % The accepted solution did not seem to work
 \hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
 \begin{abstract}
+  \ifpdf
+  \else
+  ~\bigskip
+  \begin{center}
+    \includegraphics[width=8cm]{Modelica_Language}
+  \end{center}
+  \bisgskip
+  \fi
 
 This document defines the Modelica\footnote{Modelica is a registered
   trademark of the Modelica Association} language, version 3.5, which is

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -5,11 +5,6 @@
 % The accepted solution did not seem to work
 \hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
 \begin{abstract}
-~\bigskip
-\begin{center}
-\includegraphics[width=8cm]{Modelica_Language}
-\end{center}
-\bigskip
 
 This document defines the Modelica\footnote{Modelica is a registered
   trademark of the Modelica Association} language, version 3.5, which is

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -11,7 +11,7 @@
   \begin{center}
     \includegraphics[width=8cm]{Modelica_Language}
   \end{center}
-  \bisgskip
+  \bigskip
   \fi
 
 This document defines the Modelica\footnote{Modelica is a registered

--- a/preamble.tex
+++ b/preamble.tex
@@ -243,7 +243,7 @@
 \begin{center}
 \includegraphics[width=8cm]{Modelica_Language}
 \end{center}
-\\[2\baselineskip]
+~\\[2\baselineskip]
 Modelica\textsuperscript\textregistered - A Unified Object-Oriented Language for Systems
 Modeling\\[2\baselineskip]
 Language Specification\\[2\baselineskip]

--- a/preamble.tex
+++ b/preamble.tex
@@ -239,8 +239,14 @@
 \def\paragraphautorefname{section}
 \def\subparagraphautorefname{section}
 
-\title{Modelica\textsuperscript\textregistered - A Unified Object-Oriented Language for Systems
-Modeling\\[2\baselineskip]Language
-Specification\\[2\baselineskip]Version 3.5-dev}
+\title{
+\begin{center}
+\includegraphics[width=8cm]{Modelica_Language}
+\end{center}
+\\[2\baselineskip]
+Modelica\textsuperscript\textregistered - A Unified Object-Oriented Language for Systems
+Modeling\\[2\baselineskip]
+Language Specification\\[2\baselineskip]
+Version 3.5-dev}
 \date{\today}
 \author{Modelica Association}

--- a/preamble.tex
+++ b/preamble.tex
@@ -240,10 +240,12 @@
 \def\subparagraphautorefname{section}
 
 \title{
+\ifpdf
 \begin{center}
 \includegraphics[width=8cm]{Modelica_Language}
 \end{center}
 ~\\[2\baselineskip]
+\fi
 Modelica\textsuperscript\textregistered - A Unified Object-Oriented Language for Systems
 Modeling\\[2\baselineskip]
 Language Specification\\[2\baselineskip]


### PR DESCRIPTION
It looked strange to have the logo appearing on the second page instead of the title page.
