### PR TITLE
Make mathescape=true by default

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1796,7 +1796,7 @@ String revisionId    "Revision identifier of the version management system used
 \end{lstlisting}
 
 \begin{example}
-\begin{lstlisting}[language=modelica]
+\begin{lstlisting}[language=modelica,mathescape=false]
 package Modelica
   ...
   annotation(version = "3.0.1",
@@ -1912,7 +1912,7 @@ read-only; the way to modify it is to generate a new encrypted version.\\
 
 In this section annotations are defined for protection and licensing.  Obfuscation and encryption are not standardized.
 Protection and licensing are both defined inside the \lstinline!Protection! annotation:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 annotation(Protection($\ldots$));
 \end{lstlisting}
 

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -70,12 +70,12 @@ An array indexed by \lstinline!Boolean! or enumeration type can only be used in 
 \hline
 \tablehead{Modelica form 1} & \tablehead{Modelica form 2} & \tablehead{\# dims} & \tablehead{Designation} & \tablehead{Explanation}\\ \hline
 \endhead
-\lstinline[mathescape=true]!C x!;            & \lstinline[mathescape=true]!C x!; & $0$ & Scalar & Scalar\\ \hline
-\lstinline[mathescape=true]!C[$n$] x;!       & \lstinline[mathescape=true]!C x[$n$];! & $1$ & Vector & $n$-Vector\\ \hline
-\lstinline[mathescape=true]!C[EB] x;!        & \lstinline[mathescape=true]!C x[EB]! & $1$ & Vector & Vector index by enumeration or \lstinline!Boolean! type \lstinline!EB!\\ \hline
-\lstinline[mathescape=true]!C[$n$, $m$] x;!  & \lstinline[mathescape=true]!C x[$n$, $m$];! & $2$ & Matrix & $n \times m$ Matrix\\ \hline
-\lstinline[mathescape=true]!C[$n_1$, $n_{2}$, $\ldots$, $n_k$] x;! &
-\lstinline[mathescape=true]!C x[$n_{1}$, $n_{2}$, $\ldots$, $n_{k}$];! & $k$ & Array & Array with $k$ dimensions ($k \geq 0$).\\ \hline
+\lstinline!C x!;            & \lstinline!C x!; & $0$ & Scalar & Scalar\\ \hline
+\lstinline!C[$n$] x;!       & \lstinline!C x[$n$];! & $1$ & Vector & $n$-Vector\\ \hline
+\lstinline!C[EB] x;!        & \lstinline!C x[EB]! & $1$ & Vector & Vector index by enumeration or \lstinline!Boolean! type \lstinline!EB!\\ \hline
+\lstinline!C[$n$, $m$] x;!  & \lstinline!C x[$n$, $m$];! & $2$ & Matrix & $n \times m$ Matrix\\ \hline
+\lstinline!C[$n_1$, $n_{2}$, $\ldots$, $n_k$] x;! &
+\lstinline!C x[$n_{1}$, $n_{2}$, $\ldots$, $n_{k}$];! & $k$ & Array & Array with $k$ dimensions ($k \geq 0$).\\ \hline
 \end{longtable}
 
 \begin{example}
@@ -117,10 +117,10 @@ Special cases:
 \hline
 \tablehead{Modelica form 1} & \tablehead{Modelica form 2} & \tablehead{\# dims} & \tablehead{Designation} & \tablehead{Explanation}\\ \hline
 \endhead
-\lstinline[mathescape=true]!C[1] x;!      & \lstinline[mathescape=true]!C x[1];!      & $1$ & Vector & 1-Vector, representing a scalar\\ \hline
-\lstinline[mathescape=true]!C[1, 1] x;!   & \lstinline[mathescape=true]!C x[1, 1];!   & $2$ & Matrix & $(1 \times 1)$-Matrix, representing a scalar\\ \hline
-\lstinline[mathescape=true]!C[$n$, 1] x;! & \lstinline[mathescape=true]!C x[$n$, 1];! & $2$ & Matrix & $(n \times 1)$-Matrix, representing a column\\ \hline
-\lstinline[mathescape=true]!C[1, $n$] x;! & \lstinline[mathescape=true]!C x[1, $n$];! & $2$ & Matrix & $(1 \times n)$-Matrix, representing a row\\ \hline
+\lstinline!C[1] x;!      & \lstinline!C x[1];!      & $1$ & Vector & 1-Vector, representing a scalar\\ \hline
+\lstinline!C[1, 1] x;!   & \lstinline!C x[1, 1];!   & $2$ & Matrix & $(1 \times 1)$-Matrix, representing a scalar\\ \hline
+\lstinline!C[$n$, 1] x;! & \lstinline!C x[$n$, 1];! & $2$ & Matrix & $(n \times 1)$-Matrix, representing a column\\ \hline
+\lstinline!C[1, $n$] x;! & \lstinline!C x[1, $n$];! & $2$ & Matrix & $(1 \times n)$-Matrix, representing a row\\ \hline
 \end{longtable}
 \end{nonnormative}
 
@@ -153,11 +153,11 @@ Real r[3] = p1[2]; // equivalent to r[3] = p1[2, :]
 Automatic assertions at simulation time:
 
 Let \lstinline!A! be a declared array and \lstinline!i! be the declared maximum dimension size of the \lstinline!di!-dimension, then an assert statement
-\lstinline[mathescape=true]!assert(i >= 0, $\ldots$)! is generated provided this assertion cannot be checked at compile time.  It is a quality of implementation
+\lstinline!assert(i >= 0, $\ldots$)! is generated provided this assertion cannot be checked at compile time.  It is a quality of implementation
 issue to generate a good error message if the assertion fails.
 
 Let \lstinline!A! be a declared array and \lstinline!i! be an index accessing an index of the \lstinline!di!-dimension.  Then for every such index-access an assert
-statement \lstinline[mathescape=true]!assert(1 <= i and i <= size(A, di), $\ldots$)! is generated, provided this assertion cannot be checked at compile time.
+statement \lstinline!assert(1 <= i and i <= size(A, di), $\ldots$)! is generated, provided this assertion cannot be checked at compile time.
 
 For efficiency reasons, these implicit assert statements may be optionally suppressed.
 \end{nonnormative}
@@ -171,7 +171,7 @@ The lower and upper index bounds for a dimension of an array indexed by \lstinli
 \item
   An array dimension indexed by \lstinline!Boolean! values has the lower bound \lstinline!false! and the upper bound \lstinline!true!.
 \item
-  An array dimension indexed by \lstinline!enumeration! values of the type \lstinline[mathescape=true]!E = enumeration(e1, e2, $\ldots$, en)!
+  An array dimension indexed by \lstinline!enumeration! values of the type \lstinline!E = enumeration(e1, e2, $\ldots$, en)!
   has the lower bound \lstinline!E.e1! and the upper bound \lstinline!E.en!.
 \end{itemize}
 
@@ -189,11 +189,11 @@ utilized below to define other array operators and functions:
 \begin{longtable}[]{|l|p{9cm}|}
 \caption{Promote function (cannot be used in Modelica).}\\
 \hline \endhead
-\lstinline[mathescape=true]!promote(A, $n$)! & Fills dimensions of size 1 from the right to array \lstinline!A! upto
-dimension $n$, where $n \geq$ \lstinline!ndims(A)! is required. Let \lstinline[mathescape=true]!C = promote(A, $n$)!, with $n_{\mathrm{A}}$ = \lstinline!ndims(A)!,
-then \lstinline[mathescape=true]!ndims(C) = $n$!, \lstinline[mathescape=true]!size(C, $j$) = size(A, $j$)! for $1 \leq j \leq n_{\mathrm{A}}$,
-\lstinline[mathescape=true]!size(C, $j$)! = $1$ for $n_{\mathrm{A}} + 1 \leq j \leq n$, \lstinline[mathescape=true]!C[$i_{1}$, $\ldots$, $i_{n_{\mathrm{A}}}$, 1, $\ldots$, 1]! =
-\lstinline[mathescape=true]!A[$i_{1}$, $\ldots$, $i_{n_{\mathrm{A}}}$]!\\ \hline
+\lstinline!promote(A, $n$)! & Fills dimensions of size 1 from the right to array \lstinline!A! upto
+dimension $n$, where $n \geq$ \lstinline!ndims(A)! is required. Let \lstinline!C = promote(A, $n$)!, with $n_{\mathrm{A}}$ = \lstinline!ndims(A)!,
+then \lstinline!ndims(C) = $n$!, \lstinline!size(C, $j$) = size(A, $j$)! for $1 \leq j \leq n_{\mathrm{A}}$,
+\lstinline!size(C, $j$)! = $1$ for $n_{\mathrm{A}} + 1 \leq j \leq n$, \lstinline!C[$i_{1}$, $\ldots$, $i_{n_{\mathrm{A}}}$, 1, $\ldots$, 1]! =
+\lstinline!A[$i_{1}$, $\ldots$, $i_{n_{\mathrm{A}}}$]!\\ \hline
 \end{longtable}
 
 \begin{nonnormative}
@@ -228,7 +228,7 @@ sizes are provided:
 \lstinline!ndims(A)! &
 Returns the number of dimensions $k$ of expression \lstinline!A!, with $k \geq 0$.
 \\ \hline
-\lstinline[mathescape=true]!size(A, $i$)! &
+\lstinline!size(A, $i$)! &
 Returns the size of dimension $i$ of array expression \lstinline!A! where $0 \leq i \leq \text{\lstinline!ndims(A)!}$.\\ \hline
 \lstinline!size(A)! &
 Returns a vector of length \lstinline!ndims(A)! containing the dimension sizes of \lstinline!A!.\\ \hline
@@ -273,7 +273,7 @@ is described in \autoref{vector-matrix-and-array-constructors}.
 \hline
 \tablehead{Modelica} & \tablehead{Explanation}\\ \hline
 \endhead
-\lstinline[mathescape=true]!identity($n$)!
+\lstinline!identity($n$)!
 &
 Returns the $n \times n$ \lstinline!Integer! identity matrix, with ones on the diagonal and
 zeros at the other places.\\ \hline
@@ -281,25 +281,25 @@ zeros at the other places.\\ \hline
 &
 Returns a square matrix with the elements of vector v on the diagonal
 and all other elements zero.\\ \hline
-\lstinline[mathescape=true]!zeros($n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
+\lstinline!zeros($n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
 Returns the $n_{1} \times n_{2} \times n_{3} \times \ldots$ \lstinline!Integer! array with all elements equal to zero ($n_{i} \geq 0$).
 The function needs one or more arguments, that is, \lstinline!zeros()! is not legal.\\ \hline
-\lstinline[mathescape=true]!ones($n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
+\lstinline!ones($n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
 Return the $n_{1} \times n_{2} \times n_{3} \times \ldots$ \lstinline!Integer! array with all elements equal to one ($n_{i} \geq 0$).
 The function needs one or more arguments, that is, \lstinline!ones()! is not legal.\\ \hline
-\lstinline[mathescape=true]!fill(s, $n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
+\lstinline!fill(s, $n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! &
 Returns the $n_{1} \times n_{2} \times n_{3} \times \ldots$ array with all elements equal to scalar or array expression \lstinline!s!
 ($n_{i} \geq 0$). The returned array has the same type as \lstinline!s!.
 Recursive definition:
-\lstinline[mathescape=true]!fill(s, $n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! =
-\lstinline[mathescape=true]!fill(fill(s, $n_{2}$, $n_{3}$, $\ldots$), $n_{1}$)!;
-\lstinline[mathescape=true]!fill(s, $n$)! = \lstinline[mathescape=true]!{s, s, $\ldots$, s}!.
+\lstinline!fill(s, $n_{1}$, $n_{2}$, $n_{3}$, $\ldots$)! =
+\lstinline!fill(fill(s, $n_{2}$, $n_{3}$, $\ldots$), $n_{1}$)!;
+\lstinline!fill(s, $n$)! = \lstinline!{s, s, $\ldots$, s}!.
 The function needs two or more arguments; that is \lstinline!fill(s)! is not legal.\\ \hline
-\lstinline[mathescape=true]!linspace($x_{1}$, $x_{2}$, $n$)!
+\lstinline!linspace($x_{1}$, $x_{2}$, $n$)!
 &
-Returns a \lstinline!Real! vector with $n$ equally spaced elements, such that \lstinline[mathescape=true]!v = linspace($x_{1}$, $x_{2}$, $n$)! results in
+Returns a \lstinline!Real! vector with $n$ equally spaced elements, such that \lstinline!v = linspace($x_{1}$, $x_{2}$, $n$)! results in
 \begin{equation*}
-\text{\lstinline[mathescape=true]!v[$i$]!} = x_{1} + (x_{2} - x_{1}) \frac{i - 1}{n - 1} \quad \text{for $1 \leq i \leq n$}
+\text{\lstinline!v[$i$]!} = x_{1} + (x_{2} - x_{1}) \frac{i - 1}{n - 1} \quad \text{for $1 \leq i \leq n$}
 \end{equation*}
 It is required that $n \geq 2$.  The arguments $x_{1}$ and $x_{2}$ shall be numeric scalar expressions.\\ \hline
 \end{longtable}
@@ -327,14 +327,14 @@ Returns the least element of array expression \lstinline!A!; as defined by \lsti
 &
 Returns the least element of the scalars \lstinline!x! and \lstinline!y!; as defined by \lstinline!<!.\\ \hline
 \begin{tabular}{@{}p{4cm}@{}}
-\lstinline[mathescape=true]!min(e(i, $\ldots$, j)!\\
-\lstinline[mathescape=true]! for i in u, $\ldots$,!\\
-\lstinline[mathescape=true]!     j in v)!
+\lstinline!min(e(i, $\ldots$, j)!\\
+\lstinline! for i in u, $\ldots$,!\\
+\lstinline!     j in v)!
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
 Also described in \autoref{reduction-expressions}.  Returns the least value (as defined by \lstinline!<!) of the scalar expression
-\lstinline[mathescape=true]!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
+\lstinline!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
 \end{tabular}\\ \hline
 \lstinline!max(A)!
 &
@@ -345,60 +345,60 @@ Returns the greatest element of array expression \lstinline!A!; as defined by
 Returns the greatest element of the scalars \lstinline!x! and \lstinline!y!; as defined by
 \lstinline!>!.\\ \hline
 \begin{tabular}{@{}p{4cm}@{}}
-\lstinline[mathescape=true]!max(e(i, $\ldots$, j)!\\
-\lstinline[mathescape=true]! for i in u, $\ldots$,!\\
-\lstinline[mathescape=true]!     j in v)!
+\lstinline!max(e(i, $\ldots$, j)!\\
+\lstinline! for i in u, $\ldots$,!\\
+\lstinline!     j in v)!
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
 Also described in \autoref{reduction-expressions}.  Returns the greatest value (as defined by \lstinline!>!) of the scalar expression
-\lstinline[mathescape=true]!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
+\lstinline!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
 \end{tabular}\\ \hline
 \lstinline!sum(A)!
 &
 \begin{tabular}{@{}p{10cm}@{}}
 Returns the scalar sum of all the elements of array expression \lstinline!A!:\\
-\lstinline[mathescape=true]!= sum(A[j, k, $\ldots$] for j, k, $\ldots$)!
+\lstinline!= sum(A[j, k, $\ldots$] for j, k, $\ldots$)!
 \end{tabular}\\ \hline
 \begin{tabular}{@{}p{5cm}@{}}
-\lstinline[mathescape=true]!sum(e(i, $\ldots$, j)!\\
-\lstinline[mathescape=true]! for i in u, $\ldots$,!\\
-\lstinline[mathescape=true]!     j in v)!
+\lstinline!sum(e(i, $\ldots$, j)!\\
+\lstinline! for i in u, $\ldots$,!\\
+\lstinline!     j in v)!
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the sum of the expression \lstinline[mathescape=true]!e(i, $\ldots$, j)! evaluated for all
-combinations of \lstinline[mathescape=true]!i in u!, $\ldots$, \lstinline[mathescape=true]!j in v!: For \lstinline!Integer! indexing this is
-\begin{lstlisting}[language=modelica,mathescape=true]
+Also described in \autoref{reduction-expressions}.  Returns the sum of the expression \lstinline!e(i, $\ldots$, j)! evaluated for all
+combinations of \lstinline!i in u!, $\ldots$, \lstinline!j in v!: For \lstinline!Integer! indexing this is
+\begin{lstlisting}[language=modelica]
 e(u[1], $\ldots$, v[1]) + e(u[2], $\ldots$, v[1]) + $\ldots$
  + e(u[end], $\ldots$, v[1]) + $\ldots$
  + e(u[end], $\ldots$, v[end])
 \end{lstlisting}
 For non-\lstinline!Integer! indexing this uses all valid indices instead of 1..\lstinline!end!.
-The type of \lstinline[mathescape=true]!sum(e(i, $\ldots$, j) for i in u, $\ldots$, j in v)! is the same as the type of \lstinline[mathescape=true]!e(i, $\ldots$, j)!.
+The type of \lstinline!sum(e(i, $\ldots$, j) for i in u, $\ldots$, j in v)! is the same as the type of \lstinline!e(i, $\ldots$, j)!.
 \end{tabular}\\ \hline
 \lstinline!product(A)!
 &
 \begin{tabular}{@{}p{10cm}@{}}
 Returns the scalar product of all the elements of array expression \lstinline!A!:\\
-\lstinline[mathescape=true]!= product(A[j, k, $\ldots$] for j, k, $\ldots$)!
+\lstinline!= product(A[j, k, $\ldots$] for j, k, $\ldots$)!
 \end{tabular}\\ \hline
 \begin{tabular}{@{}p{4cm}@{}}
-\lstinline[mathescape=true]!product(e(i, $\ldots$, j)!\\
-\lstinline[mathescape=true]! for i in u, $\ldots$,!\\
-\lstinline[mathescape=true]!     j in v)!
+\lstinline!product(e(i, $\ldots$, j)!\\
+\lstinline! for i in u, $\ldots$,!\\
+\lstinline!     j in v)!
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the product of the scalar expression \lstinline[mathescape=true]!e(i, $\ldots$, j)! evaluated for
+Also described in \autoref{reduction-expressions}.  Returns the product of the scalar expression \lstinline!e(i, $\ldots$, j)! evaluated for
 all combinations of \lstinline!i in u!, \ldots, \lstinline!j in v!: For \lstinline!Integer! indexing this is
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 e(u[1], $\ldots$, v[1]) * e(u[2], $\ldots$, v[1]) * $\ldots$
  * e(u[end], $\ldots$, v[1]) * $\ldots$
  * e(u[end], $\ldots$, v[end])
 \end{lstlisting}
 For non-\lstinline!Integer! indexing this uses all valid indices instead of 1..\lstinline!end!.
-The type of \lstinline[mathescape=true]!product(e(i, $\ldots$, j) for i in u, $\ldots$, j in v)! is the same as the type of \lstinline[mathescape=true]!e(i, $\ldots$, j)!.
+The type of \lstinline!product(e(i, $\ldots$, j) for i in u, $\ldots$, j in v)! is the same as the type of \lstinline!e(i, $\ldots$, j)!.
 \end{tabular}
 \\ \hline
 \end{longtable}
@@ -439,7 +439,7 @@ see \autoref{types-as-iteration-ranges}.
 \hline
 \tablehead{Function-name} & \tablehead{Restriction on expression1} & \tablehead{Result if expression2 is empty}\\ \hline
 \endhead
-\lstinline!sum! & \lstinline!Integer! or \lstinline!Real! & \lstinline[mathescape=true]!zeros($\ldots$)!\\ \hline
+\lstinline!sum! & \lstinline!Integer! or \lstinline!Real! & \lstinline!zeros($\ldots$)!\\ \hline
 \lstinline!product! & Scalar \lstinline!Integer! or \lstinline!Real! & \lstinline!1!\\ \hline
 \lstinline!min! & Scalar enumeration, \lstinline!Boolean!, \lstinline!Integer! or \lstinline!Real! &
 \begin{tabular}{@{}p{6cm}@{}}
@@ -455,7 +455,7 @@ Least value of type\\
 
 \begin{example}
 % No frame since the math would break it.
-\begin{lstlisting}[language=modelica, mathescape=true, frame=none]
+\begin{lstlisting}[language=modelica, frame=none]
 sum(i for  i in 1:10) // Gives $\sum_{i=1}^{10}i=$1+2+...+10=55
 // Read it as: compute the sum of i for i in the range 1 to 10.
 sum(i^2 for  i in {1,3,7,6}) // Gives $\sum_{i\in \begin{Bmatrix}1&3&7&6\end{Bmatrix}}i^2=$1+9+49+36=95
@@ -487,10 +487,10 @@ Returns the outer product of vectors \lstinline!x! and \lstinline!y!:\\
 & Returns a symmetric matrix which is identical to the square matrix \lstinline!A!
 on and above the diagonal.  I.e., \lstinline!B := symmetric(A)! implies
 \begin{equation*}
-\text{\lstinline[mathescape=true]!B[$i$, $j$]!} =
+\text{\lstinline!B[$i$, $j$]!} =
 \begin{cases}
-\text{\lstinline[mathescape=true]!A[$i$, $j$]!} & \text{if $i \leq j$}\\
-\text{\lstinline[mathescape=true]!A[$j$, $i$]!} & \text{if $i > j$}
+\text{\lstinline!A[$i$, $j$]!} & \text{if $i \leq j$}\\
+\text{\lstinline!A[$j$, $i$]!} & \text{if $i > j$}
 \end{cases}
 \end{equation*}\\ \hline
 \lstinline!cross(x, y)!
@@ -517,7 +517,7 @@ Returns the $3 \times 3$ skew symmetric matrix associated with a 3-vector, i.e.,
 
 \section{Vector, Matrix and Array Constructors}\doublelabel{vector-matrix-and-array-constructors}
 
-The constructor function \lstinline[mathescape=true]!array(A, B, C, $\ldots$)! constructs an array from its arguments according to the following rules:
+The constructor function \lstinline!array(A, B, C, $\ldots$)! constructs an array from its arguments according to the following rules:
 \begin{itemize}
 \item
   Size matching: All arguments must have the same sizes, i.e.,
@@ -528,9 +528,9 @@ The constructor function \lstinline[mathescape=true]!array(A, B, C, $\ldots$)! c
   \lstinline!Integer! numbers have been transformed to \lstinline!Real! numbers.
 \item
   Each application of this constructor function adds a one-sized dimension to the left in the result compared to the dimensions of the argument arrays, i.e.,
-  \lstinline[mathescape=true]!ndims(array(A, B, C)) = ndims(A) + 1 = ndims(B) + 1, $\ldots$!
+  \lstinline!ndims(array(A, B, C)) = ndims(A) + 1 = ndims(B) + 1, $\ldots$!
 \item
-  \lstinline[mathescape=true]!{A, B, C, $\ldots$}! is a shorthand notation for \lstinline[mathescape=true]!array(A, B, C, $\ldots$)!.
+  \lstinline!{A, B, C, $\ldots$}! is a shorthand notation for \lstinline!array(A, B, C, $\ldots$)!.
 \item
   There must be at least one argument.
   \begin{nonnormative}
@@ -618,7 +618,7 @@ Real hilb2[:,:]={{ 1/(i+j-1) for  j in 1:n} for i in 1:n};
 
 \subsection{Array Concatenation}\doublelabel{array-concatenation}
 
-The function \lstinline[mathescape=true]!cat($k$, A, B, C, $\ldots$)! concatenates arrays
+The function \lstinline!cat($k$, A, B, C, $\ldots$)! concatenates arrays
 \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots along
 dimension $k$ according to the following rules:
 \begin{itemize}
@@ -635,8 +635,8 @@ dimension $k$ according to the following rules:
   $k$ has to characterize an existing dimension, i.e., $1 \leq k \leq \text{\lstinline!ndims(A)!} = \text{\lstinline!ndims(B)!} = \text{\lstinline!ndims(C)!}$; $k$ shall be a parameter expression of \lstinline!Integer! type.
 \item
   Size matching: Arrays \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots must have identical array sizes
-  with the exception of the size of dimension $k$, i.e., \lstinline[mathescape=true]!size(A, $j$)! =
-  \lstinline[mathescape=true]!size(B, $j$)!, for $1 \leq j \leq \text{\lstinline!ndims(A)!}$ and $j \neq k$.
+  with the exception of the size of dimension $k$, i.e., \lstinline!size(A, $j$)! =
+  \lstinline!size(B, $j$)!, for $1 \leq j \leq \text{\lstinline!ndims(A)!}$ and $j \neq k$.
 \end{itemize}
 
 \begin{example}
@@ -646,13 +646,13 @@ Real[2,6] r2 = cat(2, r1, 2*r1);
 \end{lstlisting}
 \end{example}
 
-Formally, the concatenation \lstinline[mathescape=true]!R = cat($k$, A, B, C, $\ldots$)! is defined as follows.  Let $n$ = \lstinline!ndims(A)! = \lstinline!ndims(B)! = \lstinline!ndims(C)! = \ldots  Then the size of \lstinline!R! is given by
-\begin{lstlisting}[language=modelica,escapechar=!,mathescape=true,frame=none,xleftmargin=1em]
+Formally, the concatenation \lstinline!R = cat($k$, A, B, C, $\ldots$)! is defined as follows.  Let $n$ = \lstinline!ndims(A)! = \lstinline!ndims(B)! = \lstinline!ndims(C)! = \ldots  Then the size of \lstinline!R! is given by
+\begin{lstlisting}[language=modelica,escapechar=!,frame=none,xleftmargin=1em]
 size(R,$k$) = size(A,$k$) + size(B,$k$) + size(C,$k$) + $\ldots$
 size(R,$j$) = size(A,$j$) = size(B,$j$) = size(C,$j$) = $\ldots$ !for! $1 \leq j \leq n$ !and! $j \neq k$
 \end{lstlisting}
 and the array elements of \lstinline!R! are given by
-\begin{lstlisting}[language=modelica,escapechar=!,mathescape=true,frame=none,xleftmargin=1em]
+\begin{lstlisting}[language=modelica,escapechar=!,frame=none,xleftmargin=1em]
 R[$i_{1}$, $\ldots$, $i_{k}$, $\ldots$, $i_{n}$] = A[$i_{1}$, $\ldots$, $i_{k}$, $\ldots$, $i_{n}$]
   !for! $0 < i_{k} \leq$ size(A,$k$)
 R[$i_{1}$, $\ldots$, $i_{k}$, $\ldots$, $i_{n}$] = B[$i_{1}$, $\ldots$, $i_{k}$ - size(A,$k$), $\ldots$, $i_{n}$]
@@ -661,7 +661,7 @@ R[$i_{1}$, $\ldots$, $i_{k}$, $\ldots$, $i_{n}$] = C[$i_{1}$, $\ldots$, $i_{k}$ 
   !for! size(A,$k$) + size(B,$k$) $< i_{k} \leq$ size(A,$k$) + size(B,$k$) + size(C,$k$)
 $\ldots$
 \end{lstlisting}
-where $1 \leq i_{j} \leq$ \lstinline[mathescape=true]!size(R,$j$)! for $1 \leq j \leq n$.
+where $1 \leq i_{j} \leq$ \lstinline!size(R,$j$)! for $1 \leq j \leq n$.
 
 
 \subsubsection{Array Concatenation along First and Second Dimensions}\doublelabel{array-concatenation-along-first-and-second-dimensions}
@@ -670,19 +670,19 @@ For convenience, a special syntax is supported for the concatenation along the f
 \begin{itemize}
 \item
   \emph{Concatenation along first dimension}:\\
-  \lstinline[mathescape=true]![A; B; C; $\ldots$] = cat(1, promote(A, n), promote(B, n), promote(C, n), $\ldots$)!
-  where \lstinline[mathescape=true]!n = max(2, ndims(A), ndims(B), ndims(C), $\ldots$)!.  If necessary, 1-sized
+  \lstinline![A; B; C; $\ldots$] = cat(1, promote(A, n), promote(B, n), promote(C, n), $\ldots$)!
+  where \lstinline!n = max(2, ndims(A), ndims(B), ndims(C), $\ldots$)!.  If necessary, 1-sized
   dimensions are added to the right of \lstinline!A!, \lstinline!B!, \lstinline!C! before the operation is
   carried out, in order that the operands have the same number of dimensions which will be at least two.
 \item
   \emph{Concatenation along second dimension}:\\
-  \lstinline[mathescape=true]![A, B, C, $\ldots$] = cat(2, promote(A, n), promote(B, n), promote(C, n), $\ldots$)!
-  where \lstinline[mathescape=true]!n = max(2, ndims(A), ndims(B), ndims(C), $\ldots$)!.  If necessary, 1-sized
+  \lstinline![A, B, C, $\ldots$] = cat(2, promote(A, n), promote(B, n), promote(C, n), $\ldots$)!
+  where \lstinline!n = max(2, ndims(A), ndims(B), ndims(C), $\ldots$)!.  If necessary, 1-sized
   dimensions are added to the right of \lstinline!A!, \lstinline!B!, \lstinline!C! before the operation is
   carried out, especially that each operand has at least two dimensions.
 \item
-  The two forms can be mixed.  \lstinline[mathescape=true]![$\ldots$, $\ldots$]! has higher precedence than
-  \lstinline[mathescape=true]![$\ldots$; $\ldots$]!, e.g., \lstinline![a, b; c, d]! is parsed as \lstinline![[a, b]; [c, d]]!.
+  The two forms can be mixed.  \lstinline![$\ldots$, $\ldots$]! has higher precedence than
+  \lstinline![$\ldots$; $\ldots$]!, e.g., \lstinline![a, b; c, d]! is parsed as \lstinline![[a, b]; [c, d]]!.
 \item
   \lstinline![A] = promote(A, max(2, ndims(A)))!, i.e., \lstinline![A] = A!, if \lstinline!A! has 2 or more dimensions, and it is a matrix
   with the elements of \lstinline!A!, if \lstinline!A! is a scalar or a vector.
@@ -722,29 +722,29 @@ Real[3] v = {1, 2, 3};
 The range vector operator or colon operator of simple-expression can be used instead of or in combination with this general constructor to construct \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean! or enumeration type vectors.  Semantics of the colon operator:
 \begin{itemize}
 \item
-  \lstinline[mathescape=true]!$j$ : $k$! is the \lstinline!Integer! vector \lstinline[mathescape=true]!{$j$, $j+1$, $\ldots$, $k$}!, if $j$ and $k$ are of type
+  \lstinline!$j$ : $k$! is the \lstinline!Integer! vector \lstinline!{$j$, $j+1$, $\ldots$, $k$}!, if $j$ and $k$ are of type
   \lstinline!Integer!.
 \item
-  \lstinline[mathescape=true]!$j$ : $k$! is the \lstinline!Real! vector \lstinline[mathescape=true]!{$j$, $j+1.0$, $\ldots$, $j+n$}!, with $n = \text{\lstinline!floor!}(k - j)$, if
+  \lstinline!$j$ : $k$! is the \lstinline!Real! vector \lstinline!{$j$, $j+1.0$, $\ldots$, $j+n$}!, with $n = \text{\lstinline!floor!}(k - j)$, if
   $j$ and/or $k$ are of type \lstinline!Real!.
 \item
-  \lstinline[mathescape=true]!$j$ : $k$! is a \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, or \lstinline!enumeration! type vector with zero elements, if $j > k$.
+  \lstinline!$j$ : $k$! is a \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, or \lstinline!enumeration! type vector with zero elements, if $j > k$.
 \item
-  \lstinline[mathescape=true]!$j$ : $d$ : $k$! is the \lstinline!Integer! vector \lstinline[mathescape=true]!{$j$, $j+d$, $\ldots$, $j + n d$}!, with $n = \text{\lstinline!div!}(k - j, d)$, if $j$, $d$, and $k$ are of type \lstinline!Integer!.
+  \lstinline!$j$ : $d$ : $k$! is the \lstinline!Integer! vector \lstinline!{$j$, $j+d$, $\ldots$, $j + n d$}!, with $n = \text{\lstinline!div!}(k - j, d)$, if $j$, $d$, and $k$ are of type \lstinline!Integer!.
 \item
-  \lstinline[mathescape=true]!$j$ : $d$ : $k$! is the \lstinline!Real! vector \lstinline[mathescape=true]!{$j$, $j+d$, $\ldots$, $j + n d$}!, with $n = \text{\lstinline!floor!}((k-j)/d)$,
+  \lstinline!$j$ : $d$ : $k$! is the \lstinline!Real! vector \lstinline!{$j$, $j+d$, $\ldots$, $j + n d$}!, with $n = \text{\lstinline!floor!}((k-j)/d)$,
   if $j$, $d$, or $k$ are of type \lstinline!Real!.  In order to avoid rounding issues for the length it is recommended to use \lstinline!{j + d * i for i in 0 : n}! or
   \lstinline!linspace(j, k, n + 1)! --- if the number of elements are known.
 \item
-  \lstinline[mathescape=true]!$j$ : $d$ : $k$! is a \lstinline!Real! or \lstinline!Integer! vector with zero elements, if $d > 0$ and $j > k$ or if $d < 0$ and $j < k$.
+  \lstinline!$j$ : $d$ : $k$! is a \lstinline!Real! or \lstinline!Integer! vector with zero elements, if $d > 0$ and $j > k$ or if $d < 0$ and $j < k$.
 \item
   \lstinline!false : true! is the \lstinline!Boolean! vector \lstinline!{false, true}!.
 \item
-  \lstinline[mathescape=true]!$j$ : $j$! is \lstinline[mathescape=true]!{$j$}! if $j$ is \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, or \lstinline!enumeration! type.
+  \lstinline!$j$ : $j$! is \lstinline!{$j$}! if $j$ is \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, or \lstinline!enumeration! type.
 \item
-  \lstinline!E.ei : E.ej! is the enumeration type vector \lstinline[mathescape=true]!{E.ei, $\ldots$, E.ej}! where
+  \lstinline!E.ei : E.ej! is the enumeration type vector \lstinline!{E.ei, $\ldots$, E.ej}! where
   $\text{\lstinline!E.ej!} > \text{\lstinline!E.ei!}$, and \lstinline!ei! and \lstinline!ej! belong to some enumeration type
-  \lstinline[mathescape=true]!E = enumeration($\ldots$, ei, $\ldots$, ej, $\ldots$)!.
+  \lstinline!E = enumeration($\ldots$, ei, $\ldots$, ej, $\ldots$)!.
 \end{itemize}
 
 \begin{example}
@@ -765,7 +765,7 @@ these values. An indexing operation is subject to upper and lower array
 dimension index bounds (\autoref{array-dimension-lower-and-upper-index-bounds}).  The indexing operator takes two or more
 operands, where the first operand is the array to be indexed and the rest of the operands are index expressions:
 
-\lstinline[mathescape=true]!$\mathit{arrayname}$[$\mathit{indexexpr}_{1}$, $\mathit{indexexpr}_{2}$, $\ldots$]!
+\lstinline!$\mathit{arrayname}$[$\mathit{indexexpr}_{1}$, $\mathit{indexexpr}_{2}$, $\ldots$]!
 
 A colon is used to denote all indices of one dimension. A vector
 expression can be used to pick out selected rows, columns and elements
@@ -801,23 +801,23 @@ If \lstinline!x! is a vector, \lstinline!x[1]! is a scalar, but the slice \lstin
 \end{example}
 
 \begin{example}
-Array slicing given the declarations \lstinline[mathescape=true]!x[$n$, $m$]!, \lstinline[mathescape=true]!v[$k$]!, \lstinline[mathescape=true]!z[$i$, $j$, $p$]!.
+Array slicing given the declarations \lstinline!x[$n$, $m$]!, \lstinline!v[$k$]!, \lstinline!z[$i$, $j$, $p$]!.
 \begin{longtable}[]{|l|l|l|}
 \caption{Examples of scalars vs.\ array slices created with the colon index.}\\
 \hline
 \tablehead{Expression} & \tablehead{\# dims} & \tablehead{Type of value}\\ \hline
 \endhead
-\lstinline[mathescape=true]!x[1, 1]!                     & $0$ & Scalar\\ \hline
-\lstinline[mathescape=true]!x[:, 1]!                     & $1$ & $n$-Vector\\ \hline
-\lstinline[mathescape=true]!x[1, :]! or \lstinline!x[1]! & $1$ & $m$-Vector\\ \hline
-\lstinline[mathescape=true]!v[1:$p$]!                    & $1$ & $p$-Vector\\ \hline
-\lstinline[mathescape=true]!x[1:$p$, :]!                 & $2$ & $(p \times m)$-Matrix\\ \hline
-\lstinline[mathescape=true]!x[1:1, :]!                   & $2$ & $1 \times m$ ``row'' matrix\\ \hline
-\lstinline[mathescape=true]!x[{1, 3, 5}, :]!             & $2$ & $(3 \times m)$-Matrix\\ \hline
-\lstinline[mathescape=true]!x[:, v]!                     & $2$ & $(n \times k)$-Matrix\\ \hline
-\lstinline[mathescape=true]!z[:, 3, :]!                  & $2$ & $(i \times p)$-Matrix\\ \hline
-\lstinline[mathescape=true]!x[scalar([1]), :]!           & $1$ & $m$-Vector\\ \hline
-\lstinline[mathescape=true]!x[vector([1]), :]!           & $2$ & $1 \times m$ ``row'' matrix\\ \hline
+\lstinline!x[1, 1]!                     & $0$ & Scalar\\ \hline
+\lstinline!x[:, 1]!                     & $1$ & $n$-Vector\\ \hline
+\lstinline!x[1, :]! or \lstinline!x[1]! & $1$ & $m$-Vector\\ \hline
+\lstinline!v[1:$p$]!                    & $1$ & $p$-Vector\\ \hline
+\lstinline!x[1:$p$, :]!                 & $2$ & $(p \times m)$-Matrix\\ \hline
+\lstinline!x[1:1, :]!                   & $2$ & $1 \times m$ ``row'' matrix\\ \hline
+\lstinline!x[{1, 3, 5}, :]!             & $2$ & $(3 \times m)$-Matrix\\ \hline
+\lstinline!x[:, v]!                     & $2$ & $(n \times k)$-Matrix\\ \hline
+\lstinline!z[:, 3, :]!                  & $2$ & $(i \times p)$-Matrix\\ \hline
+\lstinline!x[scalar([1]), :]!           & $1$ & $m$-Vector\\ \hline
+\lstinline!x[vector([1]), :]!           & $2$ & $1 \times m$ ``row'' matrix\\ \hline
 \end{longtable}
 \end{example}
 
@@ -842,7 +842,7 @@ algorithm
 \subsection{Indexing with end}\doublelabel{indexing-with-end}
 
 The expression \lstinline!end! may only appear inside array subscripts, and if used in the $i$:th subscript of an array expression \lstinline!A! it is equivalent
-to \lstinline[mathescape=true]!size(A, $i$)! provided indices to \lstinline!A! are a subtype of \lstinline!Integer!.  If used inside nested array subscripts it refers
+to \lstinline!size(A, $i$)! provided indices to \lstinline!A! are a subtype of \lstinline!Integer!.  If used inside nested array subscripts it refers
 to the most closely nested array.
 
 \begin{example}
@@ -1095,19 +1095,19 @@ The following holds for slice operations:
 \begin{itemize}
 \item
   If \lstinline!a! is an array containing scalar components and \lstinline!m! is a component of those components, the expression \lstinline!a.m! is interpreted as a
-  slice operation.  It returns the array of components \lstinline[mathescape=true]!{a[1].m, $\ldots$}!.
+  slice operation.  It returns the array of components \lstinline!{a[1].m, $\ldots$}!.
 \item
   If \lstinline!m! is also an array component, the slice operation is valid only if \lstinline!size(a[1].m)! = \lstinline!size(a[2].m)! = \ldots
 \item
-  The slicing operation can be combined with indexing, e.g.\ \lstinline!a.m[1]!.  It returns the array of components \lstinline[mathescape=true]!{a[1].m[1], a[2].m[1], $\ldots$}!,
+  The slicing operation can be combined with indexing, e.g.\ \lstinline!a.m[1]!.  It returns the array of components \lstinline!{a[1].m[1], a[2].m[1], $\ldots$}!,
   and does not require that \lstinline!size(a[1].m) = size(a[2].m)!.  The number of subscripts on \lstinline!m! must not be greater than the number of array dimension
   for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if
-  \lstinline[mathescape=true]!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
+  \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
 \end{itemize}
 
 \begin{example}
 The size-restriction on the operand is only applicable if the indexing on the second operand uses vectors or colon as in the example:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
   constant Integer m=3;
   Modelica.Blocks.Continuous.LowpassButterworth tf[m](n=2:(m+1));
   Real y[m];

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -864,11 +864,11 @@ and in addition may only be placed directly in an operator
 record.
 \begin{nonnormative}
 A function declaration
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 operator function foo $\ldots$ end foo;
 \end{lstlisting}
 is conceptually treated as
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 operator foo function foo1
   $\ldots$
 end foo1; end foo;
@@ -885,7 +885,7 @@ elements of that component (possibly in combination with array indexing).
 
 \begin{example}
 Use of \lstinline!operator!:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 operator record Complex
   Real re;
   Real im;

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -9,7 +9,7 @@ The special functions \lstinline!cardinality!, \lstinline!rooted! (deprecated),
 
 Connections between objects are introduced by connect-equations in the
 equation part of a class. A connect-equation has the following syntax:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 connect(component-reference, component-reference);
 \end{lstlisting}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -754,7 +754,7 @@ all equations and algorithms that are utilized in the intended operation
 (such as simulation or linearization).  The equations of a
 when-clause are active during initialization, if and only if they are
 explicitly enabled with \lstinline!initial()!; and only in one of the
-two forms \lstinline!when initial() then! or \lstinline[mathescape=true]!when {$\ldots$, initial(), $\ldots$} then!
+two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!
 (and similarly for algorithms see below). In this case, the when-clause equations remain active during the
 whole initialization phase. In case of a
 \lstinline!reinit(x, expr)! being active during initialization (due to being inside
@@ -769,7 +769,7 @@ but not in one of the specific forms, the when-clause is not active during initi
 
 The algorithmic statements within a when-statement are active during initialization, if and only they are
 explicitly enabled with \lstinline!initial()!; and only in one of the
-two forms \lstinline!when initial() then! or \lstinline[mathescape=true]!when {$\ldots$, initial(), $\ldots$} then!.
+two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the when-statement remain active during the whole initialization phase.
 
 \begin{nonnormative}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -16,7 +16,7 @@ definitions, but using the keyword \lstinline!function! instead of \lstinline!cl
 \begin{nonnormative}
 The structure of a typical function declaration is sketched by
 the following schematic function example:
-\begin{lstlisting}[language=modelica,mathescape=true,escapechar=!]
+\begin{lstlisting}[language=modelica,escapechar=!]
 function  !\emph{functionname}!
   input  TypeI1 in1;
   input  TypeI2 in2;
@@ -318,7 +318,7 @@ from within:
 \item
   a when-statement,
 \item
-  \lstinline[mathescape=true]!pure(impureFunctionCall($\ldots$))! --- which allows calling impure
+  \lstinline!pure(impureFunctionCall($\ldots$))! --- which allows calling impure
   functions in any pure context,
 \item
   in initial equations and initial algorithms,
@@ -684,7 +684,7 @@ side of an equation or assignment. In this case, the left hand side of
 the equation or assignment shall contain a list of component references
 within parentheses:
 
-\lstinline[mathescape=true]!(out1, out2, out3) = f($\ldots$);!
+\lstinline!(out1, out2, out3) = f($\ldots$);!
 
 The component references are associated with the output components
 according to their position in the list. Thus output component i is set
@@ -889,7 +889,7 @@ the type of the corresponding formal parameter of the function.
   If the argument is not a foreach argument, it is used as-is.
 \item
   If the argument is a foreach argument, the element at index
-  \lstinline[mathescape=true]![i, $\ldots$, j]! is used.
+  \lstinline![i, $\ldots$, j]! is used.
 \end{itemize}
 \end{enumerate}
 
@@ -1596,7 +1596,7 @@ end specificEnthalpy;
 
 Every function with one output formal parameter may have one or more
 \lstinline!inverse! annotations to define inverses of this function:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 function $f_1$
   input $A_1$ $u_1$;
   ...
@@ -1619,8 +1619,8 @@ than one inverse can be defined within the same inverse annotation.
 Several inverses are separated by commas.
 
 \begin{nonnormative}
-The inverse requires that for all valid values of the input arguments of \lstinline[mathescape=true]!$f_2$(..., y, ...)! and $u_k$ being calculated as \lstinline[mathescape=true]!$u_k$ := $f_2$(..., y, ...)! implies
-the equality \lstinline[mathescape=true]!y = $f_1$(..., $u_k$, ...,)! up to a certain precision.
+The inverse requires that for all valid values of the input arguments of \lstinline!$f_2$(..., y, ...)! and $u_k$ being calculated as \lstinline!$u_k$ := $f_2$(..., y, ...)! implies
+the equality \lstinline!y = $f_1$(..., $u_k$, ...,)! up to a certain precision.
 \end{nonnormative}
 
 Function $f_1$ can have any number and types of formal
@@ -1884,14 +1884,14 @@ for input arguments.
 \tablehead{Modelica} & \tablehead{C}\\ \hline
 & \tablehead{Input and Output}\\ \hline
 \endhead
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$]! &
-\lstinline[mathescape=true,language=C]!T' *, size_t $\textit{dim}_{1}$!
+\lstinline!T[$\textit{dim}_{1}$]! &
+\lstinline[language=C]!T' *, size_t $\textit{dim}_{1}$!
 \\ \hline
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$, $\textit{dim}_{2}$]! &
-\lstinline[mathescape=true,language=C]!T' *, size_t $\textit{dim}_{1}$, size_t$\textit{dim}_{2}$!
+\lstinline!T[$\textit{dim}_{1}$, $\textit{dim}_{2}$]! &
+\lstinline[language=C]!T' *, size_t $\textit{dim}_{1}$, size_t$\textit{dim}_{2}$!
 \\ \hline
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$, $\ldots$, $\textit{dim}_{n}$]! &
-\lstinline[mathescape=true,language=C]!T' *, size_t $\textit{dim}_{1}$, $\ldots$, size_t $\textit{dim}_{n}$!
+\lstinline!T[$\textit{dim}_{1}$, $\ldots$, $\textit{dim}_{n}$]! &
+\lstinline[language=C]!T' *, size_t $\textit{dim}_{1}$, $\ldots$, size_t $\textit{dim}_{n}$!
 \\ \hline
 \end{longtable}
 
@@ -1908,14 +1908,14 @@ section.
 \tablehead{Modelica} & \tablehead{FORTRAN~77}\\ \hline
 & \tablehead{Input and Output}\\ \hline
 \endhead
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$]! &
-\lstinline[mathescape=true,language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$!
+\lstinline!T[$\textit{dim}_{1}$]! &
+\lstinline[language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$!
 \\ \hline
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$, $\textit{dim}_{2}$]! &
-\lstinline[mathescape=true,language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$, INTEGER $\textit{dim}_{2}$!
+\lstinline!T[$\textit{dim}_{1}$, $\textit{dim}_{2}$]! &
+\lstinline[language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$, INTEGER $\textit{dim}_{2}$!
 \\ \hline
-\lstinline[mathescape=true]!T[$\textit{dim}_{1}$, $\ldots$, $\textit{dim}_{n}$]! &
-\lstinline[mathescape=true,language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$, $\ldots$, INTEGER $\textit{dim}_{n}$!
+\lstinline!T[$\textit{dim}_{1}$, $\ldots$, $\textit{dim}_{n}$]! &
+\lstinline[language=FORTRAN77]!T', INTEGER $\textit{dim}_{1}$, $\ldots$, INTEGER $\textit{dim}_{n}$!
 \\ \hline
 \end{longtable}
 
@@ -2068,7 +2068,7 @@ Return types are by default mapped as follows for C and FORTRAN~77:
 \lstinline!Integer! & \lstinline!int! & \lstinline!INTEGER!\\ \hline
 \lstinline!Boolean! & \lstinline!int! & \lstinline!LOGICAL!\\ \hline
 \lstinline!String! & \lstinline!const char*! & Not allowed.\\ \hline
-\lstinline[mathescape=true]!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! & Not allowed. & Not allowed.\\ \hline
+\lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! & Not allowed. & Not allowed.\\ \hline
 Enumeration type & \lstinline!int! & \lstinline!INTEGER!\\ \hline
 Record & See \autoref{records}. & Not allowed.\\ \hline
 \end{longtable}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -685,12 +685,12 @@ M m(redeclare Modelica.Units.SI.Length x[2,4]); // Valid redeclare of the type
 
 \subsection{The class extends Redeclaration Mechanism}\doublelabel{the-class-extends-redeclaration-mechanism}
 
-A class declaration of the type \lstinline[mathescape=true]!redeclare class extends B($\ldots$)! ,
+A class declaration of the type \lstinline!redeclare class extends B($\ldots$)! ,
 where \lstinline!class! as usual can be replaced by any other specialized class,
 replaces the inherited class \lstinline!B! with another declaration that extends the
 inherited class where the optional class-modification is applied to the
 inherited class.  Inherited \lstinline!B! here means that the class
-containing \lstinline[mathescape=true]!redeclare class extends B($\ldots$)! should also inherit
+containing \lstinline!redeclare class extends B($\ldots$)! should also inherit
 another declaration of \lstinline!B! from one of its extends-clauses. The new
 declaration should explicitly include redeclare.
 
@@ -699,7 +699,7 @@ Since the rule about applying the optional class-modification implies that all d
 to apply modifiers to the new declaration.
 \end{nonnormative}
 
-For \lstinline[mathescape=true]!redeclare class extends B($\ldots$)! the inherited class is subject
+For \lstinline!redeclare class extends B($\ldots$)! the inherited class is subject
 to the same restrictions as a redeclare of the inherited element, and
 the original class \lstinline!B! should be replaceable, and the new element is only
 replaceable if the new definition is replaceable. In contrast to normal

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -87,7 +87,7 @@ variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica
 A full BNF definition of the Modelica syntax and
 lexical units is available in \autoref{modelica-concrete-syntax}.
 
-\begin{lstlisting}[language=grammar]
+\begin{lstlisting}[language=grammar,mathescape=false]
 IDENT   = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" { Q-CHAR | S-ESCAPE | """ } "'"
 NONDIGIT = "_" | letters "a" ... "z" | letters "A" ... "Z"

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -55,11 +55,11 @@ the table:
 \tablehead{Operator Group} & \tablehead{Operator Syntax} & \tablehead{Examples}\\ \hline
 postfix array index operator & \lstinline![]! & \lstinline!arr[index]! \\ \hline
 postfix access operator & \lstinline!.! & \lstinline!a.b! \\ \hline
-postfix function call & \lstinline[mathescape=true]!$\mathit{funcName}$($\mathit{functionArguments}$)! & \lstinline!sin(4.36)! \\ \hline
+postfix function call & \lstinline!$\mathit{funcName}$($\mathit{functionArguments}$)! & \lstinline!sin(4.36)! \\ \hline
 array construct/concat & \begin{tabular}{@{}p{5cm}@{}}
-\lstinline[mathescape=true]!{$\mathit{expressions}$}!\\
-\lstinline[mathescape=true]![$\mathit{expressions}$]!\\
-\lstinline[mathescape=true]![$\mathit{expressions}$; $\mathit{expressions}\ldots$]!
+\lstinline!{$\mathit{expressions}$}!\\
+\lstinline![$\mathit{expressions}$]!\\
+\lstinline![$\mathit{expressions}$; $\mathit{expressions}\ldots$]!
 \end{tabular} & \begin{tabular}{@{}p{5cm}@{}}
 \lstinline!{2,3}! \\
 \lstinline![5,6]! \\
@@ -70,21 +70,21 @@ multiplicative and array elementwise multiplicative & \lstinline!* / .* ./! & \b
 \lstinline!2*3!, \lstinline!2/3! \\
 \lstinline![1,2;3,4].*[2,3;5,6]!
 \end{tabular} \\ \hline
-additive and array elementwise additive & \lstinline[mathescape=true]!+ - +$\mathit{expr}$ -$\mathit{expr}$ .+ .-! & \lstinline![1,2;3,4].+[2,3;5,6]!\\ \hline
+additive and array elementwise additive & \lstinline!+ - +$\mathit{expr}$ -$\mathit{expr}$ .+ .-! & \lstinline![1,2;3,4].+[2,3;5,6]!\\ \hline
 relational & \lstinline!< <= > >= == <>! &
 \lstinline!a<b!, \lstinline!a<=b!, \lstinline!a>b!, \ldots\\ \hline
-unary negation & \lstinline[mathescape=true]!not $\mathit{expr}$! & \lstinline!not b1! \\ \hline
+unary negation & \lstinline!not $\mathit{expr}$! & \lstinline!not b1! \\ \hline
 logical and & \lstinline!and! & \lstinline!b1 and b2! \\ \hline
 logical or & \lstinline!or! & \lstinline!b1 or b2!\\ \hline
 array range & \begin{tabular}{@{}p{5cm}@{}}
-\lstinline[mathescape=true]!$\mathit{expr}$ : $\mathit{expr}$! \\
-\lstinline[mathescape=true]!$\mathit{expr}$ : $\mathit{expr}$ : $\mathit{expr}$!
+\lstinline!$\mathit{expr}$ : $\mathit{expr}$! \\
+\lstinline!$\mathit{expr}$ : $\mathit{expr}$ : $\mathit{expr}$!
 \end{tabular} & \begin{tabular}{@{}p{5cm}@{}}
 \lstinline!1:5! \\
 \lstinline!start:step:stop!
 \end{tabular} \\ \hline
-conditional & \lstinline[mathescape=true]!if $\mathit{expr}$ then $\mathit{expr}$ else $\mathit{expr}$! & \lstinline!if b then 3 else x!\\ \hline
-named argument & \lstinline[mathescape=true]!$\mathit{ident}$ = $\mathit{expr}$! & \lstinline!x = 2.26!\\ \hline
+conditional & \lstinline!if $\mathit{expr}$ then $\mathit{expr}$ else $\mathit{expr}$! & \lstinline!if b then 3 else x!\\ \hline
+named argument & \lstinline!$\mathit{ident}$ = $\mathit{expr}$! & \lstinline!x = 2.26!\\ \hline
 \end{tabular}
 \end{table}
 
@@ -270,11 +270,11 @@ operator in Modelica.
 
 \subsection{Array Constructor Operator}\doublelabel{array-constructor-operator}
 
-The array constructor operator \lstinline[mathescape=true]!{ $\ldots$ }! is described in \autoref{vector-matrix-and-array-constructors}.
+The array constructor operator \lstinline!{ $\ldots$ }! is described in \autoref{vector-matrix-and-array-constructors}.
 
 \subsection{Array Concatenation Operator}\doublelabel{array-concatenation-operator}
 
-The array concatenation operator \lstinline[mathescape=true]![ $\ldots$ ]! is described in \autoref{array-concatenation}.
+The array concatenation operator \lstinline![ $\ldots$ ]! is described in \autoref{array-concatenation}.
 
 \subsection{Array Range Operator}\doublelabel{array-range-operator}
 
@@ -891,7 +891,7 @@ It is recommended to perform (conceptually) one homotopy iteration
 over the whole model, and not several homotopy iterations over the
 respective non-linear algebraic equation systems. The reason is that the
 following structure can be present:
-\begin{lstlisting}[language=modelica, mathescape=true]
+\begin{lstlisting}[language=modelica]
 w = $f_1$(x) // has homotopy
 0 = $f_2$(der(x), x, z, w)
 \end{lstlisting}
@@ -1024,7 +1024,7 @@ y = semiLinear(x, sN, sb);
 ...
 \end{lstlisting}
 may be replaced by
-\begin{lstlisting}[language=modelica, mathescape=true]
+\begin{lstlisting}[language=modelica]
 s1 = if x >= 0 then sa else sb
 s2 = s1;
 s3 = s2;

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -69,7 +69,7 @@ All functions defined inside the \lstinline!operator! class must return one
 output (based on the restriction above), and may include functions with
 optional arguments, i.e.\ functions of the form
 
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 function f
   input $A_1$ $u_1$;
   ...
@@ -180,7 +180,7 @@ matrix-multiplication.
 
 \section{Overloaded String Conversions}\doublelabel{overloaded-string-conversions}
 
-Consider an expression \lstinline[mathescape=true]!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!,
+Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!,
 $k \ge 1$ where $A_1$ is an element of class \lstinline!A!.
 
 \begin{enumerate}
@@ -191,11 +191,11 @@ $k \ge 1$ where $A_1$ is an element of class \lstinline!A!.
 \item
   If \lstinline!A! is an operator record class and there exists a unique function
   $f$ in \lstinline!A.'String'! such that
-  \lstinline[mathescape=true]!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
+  \lstinline!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
   is a valid match for $f$, then
-  \lstinline[mathescape=true]!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
+  \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
   is evaluated to\\
-  \lstinline[mathescape=true]!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!.
+  \lstinline!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!.
 \item
   Otherwise the expression is erroneous.
 \end{enumerate}
@@ -222,7 +222,7 @@ Restrictions:
 \newcommand{\theop}{X}
 
 Let $\theop$ denote a binary operator and consider an expression
-\lstinline[mathescape=true]!a $\theop$ b! where \lstinline!a! is an instance or array of instances of
+\lstinline!a $\theop$ b! where \lstinline!a! is an instance or array of instances of
 class \lstinline!A! and \lstinline!b! is an instance or array of instances of
 class \lstinline!B!.
 
@@ -232,27 +232,27 @@ class \lstinline!B!.
   corresponding built-in operation is performed.
 \item
   Otherwise, if there exists \emph{exactly one} function $f$ in the
-  union of \lstinline[mathescape=true]!A.$\theop$! and \lstinline[mathescape=true]!B.$\theop$! such that
-  \lstinline[mathescape=true]!$f$(a, b)! is a valid match for the function $f$, then
-  \lstinline[mathescape=true]!a $\theop$ b! is evaluated using this function. It is an error, if
-  multiple functions match. If \lstinline!A! is not an operator record class, \lstinline[mathescape=true]!A.$\theop$!
+  union of \lstinline!A.$\theop$! and \lstinline!B.$\theop$! such that
+  \lstinline!$f$(a, b)! is a valid match for the function $f$, then
+  \lstinline!a $\theop$ b! is evaluated using this function. It is an error, if
+  multiple functions match. If \lstinline!A! is not an operator record class, \lstinline!A.$\theop$!
   is seen as the empty set, and similarly for \lstinline!B!.
   \begin{nonnormative}
   Having a union of the operators ensures that if \lstinline!A! and \lstinline!B! are the same, each function only appears once.
   \end{nonnormative}
 \item
-  Otherwise, consider the set given by $f$ in \lstinline[mathescape=true]!A.$\theop$!
+  Otherwise, consider the set given by $f$ in \lstinline!A.$\theop$!
   and an operator record class \lstinline!C! (different from \lstinline!B!) with a
-  constructor, $g$, such that \lstinline[mathescape=true]!C.'constructor'.$g$(b)! is a valid match, and
-  \lstinline[mathescape=true]!f(a, C.'constructor'.$g$(b))! is a valid match; and another set given by
-  $f$ in \lstinline[mathescape=true]!B.$\theop$! and an operator record class \lstinline!D!
+  constructor, $g$, such that \lstinline!C.'constructor'.$g$(b)! is a valid match, and
+  \lstinline!f(a, C.'constructor'.$g$(b))! is a valid match; and another set given by
+  $f$ in \lstinline!B.$\theop$! and an operator record class \lstinline!D!
   (different from \lstinline!A!) with a constructor, $h$, such that
-  \lstinline[mathescape=true]!D.'constructor'.$h$(a)! is a valid match and \lstinline[mathescape=true]!$f$(D.'constructor'.$h$(a), b)!
+  \lstinline!D.'constructor'.$h$(a)! is a valid match and \lstinline!$f$(D.'constructor'.$h$(a), b)!
   is a valid match. If the sum of the sizes of these sets is one this
   gives the unique match. If the sum of the sizes is larger than one it
   is an error.
 \begin{nonnormative}
-  Informally, this means: If there is no direct match of \lstinline[mathescape=true]!a $\theop$ b!, then it is tried to find a direct match by automatic type casts
+  Informally, this means: If there is no direct match of \lstinline!a $\theop$ b!, then it is tried to find a direct match by automatic type casts
   of \lstinline!a! or \lstinline!b!, by converting either \lstinline!a! or \lstinline!b! to the needed
   type using an appropriate constructor function from one of the
   operator record classes used as arguments of the overloaded \lstinline!op!
@@ -315,8 +315,8 @@ Restrictions:
 \section{Overloaded Unary Operations}\doublelabel{overloaded-unary-operations}
 
 Let $\theop$ denote a unary operator and consider an expression
-\lstinline[mathescape=true]!$\theop$ a! where \lstinline!a! is an instance or array of instances of class
-\lstinline!A!. Then \lstinline[mathescape=true]!$\theop$ a! is evaluated in the following way.
+\lstinline!$\theop$ a! where \lstinline!a! is an instance or array of instances of class
+\lstinline!A!. Then \lstinline!$\theop$ a! is evaluated in the following way.
 
 \begin{enumerate}
 \item
@@ -324,8 +324,8 @@ Let $\theop$ denote a unary operator and consider an expression
   operation is performed.
 \item
   If \lstinline!A! is an operator record class and there exists a unique
-  function $f$ in \lstinline[mathescape=true]!A.$\theop$! such that \lstinline[mathescape=true]!A.$\theop$.$f$(a)! is a valid
-  match, then \lstinline[mathescape=true]!$\theop$ a! is evaluated to \lstinline[mathescape=true]!A.$\theop$.$f$(a)!. It is an
+  function $f$ in \lstinline!A.$\theop$! such that \lstinline!A.$\theop$.$f$(a)! is a valid
+  match, then \lstinline!$\theop$ a! is evaluated to \lstinline!A.$\theop$.$f$(a)!. It is an
   error, if there are multiple valid matches.
 \item
   Otherwise, if \lstinline!a! is an array expression, then the expression
@@ -538,7 +538,7 @@ variants inheriting from the same operator record, but with possibly
 different operations; thus ComplexVoltage and ComplexCurrent still use
 the operations from Complex. The restriction that it is not legal to
 extend from any of its enclosing scopes implies that:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 package A
   extends Icon; // Ok
   operator record B $\ldots$ end B;

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -63,22 +63,22 @@ Import-clauses in a package or class fill the following two needs:
 %TODO-FORMAT Should be formatted using tabs or tabular?
 An \lstinline!import!-clause can occur in one of the following syntactic forms:
 
-% Note a syntactic form cannot be written as a single \lstinline[mathescape=true] due to LaTeXML problem reported here:
+% Note a syntactic form cannot be written as a single \lstinline due to LaTeXML problem reported here:
 %   https://github.com/brucemiller/LaTeXML/issues/1274 (marked as fixed as of commit 80d7940)
 % Instead, we need to break up the \lstinline at each piece of math (taking the opportunity to leave the whitespace
 % outside both \lstinline and math).
 
-\lstinline[mathescape=true]!import $\mathit{definitionname}$;! (qualified import of top-level definition)
+\lstinline!import $\mathit{definitionname}$;! (qualified import of top-level definition)
 
-\lstinline[mathescape=true]!import $\mathit{packagename}$.$\mathit{definitionname}$;! (qualified import)
+\lstinline!import $\mathit{packagename}$.$\mathit{definitionname}$;! (qualified import)
 
-\lstinline[mathescape=true]!import $\mathit{packagename}$.{$\mathit{def}_{1}$, $\mathit{def}_{2}$, $\ldots$, $\mathit{def}_{n}$};! (multiple definition import)
+\lstinline!import $\mathit{packagename}$.{$\mathit{def}_{1}$, $\mathit{def}_{2}$, $\ldots$, $\mathit{def}_{n}$};! (multiple definition import)
 
-\lstinline[mathescape=true]!import $\mathit{packagename}$.*;! (unqualified import)
+\lstinline!import $\mathit{packagename}$.*;! (unqualified import)
 
-\lstinline[mathescape=true]!import $\mathit{shortname}$ = $\mathit{definitionname}$;! (renaming import of top-level definition)
+\lstinline!import $\mathit{shortname}$ = $\mathit{definitionname}$;! (renaming import of top-level definition)
 
-\lstinline[mathescape=true]!import $\mathit{shortname}$ = $\mathit{packagename}$.$\mathit{definitionname}$;! (renaming import)
+\lstinline!import $\mathit{shortname}$ = $\mathit{packagename}$.$\mathit{definitionname}$;! (renaming import)
 
 Here $\mathit{packagename}$ is the fully qualified name of the imported package including possible dot notation and $\mathit{definitionname}$ is the name of an element in a package.  The multiple definition import is equivalent
 to multiple single definition imports with corresponding $\mathit{packagename}$ and definition names.
@@ -271,7 +271,7 @@ recommended since multiple packages will share resources.
 
 In case the class-name contains quoted identifiers, the single-quote `\lstinline!`!'
 and any reserved characters (`\lstinline!:!', `\lstinline!/!', `\lstinline!?!', `\lstinline!\#!', `\lstinline![!',
-`\lstinline!]!', `\lstinline!@!', `\lstinline!!!', `\lstinline!\$!', `\lstinline!\&!', `\lstinline!(!', `\lstinline!)!', `\lstinline!*!', `\lstinline!+!',
+`\lstinline!]!', `\lstinline!@!', `\lstinline!!!', `\lstinline[mathescape=false]!\$!', `\lstinline!\&!', `\lstinline!(!', `\lstinline!)!', `\lstinline!*!', `\lstinline!+!',
 `\lstinline!,!', `\lstinline!;!', `\lstinline!=!') should be percent-encoded as normal in URIs.
 
 \begin{example}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -65,12 +65,13 @@ An \lstinline!import!-clause can occur in one of the following syntactic forms:
 
 % Note a syntactic form cannot be written as a single \lstinline due to LaTeXML problem reported here:
 %   https://github.com/brucemiller/LaTeXML/issues/1274 (marked as fixed as of commit 80d7940)
-% Instead, we need to break up the \lstinline at each piece of math (taking the opportunity to leave the whitespace
-% outside both \lstinline and math).
+% Instead, we need to break up the \lstinline in mysterious ways.  Be sure to check that the generated HTML
+% looks OK when making changes!
 
 \lstinline!import $\mathit{definitionname}$;! (qualified import of top-level definition)
 
-\lstinline!import $\mathit{packagename}$.$\mathit{definitionname}$;! (qualified import)
+\lstinline!import $\mathit{packagename}$.!% Break up \lstinline as workaround for LaTeXML issue described above.
+\lstinline!$\mathit{definitionname}$;! (qualified import)
 
 \lstinline!import $\mathit{packagename}$.{$\mathit{def}_{1}$, $\mathit{def}_{2}$, $\ldots$, $\mathit{def}_{n}$};! (multiple definition import)
 
@@ -78,7 +79,8 @@ An \lstinline!import!-clause can occur in one of the following syntactic forms:
 
 \lstinline!import $\mathit{shortname}$ = $\mathit{definitionname}$;! (renaming import of top-level definition)
 
-\lstinline!import $\mathit{shortname}$ = $\mathit{packagename}$.$\mathit{definitionname}$;! (renaming import)
+\lstinline!import $\mathit{shortname}$ = $\mathit{packagename}$.!% Break up \lstinline as workaround for LaTeXML issue described above.
+\lstinline!$\mathit{definitionname}$;! (renaming import)
 
 Here $\mathit{packagename}$ is the fully qualified name of the imported package including possible dot notation and $\mathit{definitionname}$ is the name of an element in a package.  The multiple definition import is equivalent
 to multiple single definition imports with corresponding $\mathit{packagename}$ and definition names.

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1909,7 +1909,7 @@ The following errors have been fixed in the Modelica specification:
 \item
   Syntax rule for a function call (e.g., according to the grammar in
   Modelica 2.2 a function call of the form
-  \lstinline[mathescape=true]!Modelica.Math.Matrices.eig($\ldots$)! was invalid because the function name
+  \lstinline!Modelica.Math.Matrices.eig($\ldots$)! was invalid because the function name
   could not have `\lstinline!.!'. However, all Modelica tools supported the
   desired ``full Modelica name'' also for function calls).
 \end{itemize}

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -158,8 +158,8 @@ lines.
 \end{nonnormative}
 
 The annotation for graphics of \lstinline!transition! has the following
-structure: \lstinline[mathescape=true]!annotation(Line($\ldots$), Text($\ldots$))!; and for
-\lstinline!initialState()!: \emph{graphical-primitives}\lstinline[mathescape=true]!(Line($\ldots$))!; with \lstinline!Line!
+structure: \lstinline!annotation(Line($\ldots$), Text($\ldots$))!; and for
+\lstinline!initialState()!: \emph{graphical-primitives}\lstinline!(Line($\ldots$))!; with \lstinline!Line!
 and \lstinline!Text! annotations defined in \autoref{annotations}.
 
 \begin{example}

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -93,13 +93,13 @@ from the stream connection equations of the flow variables and of the
 stream variables.
 
 For the following definition it is assumed that $N$ inside connectors
-\lstinline[mathescape=true]!$m_{j}$.c! ($j = 1, 2, \ldots, N$) and $M$ outside connectors
-\lstinline[mathescape=true]!$c{k}$! ($k = 1, 2, \ldots, M$) belonging to the same connection set
+\lstinline!$m_{j}$.c! ($j = 1, 2, \ldots, N$) and $M$ outside connectors
+\lstinline!$c{k}$! ($k = 1, 2, \ldots, M$) belonging to the same connection set
 (see definition in \autoref{inside-and-outside-connectors}) are connected
 together and a stream variable \lstinline!h_outflow! is associated with a flow
 variable \lstinline!m_flow! in connector \lstinline!c!.
 
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 connector FluidPort
   ...
   flow Real m_flow "Flow of matter; m_flow > 0 if flow into component";
@@ -136,7 +136,7 @@ conservation equations for mass and energy.
 \end{nonnormative}
 
 With these prerequisites, the semantics of the expression
-\lstinline[mathescape=true]!inStream($m_{i}$.c.h_outflow)! is given implicitly by
+\lstinline!inStream($m_{i}$.c.h_outflow)! is given implicitly by
 defining an additional variable $\mathit{h\_mix\_in}_{i}$, and by
 adding to the model the conservation equations for mass and energy
 corresponding to the infinitesimally small volume spanning the
@@ -144,7 +144,7 @@ connection set. The connection equation for the flow variables has
 already been added to the system according to the connection semantics
 of flow variables defined in \autoref{generation-of-connection-equations}.
 
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 // Standard connection equation for flow variables
 0 = sum($m_{j}$.c.m_flow for j in 1:N) + sum(-$c_{k}$.m_flow for k in 1:M);
 \end{lstlisting}
@@ -152,7 +152,7 @@ of flow variables defined in \autoref{generation-of-connection-equations}.
 Whenever \lstinline!inStream! is applied to a stream variable of an inside connector, the balance equation of the transported
 property must be added under the assumption of flow going into the connector
 
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 // Implicit definition of inStream applied to inside connector $i$
 0 =
   sum($m_{j}$.c.m_flow *
@@ -165,14 +165,14 @@ inStream($m_{i}$.c.h_outflow) = $\mathit{h\_mix\_in}_{i}$;
 \end{lstlisting}
 
 Note that the result of
-\lstinline[mathescape=true]!inStream($m_{i}$.c.h_outflow)! is different
+\lstinline!inStream($m_{i}$.c.h_outflow)! is different
 for each port $i$, because the assumption of flow entering the port is
 different for each of them.
 
 Additional equations need to be generated for the stream variables of
 outside connectors.
 
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 // Additional connection equations for outside connectors
 for q in 1:M loop
   0 =
@@ -190,7 +190,7 @@ Neglecting zero flow conditions, the solution of the above-defined
 stream connection equations for \lstinline!inStream! values of inside connectors and
 outflow stream variables of outside connectors is (for a derivation, see
 \autoref{derivation-of-stream-equations}):
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 inStream($m_i$.c.h_outflow) :=
   (sum(max(-$m_j$.c.m_flow,0)*$m_j$.c.h_outflow for j in cat(1, 1:i-1, i+1:N) +
    sum(max( $c_k$.m_flow,0)*inStream($c_k$.h_outflow) for k in 1:M))
@@ -210,8 +210,8 @@ end for;
 \end{lstlisting}
 
 \begin{nonnormative}
-Note, that \lstinline[mathescape=true]!inStream($c_{k}$.h_outflow)! is computed from the connection set that is present one hierarchical level above.  At this higher level
-\lstinline[mathescape=true]!$c_{k}$.h_outflow! is no longer an outside connector, but an inside connector and then the formula from above for inside connectors can be used
+Note, that \lstinline!inStream($c_{k}$.h_outflow)! is computed from the connection set that is present one hierarchical level above.  At this higher level
+\lstinline!$c_{k}$.h_outflow! is no longer an outside connector, but an inside connector and then the formula from above for inside connectors can be used
 to compute it.
 \end{nonnormative}
 
@@ -225,15 +225,15 @@ flows are zero, a singularity is always present, so it is necessary to
 approximate the solution in an open neighbourhood of that point.
 
 \begin{nonnormative}
-For example, assume that \lstinline[mathescape=true]!$m_{j}$.c.m_flow = $c_{k}$.m_flow = 0!, then all equations above are identically fulfilled and \lstinline!inStream! can have any value.
+For example, assume that \lstinline!$m_{j}$.c.m_flow = $c_{k}$.m_flow = 0!, then all equations above are identically fulfilled and \lstinline!inStream! can have any value.
 \end{nonnormative}
 
 However, specific optimizations may be applied to avoid the regularization if the flow through one port is zero or non-negative, see \autoref{derivation-of-stream-equations}.
 It is required that \lstinline!inStream! is appropriately approximated when regularization is needed and the approximation must fulfill the following requirements:
 \begin{enumerate}
 \item
-  \lstinline[mathescape=true]!inStream($m_{i}$.c.h_outflow)! and
-  \lstinline[mathescape=true]!inStream($c_{k}$.h_outflow)! must be unique with
+  \lstinline!inStream($m_{i}$.c.h_outflow)! and
+  \lstinline!inStream($c_{k}$.h_outflow)! must be unique with
   respect to all values of the flow and stream variables in the
   connection set, and must have a continuous dependency on them.
 \item
@@ -249,28 +249,28 @@ It is required that \lstinline!inStream! is appropriately approximated when regu
 Based on the above requirements, the following implementation is recommended:
 \begin{itemize}
 \item $N = 1,\, M = 0$:\hfill
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 inStream($m_1$.c.h_outflow) = $m_1$.c.h_outflow;
 \end{lstlisting}
 \item $N = 2,\, M = 0$:\hfill
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 inStream($m_1$.c.h_outflow) = $m_2$.c.h_outflow;
 inStream($m_2$.c.h_outflow) = $m_1$.c.h_outflow;
 \end{lstlisting}
 \item $N = 1,\, M = 1$:\hfill
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 inStream($m_1$.c.h_outflow) = inStream($c_1$.h_outflow);
 // Additional equation to be generated
 $c_1$.h_outflow = $m_1$.c.h_outflow;
 \end{lstlisting}
 \item $N = 0,\, M = 2$:\hfill
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 // Additional equation to be generated
 $c_{1}$.h_outflow = inStream($c_{2}$.h_outflow);
 $c_{2}$.h_outflow = inStream($c_{1}$.h_outflow);
 \end{lstlisting}
 \item All other cases:\hfill
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 if $m_j$.c.m_flow.min >= 0  for all j = 1:N with j <> i  and
    $c_k$.m_flow.max <= 0 for all k = 1:M
 then
@@ -305,12 +305,12 @@ end for;
 \end{itemize}
 
 The operator
-\lstinline[mathescape=true]!positiveMax(-$m_{j}$.c.m_flow, $s_{i}$)!
+\lstinline!positiveMax(-$m_{j}$.c.m_flow, $s_{i}$)!
 should be such that:
 \begin{itemize}
 \item
-  \lstinline[mathescape=true]!positiveMax(-$m_{j}$.c.m_flow, $s_{i}$)! =
-  \lstinline[mathescape=true]!-$m_{j}$.c.m_flow! if
+  \lstinline!positiveMax(-$m_{j}$.c.m_flow, $s_{i}$)! =
+  \lstinline!-$m_{j}$.c.m_flow! if
   $-m_{j}\text{\lstinline!.c.m_flow!} > \mathit{eps1}_{j} \geq 0$,
   where $\mathit{eps1}_{j}$ are small flows, compared to typical
   problem-specific values,
@@ -321,11 +321,11 @@ should be such that:
 \end{itemize}
 
 Trivial implementation of \lstinline!positiveMax! guarantees continuity of \lstinline!inStream!:
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 postiveMax(-$m_j$.c.m_flow, $s_i$) = max(-$m_j$.c.m_flow, $\mathit{eps1}$); // so $s_i$ is not needed
 \end{lstlisting}
 More sophisticated implementation, with smooth approximation, applied only when {all} flows are small:
-\begin{lstlisting}[language=modelica,escapechar=!,mathescape=true]
+\begin{lstlisting}[language=modelica,escapechar=!]
 // Define a "small number" eps (nominal(v) is the nominal value of v - see !\autoref{attributes-start-fixed-nominal-and-unbounded}!)
 eps := relativeTolerance*min(nominal($m_j$.c.m_flow));
 
@@ -350,24 +350,24 @@ The following properties hold for this implementation:
 \begin{itemize}
 \item
   \lstinline!inStream! is continuous (and differentiable),
-  provided that \lstinline[mathescape=true]!$m_{j}$.c.h_outflow!,
-  \lstinline[mathescape=true]!$m_{j}$.c.m_flow!, \lstinline[mathescape=true]!$c_{k}$.h_outflow!, and
-  \lstinline[mathescape=true]!$c_{k}$.m_flow! are continuous and differentiable.
+  provided that \lstinline!$m_{j}$.c.h_outflow!,
+  \lstinline!$m_{j}$.c.m_flow!, \lstinline!$c_{k}$.h_outflow!, and
+  \lstinline!$c_{k}$.m_flow! are continuous and differentiable.
 \end{itemize}
 
 \begin{itemize}
 \item
-  A division by zero can no longer occur (since \lstinline[mathescape=true]!sum(positiveMax(-$m_{j}$.c.m_flow, $s_{i}$))! $\geq \mathit{eps2} > 0$),
+  A division by zero can no longer occur (since \lstinline!sum(positiveMax(-$m_{j}$.c.m_flow, $s_{i}$))! $\geq \mathit{eps2} > 0$),
   so the result is always well-defined.
 \item
   The balance equations are exactly fulfilled if the denominator is not close to zero (since the exact formula is used, if
-  \lstinline[mathescape=true]!sum(positiveMax(-$m_{j}$.c.m_flow, $s_{i}$))! $> \mathit{eps}$).
+  \lstinline!sum(positiveMax(-$m_{j}$.c.m_flow, $s_{i}$))! $> \mathit{eps}$).
 \item
   If all flows are zero,
-  \lstinline[mathescape=true]!inStream($m_{i}$.c.h_outflow)! =
-  \lstinline[mathescape=true]!sum($m_{j}$.c.h_outflow for $j \neq{} i$ and $m_{j}$.c.m_flow.min < 0) / $N_{\mathrm{p}}$!,
+  \lstinline!inStream($m_{i}$.c.h_outflow)! =
+  \lstinline!sum($m_{j}$.c.h_outflow for $j \neq{} i$ and $m_{j}$.c.m_flow.min < 0) / $N_{\mathrm{p}}$!,
   i.e., it is the mean value of all the $N_{\mathrm{p}}$ variables
-  \lstinline[mathescape=true]!$m_{j}$.c.h_outflow!, such that $j \neq i$ and
+  \lstinline!$m_{j}$.c.h_outflow!, such that $j \neq i$ and
   $m_{j}\text{\lstinline!.c.m_flow.min!} < 0$. This is a
   meaningful approximation, considering the physical diffusion effects
   that are relevant at small flow rates in a small connection volume
@@ -408,7 +408,7 @@ actualStream(c.h_outflow) = if c.m_flow > 0 then inStream(c.h_outflow) else c.h_
 In the case of equation (1), although \lstinline!actualStream!
 is discontinuous, the product with the flow variable is not, because
 \lstinline!actualStream! is discontinuous when the flow is zero by construction.
-Therefore, a tool might infer that the expression is \lstinline[mathescape=true]!smooth(0, $\ldots$)!
+Therefore, a tool might infer that the expression is \lstinline!smooth(0, $\ldots$)!
 automatically, and decide whether or not to generate an event. If a user
 wants to avoid events entirely, he/she may enclose the right-hand side
 of (1) with \lstinline!noEvent!.

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -204,22 +204,22 @@ therefore called \firstuse{clocked discrete-time} expressions:
 enumeration, and \lstinline!String! that are \emph{constant} inside each interval
 t\textsubscript{i} $\le$ t \textless{} t\textsubscript{i+1} (= piecewise
 constant continuous-time variables). In other words, \lstinline!m(t)!
-\emph{changes} value \emph{only at events}. This means, \lstinline[mathescape=true]!m($t$)! =
-\lstinline[mathescape=true]!m($t_{i}$)!, for $t_{i} \leq t < t_{i+1}$. Such variables depend continuously on time and
+\emph{changes} value \emph{only at events}. This means, \lstinline!m($t$)! =
+\lstinline!m($t_{i}$)!, for $t_{i} \leq t < t_{i+1}$. Such variables depend continuously on time and
 they are discrete-time variables.
 \end{tabular}\\ \hline
 \begin{tabular}{p{7cm}}
 \includegraphics[width=3in,height=1.875in]{clock}
 \end{tabular}&
 \begin{tabular}{p{7cm}}\firstuse{Clock variables}\\
-Clock variables \lstinline[mathescape=true]!c($t_{i}$)! are of base type \lstinline!Clock!. A
+Clock variables \lstinline!c($t_{i}$)! are of base type \lstinline!Clock!. A
 clock is either defined by a constructor (such as \lstinline!Clock(3)!)
 that defines when the clock ticks (is active) at a particular time
 instant, or it is defined with clock operators relatively to other
 clocks, see \autoref{base-clock-conversion-operators}.
 \par
 \begin{example*}
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
   Clock c1 = Clock($\ldots$);
   Clock c2 = c1;
   Clock c3 = subSample(c2, 4);
@@ -230,9 +230,9 @@ clocks, see \autoref{base-clock-conversion-operators}.
 \includegraphics[width=3in,height=1.875in]{clocked}
 \end{tabular}&
 \begin{tabular}{p{7cm}}\firstuse{Clocked variables}\\
-The elements of clocked variables \lstinline[mathescape=true]!r($t_{i}$)! are of
+The elements of clocked variables \lstinline!r($t_{i}$)! are of
 base type \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, enumeration, \lstinline!String! that are
-associated uniquely with a clock \lstinline[mathescape=true]!c($t_{i}$)!. A
+associated uniquely with a clock \lstinline!c($t_{i}$)!. A
 clocked variable can only be directly accessed at the event instant
 where the associated clock is active. A constant and a
 parameter can always be used at a place where a clocked variable is
@@ -816,7 +816,7 @@ first tick of the clock of \lstinline!u!, the start value of \lstinline!u! is re
 Clarification of \lstinline!backSample!:
 
 Let $a$ and $b$ be positive integers with $a < b$, and
-\begin{lstlisting}[language=modelica,mathescape=true]
+\begin{lstlisting}[language=modelica]
 yb = backSample (u, $a$, $b$)
 ys = shiftSample(u, $b-a$, $b$)
 \end{lstlisting}
@@ -1233,12 +1233,12 @@ $y(t)$ is the continuous-time or discrete-time
 y &= g(x, u, t)
 \end{align*}
 A solver method is applied on a subclock partition. Such a partition has
-explicit inputs $u$ marked by \lstinline[mathescape=true]!sample($u$)!,
-\lstinline[mathescape=true]!subSample($u$)!, \lstinline[mathescape=true]!superSample($u$)!, \lstinline[mathescape=true]!shiftSample($u$)!
-and/or \lstinline[mathescape=true]!backSample($u$)!. Furthermore, the outputs $y$ of
-such a partition are marked by \lstinline[mathescape=true]!hold($y$)!, \lstinline[mathescape=true]!subSample($y$)!,
-\lstinline[mathescape=true]!superSample($y$)!, \lstinline[mathescape=true]!shiftSample($y$)!, and/or
-\lstinline[mathescape=true]!backSample($y$)!. The arguments of these operators are to be used
+explicit inputs $u$ marked by \lstinline!sample($u$)!,
+\lstinline!subSample($u$)!, \lstinline!superSample($u$)!, \lstinline!shiftSample($u$)!
+and/or \lstinline!backSample($u$)!. Furthermore, the outputs $y$ of
+such a partition are marked by \lstinline!hold($y$)!, \lstinline!subSample($y$)!,
+\lstinline!superSample($y$)!, \lstinline!shiftSample($y$)!, and/or
+\lstinline!backSample($y$)!. The arguments of these operators are to be used
 as input signals $u$ and output signals $y$ in the
 conceptual ordinary differential equation above, and in the
 discretization formulae below, respectively.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -12,7 +12,7 @@ The following syntactic meta symbols are used (extended BNF):
 The following lexical units are defined (the ones in boldface are the
 ones used in the grammar, the rest are just internal to the definition
 of other lexical units):
-\begin{lstlisting}[language=grammar]
+\begin{lstlisting}[language=grammar,mathescape=false]
 IDENT = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" ( Q-CHAR | S-ESCAPE ) { Q-CHAR | S-ESCAPE | """ } "'"
 NONDIGIT = "_" | letters "a" to "z" | letters "A" to "Z"

--- a/preamble.tex
+++ b/preamble.tex
@@ -213,6 +213,7 @@
 
 \lstset{ %
   backgroundcolor=\color{white},   % choose the background color
+  mathescape=true,
   breaklines=true,                 % automatic line breaking only at whitespace
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom


### PR DESCRIPTION
This significantly reduces the clutter around all the \lstinline where math is used.