### PR TITLE
Dialog group default

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1183,7 +1183,7 @@ end Frame;
 
 \begin{lstlisting}[language=modelica]
 annotation(Dialog(enable = true, tab = "General",
-                  group = "Parameters",
+                  group = "",
                   showStartAttribute = false,
                   colorSelector = false,
                   groupImage="modelica://MyPackage/Resources/Images/switch.png",
@@ -1192,7 +1192,10 @@ annotation(Dialog(enable = true, tab = "General",
 
 The annotations \lstinline!tab! and \lstinline!group! define the placement of
 the component or of variables in a dialog with optional tab and group
-specification. If \lstinline!enable = false!, the input field may
+specification, where the empty string (default) means tool-specific tab and group.
+The idea is that a tool may as default place parameters in the group "Parameters" in the tab "General",
+but add e.g., variables with \lstinline!showStartAttribute=true! to another group.
+If \lstinline!enable = false!, the input field may
 be disabled {[}\emph{and no input can be given}{]}. If
 \lstinline!showStartAttribute = true! the dialog should allow the user to
 set the start-value and the fixed attribute for the variable instead of

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1192,7 +1192,7 @@ annotation(Dialog(enable = true, tab = "General",
 
 The annotations \lstinline!tab! and \lstinline!group! define the placement of
 the component or of variables in a dialog with optional tab and group
-specification, where the empty string (default) means tool-specific tab and group.
+specification, where the empty string (default) means tool-specific group.
 The idea is that a tool may as default place parameters in the group "Parameters" in the tab "General",
 but add e.g., variables with \lstinline!showStartAttribute=true! to another group.
 If \lstinline!enable = false!, the input field may


### PR DESCRIPTION
Specify that group does not have a default in record.
Closes modelica#2476
It would be possible to remove the default for tab as well, but if I was unsure if that was decided.