### PR TITLE
Remove presumably unintended indentation inside lstlisting environments

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1354,11 +1354,11 @@ Step step1(nIn=0);
   Drawing a connection line between connectors \lstinline!inPorts! and
   \lstinline!step1.inPorts! results in:
 \begin{lstlisting}[language=modelica]
-parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
-StepIn inPorts[nIn];
-Step step1(nIn=nIn); // nIn=0 changed to nIn=nIn
+  parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
+  StepIn inPorts[nIn];
+  Step step1(nIn=nIn); // nIn=0 changed to nIn=nIn
 equation
-connect(inPorts, step1.inPorts); // new connect equation
+  connect(inPorts, step1.inPorts); // new connect equation
 \end{lstlisting}
 \item
   If a connection line is deleted between one outside and one

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -348,11 +348,10 @@ annotations in classes and on extends-clauses.
 
 The following common definitions are used to define graphical
 annotations in the later sections.
-
 \begin{lstlisting}[language=modelica]
-  type DrawingUnit = Real(final unit="mm");
-  type Point = DrawingUnit[2] "{x, y}";
-  type Extent = Point[2] "Defines a rectangular area {{x1, y1}, {x2, y2}}";
+type DrawingUnit = Real(final unit="mm");
+type Point = DrawingUnit[2] "{x, y}";
+type Extent = Point[2] "Defines a rectangular area {{x1, y1}, {x2, y2}}";
 \end{lstlisting}
 The interpretation of \lstinline!unit! is with respect to printer output in
 natural size (not zoomed).
@@ -447,17 +446,16 @@ defined by the following priority:
 
 Properties of graphical objects and connection lines are described using
 the following attribute types.
-
 \begin{lstlisting}[language=modelica]
-  type Color = Integer[3](min=0, max=255) "RGB representation";
+type Color = Integer[3](min=0, max=255) "RGB representation";
 
-  constant Color Black = zeros(3);
-  type LinePattern = enumeration(None, Solid, Dash, Dot, DashDot, DashDotDot);
-  type FillPattern = enumeration(None, Solid, Horizontal, Vertical,
-  Cross, Forward, Backward, CrossDiag, HorizontalCylinder, VerticalCylinder, Sphere);
-  type BorderPattern = enumeration(None, Raised, Sunken, Engraved);
-  type Smooth = enumeration(None, Bezier);
-  type EllipseClosure = enumeration(None, Chord, Radial);
+constant Color Black = zeros(3);
+type LinePattern = enumeration(None, Solid, Dash, Dot, DashDot, DashDotDot);
+type FillPattern = enumeration(None, Solid, Horizontal, Vertical,
+Cross, Forward, Backward, CrossDiag, HorizontalCylinder, VerticalCylinder, Sphere);
+type BorderPattern = enumeration(None, Raised, Sunken, Engraved);
+type Smooth = enumeration(None, Bezier);
+type EllipseClosure = enumeration(None, Chord, Radial);
 \end{lstlisting}
 The \lstinline!LinePattern! attribute \lstinline!Solid! indicates a normal line, \lstinline!None! an
 invisible line, and the other attributes various forms of dashed/dotted
@@ -513,9 +511,9 @@ The values of the \lstinline!EllipseClosure! enumeration specify if and how the
 endpoints of an elliptical arc are to be joined (see \autoref{ellipse} Ellipse).
 
 \begin{lstlisting}[language=modelica]
-  type Arrow = enumeration(None, Open, Filled, Half);
-  type TextStyle = enumeration(Bold, Italic, UnderLine);
-  type TextAlignment = enumeration(Left, Center, Right);
+type Arrow = enumeration(None, Open, Filled, Half);
+type TextStyle = enumeration(Bold, Italic, UnderLine);
+type TextAlignment = enumeration(Left, Center, Right);
 \end{lstlisting}
 Filled shapes have the following attributes for the border and interior.
 
@@ -656,8 +654,8 @@ and optionally a Text-primitive, as specified below.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  connect(a.x, b.x)
-   annotation(Line(points={{-25,30}, {10,30}, {10, -20}, {40,-20}}));
+connect(a.x, b.x)
+  annotation(Line(points={{-25,30}, {10,30}, {10, -20}, {40,-20}}));
 \end{lstlisting}
 \end{example}
 
@@ -697,10 +695,9 @@ Having a zero size for the extent is deprecated and is handled as if upper part 
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  connect(controlBus.axisControlBus1, axis1.axisControlBus) annotation (
-      Text(string="%first", index=-1, extent=[-6,3; -6,7]),
-      Line(points={{-80,-10},{-80,-14.5},{-79,-14.5},{-79,-17},{-65,-17},{-65,-65},
-           {-25,-65}}));
+connect(controlBus.axisControlBus1, axis1.axisControlBus) annotation (
+  Text(string="%first", index=-1, extent=[-6,3; -6,7]),
+  Line(points={{-80,-10},{-80,-14.5},{-79,-14.5},{-79,-17},{-65,-17},{-65,-65},{-25,-65}}));
 \end{lstlisting}
 Draws a connection line and adds the text \emph{axisControlBus1}
 ending at \{-6, 3\}+\{-25, -65\} and 4 vertical units of space for the text.
@@ -937,12 +934,12 @@ The level of a tank could be animated by a
 rectangle expanding in vertical direction and its color depending on a
 variable overflow:
 \begin{lstlisting}[language=modelica]
