### PR TITLE
Clarify convertClassIf

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1558,7 +1558,11 @@ Convert class \lstinline!OldClass! to \lstinline!NewClass! if the literal modifi
 \lstinline!oldElement!.
 
 These are considered before \lstinline!convertClass! and \lstinline!convertMessage! for the same
-\lstinline!OldClass!. For string elements the value should be up-quoted, e.g. \lstinline!"\"My String\""!,
+\lstinline!OldClass!. 
+
+The old element should be of a \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String!, or enumeration
+type and the match is based on the literal value of the modifier.
+For string elements the value argument to \lstinline!convertClassIf! shall be up-quoted, e.g. \lstinline!"\"My String\""!,
 and for enumeration literals only the enumeration literal part of the old value matters, e.g., \lstinline!red!
 for \lstinline!"Colors.red"!.
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1558,7 +1558,7 @@ Convert class \lstinline!OldClass! to \lstinline!NewClass! if the literal modifi
 \lstinline!oldElement!.
 
 These are considered before \lstinline!convertClass! and \lstinline!convertMessage! for the same
-\lstinline!OldClass!. 
+\lstinline!OldClass!.
 
 The old element should be of a \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String!, or enumeration
 type and the match is based on the literal value of the modifier.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1558,7 +1558,9 @@ Convert class \lstinline!OldClass! to \lstinline!NewClass! if the literal modifi
 \lstinline!oldElement!.
 
 These are considered before \lstinline!convertClass! and \lstinline!convertMessage! for the same
-\lstinline!OldClass!.
+\lstinline!OldClass!. For string elements the value should be up-quoted, e.g. \lstinline!"\"My String\""!,
+and for enumeration literals only the enumeration literal part of the old value matters, e.g., \lstinline!red!
+for \lstinline!"Colors.red"!.
 
 \paragraph*{convertElement("OldClass", "OldName", "NewName")}\doublelabel{convertelementoldclassoldnamenewname}
 


### PR DESCRIPTION
Restrict types, and clarify enumerations and strings.
Closes #2451 
(Note that MSL 4.0.0 does not rely on those advanced cases.)