### PR TITLE
Globally singular

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1212,7 +1212,7 @@ models used for the replaceable component \lstinline!t!). }
 unknowns is structurally non-singular. However, this does not provide
 any guarantees for the global set of equations, and specific
 combinations of models that are locally non-singular may lead to a
-globally non-singular model.}{]}
+globally singular model.}{]}
 
 \emph{Example 3:}
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
Locally non-singular can be combined to globally singular.
Closes #2510
Note that locally non-singular may combine to globally non-singular or globally singular;
and the latter is the exception that should be mentioned.