-  annotation (
-   Icon(graphics={Rectangle(
-     extent=DynamicSelect({{0,0},{20,20}},{{0,0},{20,level}}),
-      fillColor=DynamicSelect({0,0,255},
-                              if overflow then {255,0,0} else {0,0,255}))}
- );
+annotation (
+  Icon(graphics={Rectangle(
+    extent=DynamicSelect({{0,0},{20,20}},{{0,0},{20,level}}),
+    fillColor=DynamicSelect({0,0,255},
+                            if overflow then {255,0,0} else {0,0,255}))})
+);
 \end{lstlisting}
 \end{example}
 
@@ -973,10 +970,11 @@ end OnMouseDownSetBoolean;
 A button can be represented by a rectangle changing color depending on a \lstinline!Boolean! variable \lstinline!on! and toggles the
 variable when the rectangle is clicked on:
 \begin{lstlisting}[language=modelica]
-  annotation (Icon(graphics={Rectangle(extent=[0,0; 20,20],
-  fillColor=if  on then {255,0,0} else
-  {0,0,255})},
-  interaction={ OnMouseDownSetBoolean (on, not on)}));
+annotation (Icon(
+  graphics={Rectangle(
+    extent=[0,0; 20,20],
+    fillColor=if on then {255,0,0} else {0,0,255})},
+  interaction={OnMouseDownSetBoolean (on, not on)}));
 \end{lstlisting}
 \end{example}
 
@@ -1062,12 +1060,12 @@ graphical user interface:
 When creating a component of the given class, the recommended component name is \emph{name}.
 
 \begin{lstlisting}[language=modelica]
-  annotation(defaultComponentPrefixes = "prefixes")
+annotation(defaultComponentPrefixes = "prefixes")
 \end{lstlisting}
 
 When creating a component, it is recommended to generate a declaration of the form
 \begin{lstlisting}[language=modelica]
-  prefixes class-name component-name
+prefixes class-name component-name
 \end{lstlisting}
 
 The following prefixes may be included in the string \lstinline!prefixes!: \lstinline!inner!,
@@ -1080,7 +1078,7 @@ and the default name cannot be used (e.g., since it is already in use) it is rec
 \end{nonnormative}
 
 \begin{lstlisting}[language=modelica]
-  annotation(missingInnerMessage = "message")
+annotation(missingInnerMessage = "message")
 \end{lstlisting}
 
 When an \lstinline!outer! component of the class does not have a corresponding \lstinline!inner!
@@ -1099,13 +1097,13 @@ end World;
 When an instance of model \lstinline!World! is dragged in to the diagram layer, the
 following declaration is generated:
 \begin{lstlisting}[language=modelica]
-  inner replaceable World world;
+inner replaceable World world;
 \end{lstlisting}
 \end{example}
 
 A simple type or component of a simple type may have:
 \begin{lstlisting}[language=modelica]
-  annotation(absoluteValue=false);
+annotation(absoluteValue=false);
 \end{lstlisting}
 
 If \lstinline!false!, then the variable defines a relative quantity, and if true an
@@ -1120,7 +1118,7 @@ This annotation is used in the Modelica Standard Library, for example in
 
 A model or block definition may contain:
 \begin{lstlisting}[language=modelica]
-  annotation(defaultConnectionStructurallyInconsistent=true)
+annotation(defaultConnectionStructurallyInconsistent=true)
 \end{lstlisting}
 
 If \lstinline!true!, it is stated that a default connection will result in a
@@ -1148,7 +1146,7 @@ wrong error message.
 
 A class may have the following annotation:
 \begin{lstlisting}[language=modelica]
-  annotation(obsolete = "message");
+annotation(obsolete = "message");
 \end{lstlisting}
 
 It indicates that the class ideally should not be used anymore and gives
@@ -1160,7 +1158,7 @@ If that is not possible the current class can have also have an obsolete-annotat
 
 A declaration may have the following annotations:
 \begin{lstlisting}[language=modelica]
-  annotation(unassignedMessage = "message");
+annotation(unassignedMessage = "message");
 \end{lstlisting}
 
 When the variable to which this annotation is attached in the
@@ -1349,18 +1347,18 @@ rules:
   of a (\lstinline!connectorSizing!) parameter. \emph{Example:} Assume there is a
   connector \lstinline!inPorts! and a component \lstinline!step1!:
 \begin{lstlisting}[language=modelica]
-  parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
-  StepIn inPorts[nIn];
-  Step step1(nIn=0);
+parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
+StepIn inPorts[nIn];
+Step step1(nIn=0);
 \end{lstlisting}
   Drawing a connection line between connectors \lstinline!inPorts! and
   \lstinline!step1.inPorts! results in:
 \begin{lstlisting}[language=modelica]
-  parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
-  StepIn inPorts[nIn];
-  Step step1(nIn=nIn); // nIn=0 changed to nIn=nIn
-  equation
-  connect(inPorts, step1.inPorts); // new connect equation
+parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
+StepIn inPorts[nIn];
+Step step1(nIn=nIn); // nIn=0 changed to nIn=nIn
+equation
+connect(inPorts, step1.inPorts); // new connect equation
 \end{lstlisting}
 \item
   If a connection line is deleted between one outside and one
@@ -1370,9 +1368,9 @@ rules:
   \emph{Example:} Assume the connection line in (3) is removed.
   This results in:
 \begin{lstlisting}[language=modelica]
-  parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
-  StepIn inPorts[nIn];
-  Step step1; // modifier nIn=nIn is removed
+parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
+StepIn inPorts[nIn];
+Step step1; // modifier nIn=nIn is removed
 \end{lstlisting}
 \item
   If a new connection line is drawn to an inside connector with
@@ -1381,9 +1379,9 @@ rules:
   index. \emph{Example:} Assume that 3 connections are present and a new
   connection is performed. The result is:
 \begin{lstlisting}[language=modelica]
-    Step step1(nIn=4); // index changed from nIn=3 to nIn=4
-  equation
-    connect(.., step1.inPorts[4]); // new connect equation
+  Step step1(nIn=4); // index changed from nIn=3 to nIn=4
+equation
+  connect(.., step1.inPorts[4]); // new connect equation
 \end{lstlisting}
   In some applications, like state machines, the vector index is
   used as a priority, e.g., to define which transition is firing if
@@ -1616,13 +1614,13 @@ convertElement({"Modelica.Mechanics.MultiBody.World",
 \end{lstlisting}
 This implies that
 \begin{lstlisting}[language=modelica]
-  Modelica.Mechanics.MultiBody.World world(mue=2);
-  function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mue=4);
+Modelica.Mechanics.MultiBody.World world(mue=2);
+function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mue=4);
 \end{lstlisting}
 is converted to:
 \begin{lstlisting}[language=modelica]
-  Modelica.Mechanics.MultiBody.World world(mu=2);
-  function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mu=4);
+Modelica.Mechanics.MultiBody.World world(mu=2);
+function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mu=4);
 \end{lstlisting}
 \end{example}
 
@@ -1923,10 +1921,10 @@ class are visible, and only the parts explicitly listed as visible below can be 
 (if a class is encrypted and no Protection annotation is defined, the access annotation has the default value
 \lstinline!Access.documentation!):
 \begin{lstlisting}[language=modelica]
-  type Access = enumeration(hide, icon, documentation,
-  diagram, nonPackageText, nonPackageDuplicate,
-  packageText, packageDuplicate);
-  annotation(Protection(access = Access.documentation));
+type Access = enumeration(hide, icon, documentation,
+diagram, nonPackageText, nonPackageDuplicate,
+packageText, packageDuplicate);
+annotation(Protection(access = Access.documentation));
 \end{lstlisting}
 
 The items of the Access enumeration have the following meaning:

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -134,25 +134,25 @@ single declaration or in multiple declarations. For example, regard the
 following single declaration (\lstinline!component-clause!) of two matrix
 variables:
 \begin{lstlisting}[language=modelica]
