### PR TITLE
Restore to non-generic makefile, needed for nmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ MLS.pdf: *.tex chapters/*.tex
 	pdflatex MLS.tex
 
 # Seems to be some issue with graphicpath, so set path here as well
+# Not using %.html since nmake does not support it (instead using old-style suffix rules)
 MLS.html: MLS.tex chapters/*.tex
 	$(LATEXMLPREFIX)latexml $*.tex --path=media --dest $*.xml
 	$(LATEXMLPREFIX)latexmlpost $*.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --javascript=css/LaTeXML-maybeMathJax.js --navigationtoc=context --css=css/LaTeXML-navbar-left.css --dest $@

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ MLS.pdf: *.tex chapters/*.tex
 	pdflatex MLS.tex
 
 # Seems to be some issue with graphicpath, so set path here as well
-%.html: %.tex chapters/*.tex
+MLS.html: MLS.tex chapters/*.tex
 	$(LATEXMLPREFIX)latexml $*.tex --path=media --dest $*.xml
 	$(LATEXMLPREFIX)latexmlpost $*.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --javascript=css/LaTeXML-maybeMathJax.js --navigationtoc=context --css=css/LaTeXML-navbar-left.css --dest $@


### PR DESCRIPTION
For some reason nmake cannot handle the target %.html 
and I thus want to restore it since we only generate MLS.html anyway.

The added dependency on chapters/*.tex is still present.