### PR TITLE
Allocate MCP number for "Multilingual support for Modelica"

### DIFF
--- a/RationaleMCP/0035/Readme.md
+++ b/RationaleMCP/0035/Readme.md
@@ -1,0 +1,5 @@
+Modelica currently supports only one language for description texts. This is usually English. In order to better support users from other language areas and to make Modelica libraries more attractive and easier to understand for them, it should be possible to provide translations of the texts in any language in a standardized form, so that tools can find, read and display them to the user in his or her preferred language.
+The definition of the interface to the translated texts is the subject of the MCP.
+
+In the discussion in #302 it was decided to provide the translation externally  the Modelica files using the [GNU gettext](https://www.gnu.org/software/gettext/) format. The exact use of this format in the Modelica context is described in the MCP.
+

--- a/RationaleMCP/0035/Readme.md
+++ b/RationaleMCP/0035/Readme.md
@@ -1,5 +1,0 @@
-Modelica currently supports only one language for description texts. This is usually English. In order to better support users from other language areas and to make Modelica libraries more attractive and easier to understand for them, it should be possible to provide translations of the texts in any language in a standardized form, so that tools can find, read and display them to the user in his or her preferred language.
-The definition of the interface to the translated texts is the subject of the MCP.
-
-In the discussion in #302 it was decided to provide the translation externally  the Modelica files using the [GNU gettext](https://www.gnu.org/software/gettext/) format. The exact use of this format in the Modelica context is described in the MCP.
-

--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -17,6 +17,7 @@ New MCP should be added to the following list - on the main branch to keep track
 but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
+- MCP0035 Multilingual support od Modelica([MCP/0035](https://github.com/modelica/ModelicaSpecification/tree/MCP/0035/RationaleMCP/0035))
 - MCP0034 Ternary ([MCP/0034](https://github.com/modelica/ModelicaSpecification/tree/MCP/0034/RationaleMCP/0034))
 - MCP0033 Annotations for Predefined Plots ([MCP/0033](https://github.com/modelica/ModelicaSpecification/tree/MCP/0033/RationaleMCP/0033))
 - MCP0032 Selective Model Extension ([MCP/0032](https://github.com/modelica/ModelicaSpecification/tree/MCP/0032/RationaleMCP/0032))


### PR DESCRIPTION
# Allocate MCP number for "Multilingual support for Modelica"

Modelica currently supports only one language for description texts. This is usually English. In order to better support users from other language areas and to make Modelica libraries more attractive and easier to understand for them, it should be possible to provide translations of the texts in any language in a standardized form, so that tools can find, read and display them to the user in his or her preferred language.
The definition of the interface to the translated texts is the subject of the MCP.

In the discussion in #302 it was decided to provide the translation externally  the Modelica files using the [GNU gettext](https://www.gnu.org/software/gettext/) format. The exact use of this format in the Modelica context is described in the MCP.