-  Real[2,2] A, B;
+Real[2,2] A, B;
 \end{lstlisting}
 That declaration has the same meaning as the following two
 declarations together:
 \begin{lstlisting}[language=modelica]
-  Real[2,2] A;
-  Real[2,2] B;
+Real[2,2] A;
+Real[2,2] B;
 \end{lstlisting}
 The array dimension descriptors may instead be placed after the
 variable name, giving the two declarations below, with the same meaning
 as in the previous example:
 \begin{lstlisting}[language=modelica]
-  Real A[2,2];
-  Real B[2,2];
+Real A[2,2];
+Real B[2,2];
 \end{lstlisting}
 The following declaration is different, meaning that the variable
 a is a scalar but B is a matrix as above:
 \begin{lstlisting}[language=modelica]
-  Real a, B[2,2];
+Real a, B[2,2];
 \end{lstlisting}
 \end{nonnormative}
 

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -91,21 +91,21 @@ The figure visualizes the following \lstinline!connect! equations to
 the connector \lstinline!c! in the models \lstinline!m!$i$. Consider the
 following \lstinline!connect! equations found in the model for component \lstinline!m0!:
 \begin{lstlisting}[language=modelica]
-  connect(m1.c, m3.c); // m1.c and m3.c are inside connectors
-  connect(m2.c, m3.c); // m2.c and m3.c are inside connectors
+connect(m1.c, m3.c); // m1.c and m3.c are inside connectors
+connect(m2.c, m3.c); // m2.c and m3.c are inside connectors
 \end{lstlisting}
 and in the model for component \lstinline!m3! (\lstinline!c.x! is a sub-connector inside
 \lstinline!c!):
 \begin{lstlisting}[language=modelica]
-  connect(c, m4.c); // c is an outside
-  connector, m4.c is an inside connector
-  connect(c.x, m5.c); // c.x is an outside
-  connector, m5.c is an inside connector
-  connect(c , d) ; // c is an outside  connector, d  is an outside connector
+connect(c, m4.c); // c is an outside
+connector, m4.c is an inside connector
+connect(c.x, m5.c); // c.x is an outside
+connector, m5.c is an inside connector
+connect(c , d) ; // c is an outside  connector, d  is an outside connector
 \end{lstlisting}
 and in the model for component \lstinline!m6!:
 \begin{lstlisting}[language=modelica]
-  connect(d, m7.c); // d is an outside connector, m7.c is an inside connector
+connect(d, m7.c); // d is an outside connector, m7.c is an inside connector
 \end{lstlisting}
 \end{example}
 
@@ -365,12 +365,12 @@ of the union of all connectors is introduced.
 
 The \lstinline!engine_bus! contains the following variable declarations:
 \begin{lstlisting}[language=modelica]
-  RealOutput engine_speed;
-  RealOutput engine_temp;
-  CylinderBus cylinder_bus[1];
-  CylinderBus cylinder_bus[2];
-  CylinderBus cylinder_bus[3];
-  CylinderBus cylinder_bus[4];
+RealOutput engine_speed;
+RealOutput engine_temp;
+CylinderBus cylinder_bus[1];
+CylinderBus cylinder_bus[2];
+CylinderBus cylinder_bus[3];
+CylinderBus cylinder_bus[4];
 \end{lstlisting}
 \end{example}
 
@@ -1081,41 +1081,42 @@ passed between components, in order to avoid redundant equations.
 An overdetermined connector for 3-dimensional mechanical systems
 may be defined as:
 \begin{lstlisting}[language=modelica]
-  type TransformationMatrix = Real[3,3];
-  type Orientation "Orientation from frame 1 to frame 2"
-    extendsTransformationMatrix;
-    function equalityConstraint
-      input Orientation R1 "Rotation from inertial frame to frame 1";
-      input Orientation R2 "Rotation from inertial frame to frame 2";
-      output Real residue[3];
-      protected
-      Orientation R_rel "Relative Rotation from frame 1 to frame 2";
-    algorithm
-      R_rel := R2*transpose(R1);
-      /* If frame_1 and frame_2 are identical, R_rel must be
-the unit matrix. If they are close together, R_rel can be
-linearized yielding:
-R_rel = [ 1, phi3, -phi2;
--phi3, 1, phi1;
-phi2, -phi1, 1 ];
-where phi1, phi2, phi3 are the small rotation angles around
-axis x, y, z of frame 1 to rotate frame 1 into frame 2.
-The atan2 is used to handle large rotation angles, but does not
-modify the result for small angles.
-*/
-      residue := { Modelica.Math.atan2(R_rel[2, 3], R_rel[1, 1]),
-      Modelica.Math.atan2(R_rel[3, 1], R_rel[2, 2]),
-      Modelica.Math.atan2(R_rel[1, 2], R_rel[3, 3])};
-    end equalityConstraint;
-  end Orientation;
+type TransformationMatrix = Real[3,3];
+type Orientation "Orientation from frame 1 to frame 2"
+  extendsTransformationMatrix;
+  function equalityConstraint
+    input Orientation R1 "Rotation from inertial frame to frame 1";
+    input Orientation R2 "Rotation from inertial frame to frame 2";
+    output Real residue[3];
+    protected
+    Orientation R_rel "Relative Rotation from frame 1 to frame 2";
+  algorithm
+    R_rel := R2*transpose(R1);
+    /*
+      If frame_1 and frame_2 are identical, R_rel must be
+      the unit matrix. If they are close together, R_rel can be
+      linearized yielding:
+        R_rel = [ 1, phi3, -phi2;
+        -phi3, 1, phi1;
+        phi2, -phi1, 1 ];
+      where phi1, phi2, phi3 are the small rotation angles around
+      axis x, y, z of frame 1 to rotate frame 1 into frame 2.
+      The atan2 is used to handle large rotation angles, but does not
+      modify the result for small angles.
+    */
+    residue := { Modelica.Math.atan2(R_rel[2, 3], R_rel[1, 1]),
+    Modelica.Math.atan2(R_rel[3, 1], R_rel[2, 2]),
+    Modelica.Math.atan2(R_rel[1, 2], R_rel[3, 3])};
+  end equalityConstraint;
+end Orientation;
 
