### PR TITLE
Update grammar.md

### DIFF
--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -178,7 +178,7 @@ The reason for this generalization is that some manipulations, in particular inl
 expressions and without the slight generalization we could not generate flat Modelica for them. It does not add any real complication
 to the translator.
 
-The reason it is to parenthesized expressions is that `a.x[1]` (according to normal Modelica semantics) and `(a.x)[1]` will often work differently.
+The reason it is  restricted to parenthesized expressions is that `a.x[1]` (according to normal Modelica semantics) and `(a.x)[1]` will often work differently.
 Consider
 ```
 record R
@@ -189,5 +189,5 @@ R a[3];
 Here  `a.x[1]` is a slice operation in Modelica generating the array  `{a[1].x[1],a[2].x[1],a[3].x[1]}`, whereas `(a.x)[1]` 
 is a subscripted slice operation generating the array `{a[1].x[1],a[1].x[2]}` 
 (assuming trailing subscripts can be skipped, otherwise it is illegal).
-It would be possible to extend subscripting to `{a,b}[1]`, `[a,b][1,1]`, and `foo()[1]` without causing any similar ambiguity 
-- but it was not deemed necessary at the moment.
+It would be possible to extend subscripting to `{a,b}[1]`, `[a,b][1,1]`, 
+and `foo()[1]` without causing any similar ambiguity - but it was not deemed necessary at the moment.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -171,3 +171,22 @@ In Flat Modelica, component declarations outside functions may only specify cons
 #### Change and reason for the change
 In Modelica, array sizes with parameter variability outside of functions are somehow allowed, at least not forbidden, but the semantics are not defined.
 So it is easier to forbid this feature for now. If introduced in Modelica, it is still possible to introduce them here with the same semantics. It would be impossible the other way around.
+
+## Subscripting of general expressions
+In Flat Modelica it is possible to have a subscript on any (parenthesized) expression.
+The reason for this generalization is that some manipulations, in particular inlining of function calls, can lead to such 
+expressions and without the slight generalization we could not generate flat Modelica for them. It does not add any real complication
+to the translator.
+
+The reason it is restricted is that `a.x[1]` (according to normal Modelica semantics) and `(a.x)[1]` will often work differently.
+Consider
+```
+record R
+  Real x[2];
+end R;
+R a[3];
+```
+Here  `a.x[1]` will cause slicing generating the array  `{a[1].x[1],a[2].x[1],a[3].x[1]}`, whereas `(a.x)[1]` generates the array 
+`{a[1].x[1],a[1].x[2]}` (assuming trailing subscripts can be skipped, otherwise it is illegal).
+It would be possible to extend subscripting to `{a,b}[1]`, `[a,b][1,1]`, and `foo()[1]` without causing any similar ambiguity 
+- but it was not deemed necessary at the moment.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -178,7 +178,7 @@ The reason for this generalization is that some manipulations, in particular inl
 expressions and without the slight generalization we could not generate flat Modelica for them. It does not add any real complication
 to the translator.
 
-The reason it is restricted is that `a.x[1]` (according to normal Modelica semantics) and `(a.x)[1]` will often work differently.
+The reason it is to parenthesized expressions is that `a.x[1]` (according to normal Modelica semantics) and `(a.x)[1]` will often work differently.
 Consider
 ```
 record R
@@ -186,7 +186,8 @@ record R
 end R;
 R a[3];
 ```
-Here  `a.x[1]` will cause slicing generating the array  `{a[1].x[1],a[2].x[1],a[3].x[1]}`, whereas `(a.x)[1]` generates the array 
-`{a[1].x[1],a[1].x[2]}` (assuming trailing subscripts can be skipped, otherwise it is illegal).
+Here  `a.x[1]` is a slice operation in Modelica generating the array  `{a[1].x[1],a[2].x[1],a[3].x[1]}`, whereas `(a.x)[1]` 
+is a subscripted slice operation generating the array `{a[1].x[1],a[1].x[2]}` 
+(assuming trailing subscripts can be skipped, otherwise it is illegal).
 It would be possible to extend subscripting to `{a,b}[1]`, `[a,b][1,1]`, and `foo()[1]` without causing any similar ambiguity 
 - but it was not deemed necessary at the moment.

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -346,7 +346,7 @@ end _F;
 > &emsp; | **true**\
 > &emsp; | ( **der** | **initial** | **pure** ) _function-call-args_\
 > &emsp; | _component-reference_ _function-call-args_?\
-> &emsp; | `[(]` _output-expression-list_ `[)]`\
+> &emsp; | `[(]` _output-expression-list_ `[)]` _array-subscripts_?\
 > &emsp; | `[[]` _expression-list_ ( **;** _expression-list_ )* `[]]`\
 > &emsp; | **{** _array-arguments_ **}**\
 > &emsp; | **end**


### PR DESCRIPTION
Allow sub-scripting on general expressions as discussed.

There are multiple ways to handle this, but this seemed like a minimal change that achieves the goal of allowing indexing of general expressions by just allowing `(...)[j]`. 

There is no loss of generality as any general expression `e[i]` can be handled safely by writing `(e)[j]`.

Special cases that are likely to occur include sub-scripting of matrices/vector-expressions and function calls, and allowing them without parenthesis does not make the code that much more readable (not saying that parenthesis makes it easy to read either): `[1,2][1,2]` `{1,2}[1]` `foo(1)[1]`.
