### PR TITLE
Remove left over "Equations:." before sequence of examples

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -866,8 +866,6 @@ informing the user.  For example, variables assigned in a when-clause which are 
 used on these variables, do not have an effect on the simulation.
 \end{nonnormative}
 
-Examples:.
-
 \begin{example}
 Continuous time controller initialized in steady-state:
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
This header-like paragraph dates from before each of the different examples at the end of the section was presented as an example on its own.