-  connector Frame "3-dimensional mechanical connector"
-    import Modelica.Units.SI;
-    SI.Position r[3] "Vector from inertial frame to Frame";
-    Orientation R "Orientation from inertial frame to Frame";
-    flow SI.Force f[3] "Cut-force resolved in Frame";
-    flow SI.Torque t[3] "Cut-torque resolved in Frame";
-  end Frame;
+connector Frame "3-dimensional mechanical connector"
+  import Modelica.Units.SI;
+  SI.Position r[3] "Vector from inertial frame to Frame";
+  Orientation R "Orientation from inertial frame to Frame";
+  flow SI.Force f[3] "Cut-force resolved in Frame";
+  flow SI.Torque t[3] "Cut-torque resolved in Frame";
+end Frame;
 \end{lstlisting}
 A fixed translation from a frame \lstinline!A! to a frame \lstinline!B! may be defined as:
 \begin{lstlisting}[language=modelica]

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -222,10 +222,9 @@ end m2;
 Consider the case of and all other mass flow rates positive (with the
 min attribute set accordingly). Connecting \lstinline!m1.c! with \lstinline!m2.c! and \lstinline!m3.c!, such
 that
-
 \begin{lstlisting}[language=modelica]
-  m2.c.m_flow.min = 0; // max(-m2.c.m_flow,0) = 0
-  m3.c.m_flow.min = 0; // max(-m3.c.m_flow,0) = 0
+m2.c.m_flow.min = 0; // max(-m2.c.m_flow,0) = 0
+m3.c.m_flow.min = 0; // max(-m3.c.m_flow,0) = 0
 \end{lstlisting}
 results in the following equation:
 \begin{equation*}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -477,12 +477,12 @@ end RealToString;
 \end{lstlisting}
 Then the following applications are equivalent:
 \begin{lstlisting}[language=modelica]
-  RealToString(2.0);
-  RealToString(2.0, 6, 0);
-  RealToString(2.0, 6);
-  RealToString(2.0, precision=6);
-  RealToString(2.0, length=0);
-  RealToString(2.0, 6, precision=6); // error: slot is used twice
+RealToString(2.0);
+RealToString(2.0, 6, 0);
+RealToString(2.0, 6);
+RealToString(2.0, precision=6);
+RealToString(2.0, length=0);
+RealToString(2.0, 6, precision=6); // error: slot is used twice
 \end{lstlisting}
 \end{example}
 
@@ -499,7 +499,7 @@ value.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  function quadrature "Integrate function y=integrand(x) from x1 to x2"
+function quadrature "Integrate function y=integrand(x) from x1 to x2"
   input Real x1;
   input Real x2;
   input Integrand integrand; // Integrand is a partial function,
@@ -550,7 +550,7 @@ area = quadrature(0, 1, Parabola);
 The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a
 component as input argument according to case (c):
 \begin{lstlisting}[language=modelica]
-  function quadrature2 "Integrate function y=integrand(x) from x1 to x2"
+function quadrature2 "Integrate function y=integrand(x) from x1 to x2"
   input Real x1;
   input Real x2;
   input Integrand integrand; // Integrand is a partial function type
@@ -574,7 +574,7 @@ function declaration. A function partial application is specified by the
 giving named formal parameter associations for the formal parameters to
 be bound, e.g.:
 \begin{lstlisting}[language=modelica]
-  function func_name(..., formal_parameter_name = expr, ...)
+function func_name(..., formal_parameter_name = expr, ...)
 \end{lstlisting}
 
 \begin{nonnormative}
@@ -626,7 +626,7 @@ area := area + quadrature(0, 1, integrand = function Sine(A=2, w=i*time));
 Function types are matching after removing the bound arguments \lstinline!A! and \lstinline!w! in a function partial
 application:
 \begin{lstlisting}[language=modelica]
-  function Sine2 "y = Sine2(A,w,x)"
+function Sine2 "y = Sine2(A,w,x)"
   input Real A;
   input Real w;
   input Real x; // Note: x is now last in argument list.
@@ -711,11 +711,11 @@ be automatically deduced by an optimizing compiler.
 Function \lstinline!eigen! to compute eigenvalues and optionally
 eigenvectors may be called in the following ways:
 \begin{lstlisting}[language=modelica]
-  ev = eigen(A); // calculate eigenvalues
-  x = isStable(eigen(A)); // used in an expression
-  (ev, vr) = eigen(A) // calculate eigenvectors
-  (ev,vr,vl) = eigen(A) // and also left eigenvectors
-  (ev,,vl) = eigen(A) // no right eigenvectors
+ev = eigen(A); // calculate eigenvalues
+x = isStable(eigen(A)); // used in an expression
+(ev, vr) = eigen(A) // calculate eigenvectors
+(ev,vr,vl) = eigen(A) // and also left eigenvectors
+(ev,,vl) = eigen(A) // no right eigenvectors
 \end{lstlisting}
 The function may be defined as:
 \begin{lstlisting}[language=modelica]
@@ -743,8 +743,8 @@ a function.
 \begin{example}
 The following are illegal:
 \begin{lstlisting}[language=modelica]
-  (x+1, 3.0, z/y) = f(1.0, 2.0); // Not a list of component references.
-  (x, y, z) + (u, v, w) // Not LHS of suitable eqn/assignment.
+(x+1, 3.0, z/y) = f(1.0, 2.0); // Not a list of component references.
+(x, y, z) + (u, v, w) // Not LHS of suitable eqn/assignment.
 \end{lstlisting}
 \end{example}
 
@@ -898,9 +898,9 @@ size, and they are traversed in parallel.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  sin({a, b, c}) = {sin(a), sin(b), sin(c)} // argument is a vector
-  sin([a,b,c]) = [sin(a),sin(b),sin(c)] // argument may be a matrix
-  atan({a,b,c},{d,e,f}) = {atan(a,d), atan(b,e), atan(c,f)}
+sin({a, b, c}) = {sin(a), sin(b), sin(c)} // argument is a vector
+sin([a,b,c]) = [sin(a),sin(b),sin(c)] // argument may be a matrix
+atan({a,b,c},{d,e,f}) = {atan(a,d), atan(b,e), atan(c,f)}
 \end{lstlisting}
 This works even if the function is declared to take an array as
 one of its arguments. If \lstinline!pval! is defined as a function that takes
@@ -909,17 +909,17 @@ be used with an actual argument which is a two-dimensional array (a
 vector of vectors). The result type in this case will be a vector of
 \lstinline!Real!.
 \begin{lstlisting}[language=modelica]
-  pval([1,2;3,4]) = [pval([1,2]); pval([3,4])]
-  sin([1,2;3,4]) = [sin({1,2}); sin({3,4})]
+pval([1,2;3,4]) = [pval([1,2]); pval([3,4])]
+sin([1,2;3,4]) = [sin({1,2}); sin({3,4})]
   = [sin(1), sin(2); sin(3), sin(4)]
 \end{lstlisting}
 \begin{lstlisting}[language=modelica]
