### PR TITLE
Fix two cases of linking to the wrong section with the same title

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -167,7 +167,7 @@ in detail in \autoref{connect-equations-and-connectors}.
 
 The same restrictions apply to Connections\allowbreak{}.branch, Connections\allowbreak{}.root, and
 Connections\allowbreak{}.potentialRoot; which after expansion are handled according
-to \autoref{equation-operators-for-overconstrained-connection-based-equation-systems}.
+to \autoref{equation-operators-for-overconstrained-connection-based-equation-systems1}.
 
 \subsection{If-Equations}\doublelabel{if-equations}
 
@@ -557,7 +557,7 @@ end ThrowingBall;
 
 \subsection{Equation Operators for Overconstrained Connection-Based Equation Systems}\doublelabel{equation-operators-for-overconstrained-connection-based-equation-systems}
 
-See \autoref{equation-operators-for-overconstrained-connection-based-equation-systems} for a description of this topic.
+See \autoref{equation-operators-for-overconstrained-connection-based-equation-systems1} for a description of this topic.
 
 \section{Synchronous Data-flow Principle and Single Assignment Rule}\doublelabel{synchronous-data-flow-principle-and-single-assignment-rule}
 


### PR DESCRIPTION
This should make the links the same as in version 3.4.