### PR TITLE
Relax the uniqueness requirements of plot identifiers

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -115,10 +115,11 @@ replacements, as described in \autoref{variable-replacements}, can be used in th
 \lstinline!title! of \lstinline!Figure! and \lstinline!Plot!.
 
 The \lstinline!identifier! in \lstinline!Figure! and \lstinline!Plot! is
-optional, and is intended for programmatic access.  An \lstinline!identifier!
-must be unique within the class containing the \lstinline!figures! annotation,
-without considering whether it belongs to \lstinline!Figure! or
-\lstinline!Plot!.
+optional, and is intended for programmatic access.  A \lstinline!Figure!
+\lstinline!identifier! must be unique within the class containing the
+\lstinline!figures! annotation, whereas a \lstinline!Plot!
+\lstinline!identifier! must be unique among the \lstinline!plots! in the
+\lstinline!Figure! annotation.
 
 \begin{nonnormative}
 For \lstinline!Figure!, this makes it possible to reference the plot from a


### PR DESCRIPTION
I think that it would be better to only require that `Plot` `identifier` is unique within the `Figure`. For example if you want to duplicate a `Figure` with nice hand crafted identifiers for the plots it makes no sense to require the user to change them, it should be sufficient to only give the `Figure` a new `idenitifier`.