-  function Add
-    input Real e1, e2;
-    output Real sum1;
-  algorithm
-    sum1 := e1 + e2;
-  end Add;
+function Add
+  input Real e1, e2;
+  output Real sum1;
+algorithm
+  sum1 := e1 + e2;
+end Add;
 \end{lstlisting}
 \lstinline!Add(1, [1,2,3])! adds one to each of the elements of the second
 argument giving the result \lstinline![2,3,4]!. However, it is illegal to
@@ -1125,9 +1125,9 @@ end Demo;
 \end{lstlisting}
 and can be applied in the following way
 \begin{lstlisting}[language=modelica]
-  Demo.Record2 r1 = Demo.Record2(r0=1, c2=2, n1=2, n2=3, r1=1, r2=2,r4=5, r5=5, r6={1,2}, r7={1,2,3});
-  Demo.Record2 r2 = Demo.Record2(1,2,2,3,1,2,5,5,{1,2},{1,2,3});
-  parameter Demo.Record2 r3 = Demo.Record2(c2=2, n2=1, r1=1,r4=4, r6=1:5, r7={1});
+Demo.Record2 r1 = Demo.Record2(r0=1, c2=2, n1=2, n2=3, r1=1, r2=2,r4=5, r5=5, r6={1,2}, r7={1,2,3});
+Demo.Record2 r2 = Demo.Record2(1,2,2,3,1,2,5,5,{1,2},{1,2,3});
+parameter Demo.Record2 r3 = Demo.Record2(c2=2, n2=1, r1=1,r4=4, r6=1:5, r7={1});
 \end{lstlisting}
 
 The above example is only used to show the different variants
@@ -1262,13 +1262,13 @@ This means that the most restrictive derivatives should be written first.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  function foo0 annotation(derivative=foo1);
-  end foo0;
+function foo0 annotation(derivative=foo1);
+end foo0;
 
-  function foo1 annotation(derivative(order=2)=foo2);
-  end foo1;
+function foo1 annotation(derivative(order=2)=foo2);
+end foo1;
 
-  function foo2 end foo2;
+function foo2 end foo2;
 \end{lstlisting}
 \end{example}
 

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -551,7 +551,7 @@ end E;
 \end{lstlisting}
 This implies that \lstinline!b[k].c[i].a[j]=j! and
 \begin{lstlisting}[language=modelica]
-  b[k].c[i].d=i and b[k].p=k
+b[k].c[i].d=i and b[k].p=k
 \end{lstlisting}
 For \lstinline!c.a! the additional (outer) \lstinline!each! has no effect, but it is
 necessary for \lstinline!c.d!.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -532,7 +532,7 @@ model B
   parameter Real b=0;
 end B;
 \end{lstlisting}
-This implies that \lstinline!c[i].a[j]=j!, and \lstinline!c[i].d=i!.
+This implies \lstinline!c[i].a[j] = j! and \lstinline!c[i].d = i!.
 
 \begin{lstlisting}[language=modelica]
 model D
@@ -541,7 +541,7 @@ model D
   B b2(c(each a={3,4,5}, d={2,3,4,5,6}));
 end D;
 \end{lstlisting}
-This implies that \lstinline!b.c[i].a[j]=2+j! and \lstinline!b.c[i].d=1+i!
+This implies \lstinline!b.c[i].a[j] = 2+j! and \lstinline!b.c[i].d = 1+i!.
 \begin{lstlisting}[language=modelica]
 model E
   B b[2](each c(each a={1,2,3}, d={1,2,3,4,5}), p={1,2});
@@ -549,12 +549,8 @@ model E
   B b2[2](c(each a={1,2,3}, d=fill({1,2,3,4,5},2)), p={1,2});
 end E;
 \end{lstlisting}
-This implies that \lstinline!b[k].c[i].a[j]=j! and
-\begin{lstlisting}[language=modelica]
-b[k].c[i].d=i and b[k].p=k
-\end{lstlisting}
-For \lstinline!c.a! the additional (outer) \lstinline!each! has no effect, but it is
-necessary for \lstinline!c.d!.
+This implies \lstinline!b[k].c[i].a[j] = j!, \lstinline!b[k].c[i].d = i!, and \lstinline!b[k].p = k!.  For \lstinline!c.a! the additional (outer) \lstinline!each! has no effect,
+but it is necessary for \lstinline!c.d!.
 \end{example}
 
 \subsection{Final Element Modification Prevention}\doublelabel{final-element-modification-prevention}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -139,8 +139,8 @@ equation
 
 To guard square against square root of negative number use \lstinline!noEvent!:
 \begin{lstlisting}[language=modelica]
-  der(h)=if h>0 then -c*sqrt(h) else 0; // Incorrect
-  der(h)=if noEvent(h>0) then -c*sqrt(h) else 0; // Correct
+der(h)=if h>0 then -c*sqrt(h) else 0; // Incorrect
+der(h)=if noEvent(h>0) then -c*sqrt(h) else 0; // Correct
 \end{lstlisting}
 \end{example}
 

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -258,10 +258,10 @@ class \lstinline!B!.
   operator record classes used as arguments of the overloaded \lstinline!op!
   functions. Example using the Complex-definition below:
 \begin{lstlisting}[language=modelica]
-   Real a;
-  Complex b;
-  Complex c = a*b; // interpreted as:
-  // Complex.'*'.multiply(Complex.'constructor'.fromReal(a),b);
+Real a;
+Complex b;
+Complex c = a*b; // interpreted as:
+// Complex.'*'.multiply(Complex.'constructor'.fromReal(a),b);
 \end{lstlisting}
 \end{nonnormative}
 \item
@@ -492,9 +492,9 @@ algorithm
 
 How overloaded operators can be symbolically processed. Example:
 \begin{lstlisting}[language=modelica]
-  Real a;
-  Complex b;
-  Complex c = a + b;
+Real a;
+Complex b;
+Complex c = a + b;
 \end{lstlisting}
 Due to inlining of functions, the equation for \lstinline!c! is
 transformed to:
@@ -505,8 +505,8 @@ c = Complex.'+'.add(Complex.'constructor'.fromReal(a), b);
 \end{lstlisting}
 or
 \begin{lstlisting}[language=modelica]
-  c.re = a + b.re;
-  c.im = b.im;
+c.re = a + b.re;
+c.im = b.im;
 \end{lstlisting}
 These equations can be symbolically processed as other equations.
 
@@ -528,10 +528,10 @@ equation
 The two connect equations result in the following connection
 equations:
 \begin{lstlisting}[language=modelica]
