### PR TITLE
Clarify pre for arrays

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1160,7 +1160,7 @@ positive number.\\ \hline
 % pre
 \lstinline!pre(y)! & Returns the \emph{left limit} $y(t^{-})$ of
 variable $y(t)$ at a time instant $t$. At an event instant,
-$y(t^{-})$ is the value of y after the last event
+$y(t^{-})$ is the value of $y$ after the last event
 iteration at time instant $t$ (see comment below).
 Any subscripts in the component expression $y$ must be parameter expressions.
 The \lstinline!pre()! operator can

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1161,7 +1161,7 @@ positive number.\\ \hline
 \lstinline!pre(y)! & Returns the \emph{left limit} $y(t^{-})$ of
 variable $y(t)$ at a time instant $t$. At an event instant,
 $y(t^{-})$ is the value of y after the last event
-iteration at time instant $t$ (see comment below). 
+iteration at time instant $t$ (see comment below).
 Any subscripts in the component expression $y$ must be parameter expressions.
 The \lstinline!pre()! operator can
 be applied if the following three conditions are fulfilled

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1158,10 +1158,12 @@ a subtype of Real or Integer. The sample interval \lstinline!interval! must be a
 positive number.\\ \hline
 
 % pre
-\lstinline!pre(y)! & Returns the \emph{left limit} $y(t\textsuperscript{pre})$ of
+\lstinline!pre(y)! & Returns the \emph{left limit} $y(t^{-})$ of
 variable $y(t)$ at a time instant $t$. At an event instant,
-$y(t\textsuperscript{pre})$ is the value of y after the last event
-iteration at time instant $t$ (see comment below). The \lstinline!pre()! operator can
+$y(t^{-})$ is the value of y after the last event
+iteration at time instant $t$ (see comment below). 
+Any subscripts in the component expression $y$ must be parameter expressions.
+The \lstinline!pre()! operator can
 be applied if the following three conditions are fulfilled
 simultaneously: (a) variable $y$ is either a subtype of a simple type or
 is a record component, (b) $y$ is a discrete-time expression (c) the


### PR DESCRIPTION
Closes #2556

Note I also changed another part of pre for typographic reasons.

Currently on https://specification.modelica.org/master/operators-and-expressions.html#event-related-operators-with-function-syntax I see
y(tUnknown node type: sup)
which isn't good, and I assume it is related to textsuperscript in math.
I experimented a bit and in case mathjax isn't active (seems to be the case locally with edge and chrome) tpre looks weird, so t^-^ seems like the safest solution.