### PR TITLE
Clarify order dialog

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1202,6 +1202,9 @@ the value-attribute {[}\emph{this is primarily intended for
 non-parameter values and avoids introducing a separate parameter for the
 start-value of the variable{]}}.
 
+The order of parameters within each group and the order of the groups and tabs are according
+to the declaration order, where inherited elements are added at the place of the extends.
+
 If \lstinline!colorSelector=true!, it indicates that an rgb-value selector can be
 presented for a vector of three elements and generate values 0..255 (the
 annotation should be useable both for vectors of Integers and Reals).


### PR DESCRIPTION
Clarify that the parameter dialog is according to declaration order.
Closes #2310 