-  p1.v = p2.v;
-  p1.v = p3.v;
-  p1.i + p2.i + p3.i = Complex.'0'();
-  // Complex.'+'(p1.i, Complex.'+'(p2.i, p3.i)) = Complex.'0'();
+p1.v = p2.v;
+p1.v = p3.v;
+p1.i + p2.i + p3.i = Complex.'0'();
+// Complex.'+'(p1.i, Complex.'+'(p2.i, p3.i)) = Complex.'0'();
 \end{lstlisting}
 The restrictions on extends are intended to avoid combining two
 variants inheriting from the same operator record, but with possibly

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -104,11 +104,11 @@ a simple name without dot notation that can be used to refer to the package afte
 
 The forms of \lstinline!import! are exemplified below assuming that we want to access the addition operation of the hypothetical package \lstinline!Modelica.Math.ComplexNumbers!:
 \begin{lstlisting}[language=modelica]
-  import Modelica.Math.ComplexNumbers;       // Accessed by ComplexNumbers.Add
-  import Modelica.Math.ComplexNumbers.Add;   // Accessed by Add
-  import Modelica.Math.ComplexNumbers.{Add,Sub}; // Accessed by Add and Sub
-  import Modelica.Math.ComplexNumbers.*;     // Accessed by Add
-  import Co = Modelica.Math.ComplexNumbers;  // Accessed by Co.Add
+import Modelica.Math.ComplexNumbers;       // Accessed by ComplexNumbers.Add
+import Modelica.Math.ComplexNumbers.Add;   // Accessed by Add
+import Modelica.Math.ComplexNumbers.{Add,Sub}; // Accessed by Add and Sub
+import Modelica.Math.ComplexNumbers.*;     // Accessed by Add
+import Co = Modelica.Math.ComplexNumbers;  // Accessed by Co.Add
 \end{lstlisting}
 \end{nonnormative}
 
@@ -222,9 +222,9 @@ The subpackage \lstinline!Rotational! declared within
 the packageprefixname with the short name of the package. The
 declaration of \lstinline!Rotational! could be given as below:
 \begin{lstlisting}[language=modelica]
-  within Modelica.Mechanics;
-  package Rotational // Modelica.Mechanics.Rotational
-    ...
+within Modelica.Mechanics;
+package Rotational // Modelica.Mechanics.Rotational
+  ...
 \end{lstlisting}
 \end{example}
 

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1802,13 +1802,13 @@ The following main changes in Modelica 3.0 are \emph{not} backwards compatible:
   number of variables that are neither parameter, constant, input,
   output, nor flow. For example, the following connector is illegal in
   Modelica 3:
-  \begin{lstlisting}[language=modelica]
-  connector notValid // illegal connector
-    Real r1;
-    Real r2;
-    flow Real r3;
-  end notValid;
-  \end{lstlisting}
+\begin{lstlisting}[language=modelica]
+connector notValid // illegal connector
+  Real r1;
+  Real r2;
+  flow Real r3;
+end notValid;
+\end{lstlisting}
 \item
   In a non-partial model or block, all non-connector inputs of model or
   block components must have binding equations.

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -244,7 +244,7 @@ The state update starts from \lstinline!nextState!, i.e., what has been determin
 \lstinline!selectedState! takes into account if a reset of the state machine is to be done.
 
 \begin{lstlisting}[language=modelica]
-  output Integer selectedState = if reset then 1 else previous(nextState);
+output Integer selectedState = if reset then 1 else previous(nextState);
 \end{lstlisting}
 The integer fired is calculated as the index of the transition to be
 fired by checking that \lstinline!selectedState! is the from-state and the condition
@@ -253,13 +253,14 @@ delayed transition. The max function returns the index of the transition
 with highest priority or 0.
 
 \begin{lstlisting}[language=modelica]
-  Integer fired = max(if
-    (if t[i].from == selectedState
-	   then (if t[i].immediate then c[i] else previous(c[i]))
-	   else false)
-	 then i
-	 else 0
-   for i in 1:size(t,1));
+Integer fired =
+  max(
+    if (if t[i].from == selectedState
+        then (if t[i].immediate then c[i] else previous(c[i]))
+        else false)
+      then i
+      else 0
+    for i in 1:size(t,1));
 \end{lstlisting}
 The start value of c is false. This definition would require that the
 previous value is recorded for all transitions conditions. Below is
@@ -272,13 +273,14 @@ from-state and the condition is true. The max function returns the index
 of the transition with true condition and highest priority or 0.
 
 \begin{lstlisting}[language=modelica]
-  Integer immediate = max(if
-     (if t[i].immediate and  t[i].from == selectedState
+Integer immediate =
+  max(
+    if (if t[i].immediate and t[i].from == selectedState
         then c[i]
-		else false)
-	  then i
-	  else 0
-	for i in 1:size(t,1));
+        else false)
+      then i
+      else 0
+    for i in 1:size(t,1));
 \end{lstlisting}
 
 In a similar way, the \lstinline!Integer delayed! is calculated as the index for a
@@ -286,37 +288,40 @@ potentially delayed transition, i.e.\ a transition taking place at the
 next clock tick. In this case the from-state needs to be equal to
 \lstinline!nextState!:
 \begin{lstlisting}[language=modelica]
-  Integer delayed =  max(if
-    (if not t[i].immediate and t[i].from == nextState
-	   then c[i]
-	   else false)
-	 then i
-	 else 0
-  for i in 1:size(t,1));
+Integer delayed =
+  max(
+    if (if not t[i].immediate and t[i].from == nextState
+        then c[i]
+        else false)
+      then i
+      else 0
+    for i in 1:size(t,1));
 \end{lstlisting}
 
 The transition to be fired is determined as follows, taking into account
 that a delayed transition might have higher priority than an immediate:
 \begin{lstlisting}[language=modelica]
-  Integer fired = max(previous(delayed), immediate);
+Integer fired = max(previous(delayed), immediate);
 \end{lstlisting}
 \lstinline!nextState! is set to the found transitions to-state:
 \begin{lstlisting}[language=modelica]
-  Integer nextState = if active then
-                        (if fired > 0
-						   then t[fired].to
-						   else selectedState)
-					  else previous(nextState);
+Integer nextState =
+  if active then
+    (if fired > 0
+		  then t[fired].to
+		  else selectedState)
+	else
+    previous(nextState);
 \end{lstlisting}
 In order to define synchronize transitions, each state machine must
 determine which are the final states, i.e.\ states without
 from-transitions and to determine if the state machine is in a final
 state currently:
 \begin{lstlisting}[language=modelica]
-  Boolean finalStates[nStates] = {
-       max(if  t[j].from == i then 1 else 0 for j in 1:size(t,1)) == 0
-	for i in 1:nStates};
-  Boolean stateMachineInFinalState = finalStates[activeState];
+Boolean finalStates[nStates] = {
+  max(if  t[j].from == i then 1 else 0 for j in 1:size(t,1)) == 0
+  for i in 1:nStates};
+Boolean stateMachineInFinalState = finalStates[activeState];
 \end{lstlisting}
 To enable a synchronize transition, all the stateMachineInFinalState
 conditions of all state machines within the meta state must be true. An
@@ -341,13 +346,16 @@ nextResetStates vectors.
 The state machine reset flag is propagated and maintained to each state
 individually:
 \begin{lstlisting}[language=modelica]
-  output Boolean activeResetStates[nStates] = {if reset then true else previous(nextResetStates[i]) for i in 1:nStates};
+output Boolean activeResetStates[nStates] = {if reset then true else previous(nextResetStates[i]) for i in 1:nStates};
 \end{lstlisting}
 until a state is eventually executed, then its corresponding reset
 condition is set to false:
 \begin{lstlisting}[language=modelica]
-  Boolean nextResetStates[nStates] = if  active then {if activeState == i then false else activeResetStates[i] for i in 1:nStates}
-   else previous(nextResetStates)
+Boolean nextResetStates[nStates] =
+  if active then
+    {if activeState == i then false else activeResetStates[i] for i in 1:nStates}
+  else
+    previous(nextResetStates)
 \end{lstlisting}
 The second reset mechanism is implemented with the selectedReset~and
 nextReset~variables. If no reset transition is fired, the nextReset is

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -142,14 +142,14 @@ It is possible to omit receiving variables from this list:
 \begin{example}
 The function \lstinline!f! called below has three results and two inputs:
 \begin{lstlisting}[language=modelica]
-  (a, b, c) := f(1.0, 2.0);
-  (x[1], x[2], x[1]) := f(3,4);
+(a, b, c) := f(1.0, 2.0);
+(x[1], x[2], x[1]) := f(3,4);
 \end{lstlisting}
 In the second example above \lstinline!x[1]! is assigned twice -- first
 with the first output and then with the third output. For that case the
 following will give the same result:
 \begin{lstlisting}[language=modelica]
-  (, x[2], x[1]) := f(3,4);
+(, x[2], x[1]) := f(3,4);
 \end{lstlisting}
 \end{example}
 

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -402,8 +402,8 @@ actualStream(c.h_outflow) = if c.m_flow > 0 then inStream(c.h_outflow) else c.h_
 \begin{nonnormative}
 \lstinline!actualStream! is typically used in two contexts:
 \begin{lstlisting}[language=modelica]
-  der(U) = c.m_flow * actualStream(c.h_outflow);  // (1) energy balance equation
-  h_c = actualStream(c.h);                        // (2) monitoring the enthalpy at port c
+der(U) = c.m_flow * actualStream(c.h_outflow);  // (1) energy balance equation
+h_c = actualStream(c.h);                        // (2) monitoring the enthalpy at port c
 \end{lstlisting}
 In the case of equation (1), although \lstinline!actualStream!
 is discontinuous, the product with the flow variable is not, because

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -57,9 +57,9 @@ together with sample and (zero-order) hold elements}
   The \lstinline!when!-clause in the controller could also be removed
   and the controller could just be defined by the equations:
 \begin{lstlisting}[language=modelica]
-  // discrete controller
-  E*xd = A*previous(xd) + B*yd;
-  ud = C*previous(xd) + D*yd;
+// discrete controller
+E*xd = A*previous(xd) + B*yd;
+ud = C*previous(xd) + D*yd;
 \end{lstlisting}
 \item
   \lstinline!previous(xd)! returns the value of \lstinline!xd! at
@@ -300,17 +300,17 @@ defining the operators:
   \end{nonnormative}
   \begin{example}
 \begin{lstlisting}[language=modelica]
-  Real u1;
-  Real u2[4];
-  Complex c;
-  Resistor R;
-  ...
-  y1 = previous(u1);    // fine
-  y2 = previous(u2);    // fine
-  y3 = previous(u2[2]); // fine
-  y4 = previous(c.im);  // fine
-  y5 = previous(2*u);   // error (general expression, no Component Expression)
-  y6 = previous(R);     // error (component, no Component Expression)
+Real u1;
+Real u2[4];
+Complex c;
+Resistor R;
+...
+y1 = previous(u1);    // fine
+y2 = previous(u2);    // fine
+y3 = previous(u2[2]); // fine
+y4 = previous(c.im);  // fine
+y5 = previous(2*u);   // error (general expression, no Component Expression)
+y6 = previous(R);     // error (component, no Component Expression)
 \end{lstlisting}
   \end{example}
 \item[The input argument is a \emph{parameter expression}:]
@@ -323,12 +323,12 @@ defining the operators:
   \end{nonnormative}
   \begin{example}
 \begin{lstlisting}[language=modelica]
-  Real u;
-  parameter Real p=3;
-  ...
-  y1 = subSample(u, factor=3);       // fine (literal)
-  y2 = subSample(u, factor=2*p - 3); // fine (parameter expression)
-  y3 = subSample(u, factor=3*u);     // error (general expression)
+Real u;
+parameter Real p=3;
+...
+y1 = subSample(u, factor=3);       // fine (literal)
+y2 = subSample(u, factor=2*p - 3); // fine (parameter expression)
+y3 = subSample(u, factor=3*u);     // error (general expression)
 \end{lstlisting}
   \end{example}
 \item[The input argument is an \emph{expression}:]
@@ -467,8 +467,8 @@ that is modeled as Boolean in the simulation model.
 \par
 \begin{example*}
 \begin{lstlisting}[language=modelica]
-  Clock c = Clock(angle > 0, 0.1) // before first tick of c:
-                                  // interval(c) = 0.1
+Clock c = Clock(angle > 0, 0.1) // before first tick of c:
+                                // interval(c) = 0.1
 \end{lstlisting}
 
 The implicitly given interval and time shift can be modified by
@@ -493,10 +493,10 @@ String, then this Clock-construct does not associate an integrator with the retu
 \par
 \begin{example*}
 \begin{lstlisting}[language=modelica]
-  Clock c1 = Clock(1,10) // 100 ms, no solver
-  Clock c2 = Clock(c1, "ImplicitTrapezoid");
-    // 100 ms, ImplicitTrapezoid solver
-  Clock c3 = Clock(c2, ""); // 100 ms, no solver
+Clock c1 = Clock(1,10) // 100 ms, no solver
+Clock c2 = Clock(c1, "ImplicitTrapezoid");
+  // 100 ms, ImplicitTrapezoid solver
+Clock c3 = Clock(c2, ""); // 100 ms, no solver
 \end{lstlisting}
 \end{example*}
 \end{tabular}
@@ -729,11 +729,11 @@ base clock.
 \par
 \begin{example*}
 \begin{lstlisting}[language=modelica]
-  Clock u = Clock(x > 0);
-  Clock y1 = subSample(u,4);
-  Clock y2 = superSample(y1,2); // fine; y2 =  subSample(u,2)
-  Clock y3 = superSample(u ,2); // error
-  Clock y4 = superSample(y1,5); // error
+Clock u = Clock(x > 0);
+Clock y1 = subSample(u,4);
+Clock y2 = superSample(y1,2); // fine; y2 =  subSample(u,2)
+Clock y3 = superSample(u ,2); // error
+Clock y4 = superSample(y1,5); // error
 \end{lstlisting}
 \end{example*}
 \\ \hline
@@ -987,38 +987,38 @@ All continuous-time partitions are collected together and form \emph{the} contin
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  // Controller 1
-  ud1 = sample(y,c1);
-  0 = f1(yd1, ud1, previous(yd1));
+// Controller 1
+ud1 = sample(y,c1);
+0 = f1(yd1, ud1, previous(yd1));
 
-  // Controller 2
-  ud2 = superSample(yd1,2);
-  0 = f2(yd2, ud2);
+// Controller 2
+ud2 = superSample(yd1,2);
+0 = f2(yd2, ud2);
 
-  // Continuous-time system
-  u = hold(yd2);
-  0 = f3(der(x1), x1, u);
-  0 = f4(der(x2), x2, x1);
-  0 = f5(der(x3), x3);
-  0 = f6(y, x1, u);
+// Continuous-time system
+u = hold(yd2);
+0 = f3(der(x1), x1, u);
+0 = f4(der(x2), x2, x1);
+0 = f5(der(x3), x3);
+0 = f6(y, x1, u);
 \end{lstlisting}
 
 After base clock partitioning, the following partitions are identified:
 \begin{lstlisting}[language=modelica]
-  // Base partition 1 // clocked partition
-  ud1 = sample (y,c1); // incidence(e) = {ud1}
-  0 = f1(yd1, ud1, previous(ud1)); // incidence(e) = {yd1,ud1}
-  ud2 = superSample (yd1,2); // incidence(e) = {ud2, yd1}
-  0 = f2(yd2, ud2); // incidence(e) = {yd2, ud2}
+// Base partition 1 // clocked partition
+ud1 = sample (y,c1); // incidence(e) = {ud1}
+0 = f1(yd1, ud1, previous(ud1)); // incidence(e) = {yd1,ud1}
+ud2 = superSample (yd1,2); // incidence(e) = {ud2, yd1}
+0 = f2(yd2, ud2); // incidence(e) = {yd2, ud2}
 
-  // Base partition 2 // continuous-time partition
-  u = hold (yd2); // incidence(e) = {u}
-  0 = f3(der(x1), x1, u); // incidence(e) = {x1,u}
-  0 = f4(der(x2), x2, x1); // incidence(e) = {x2,x1}
-  0 = f6(y, x1, u); // incidence(e) = {y,x1,u}
+// Base partition 2 // continuous-time partition
+u = hold (yd2); // incidence(e) = {u}
+0 = f3(der(x1), x1, u); // incidence(e) = {x1,u}
+0 = f4(der(x2), x2, x1); // incidence(e) = {x2,x1}
+0 = f6(y, x1, u); // incidence(e) = {y,x1,u}
 
-  // Identified as separate partition, but belonging to partition 2
-  0 = f5(der(x3), x3); // incidence(e) = {x3}
+// Identified as separate partition, but belonging to partition 2
+0 = f5(der(x3), x3); // incidence(e) = {x3}
 \end{lstlisting}
 \end{example}
 
@@ -1054,21 +1054,21 @@ $E = \bigcup E_{ij}$
 \begin{example}
 After sub-clock partitioning of the example from \autoref{base-clock-partitioning}, the following partitions are identified:
 \begin{lstlisting}[language=modelica]
-  // Base partition 1 (clocked partition)
-  // Sub-clock partition 1.1
-  ud1 = sample (y,c1); // incidence(e) = {ud1}
-  0 = f1(yd1,ud1,previous(yd1)); // incidence(e) = {yd1,ud1}
+// Base partition 1 (clocked partition)
+// Sub-clock partition 1.1
+ud1 = sample (y,c1); // incidence(e) = {ud1}
+0 = f1(yd1,ud1,previous(yd1)); // incidence(e) = {yd1,ud1}
 
-  // Sub-Clock partition 1.2
-  ud2 = superSample (yd1,2); // incidence(e) = {ud2}
-  0 = f2(yd2,ud2); // incidence(e) = {yd2,ud2}
+// Sub-Clock partition 1.2
+ud2 = superSample (yd1,2); // incidence(e) = {ud2}
+0 = f2(yd2,ud2); // incidence(e) = {yd2,ud2}
 
-  // Base partition 2 (no sub-clock partitioning, since continuous-time)
-  u = hold (yd2);
-  0 = f3(der(x1), x1, u);
-  0 = f4(der(x2), x2, x1);
-  0 = f5(der(x3), x3);
-  0 = f6(y, x1, u);
+// Base partition 2 (no sub-clock partitioning, since continuous-time)
+u = hold (yd2);
+0 = f3(der(x1), x1, u);
+0 = f4(der(x2), x2, x1);
+0 = f5(der(x3), x3);
+0 = f6(y, x1, u);
 \end{lstlisting}
 \end{example}
 
@@ -1338,16 +1338,16 @@ with this clock, then the partition is integrated with it.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-  // Continuous PI controller in a clocked partition
-  vd = sample(x2, Clock(Clock(1,10),solverMethod="ImplicitEuler"));
-  e = ref-vd;
-  der(xd) = e/Ti;
-  u = k*(e + xd);
+// Continuous PI controller in a clocked partition
+vd = sample(x2, Clock(Clock(1,10),solverMethod="ImplicitEuler"));
+e = ref-vd;
+der(xd) = e/Ti;
+u = k*(e + xd);
 
-  // Physical model
-  f = hold(u);
-  der(x1) = x2;
-  m*der(x2) = f;
+// Physical model
+f = hold(u);
+der(x1) = x2;
+m*der(x2) = f;
 \end{lstlisting}
 \end{example}
 


### PR DESCRIPTION
In case the indentation inside `lstlisting` environments is just an unintentional consequence of a friendly text editor trying to increase readability of the LaTeX sources, this PR removes such indentation since it also affects the indentation in the typeset documentation.

If the indentation is actually intentional, it might be a good idea to at least write down the rules for when to indent all lines of a listing…

I see at least one reason to avoid listings where all lines are indented, and that is the simplicity of the rule, which gives us a chance to make sure it is applied consistently throughout the specification.
