### PR TITLE
Replace class-name by new name

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1066,8 +1066,8 @@ When creating a component of the given class, the recommended component name is 
 \end{lstlisting}
 
 When creating a component, it is recommended to generate a declaration of the form
-\begin{lstlisting}[language=modelica]
-  prefixes class-name component-name
+\begin{lstlisting}[language=grammar]
+  type-prefix type-specifier component-declaration
 \end{lstlisting}
 
 The following prefixes may be included in the string \lstinline!prefixes!: \lstinline!inner!,

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1548,7 +1548,7 @@ All of these convert-functions only use inheritance among user
 models, and not in the library that is used for the conversion -- thus
 conversions of base-classes will require multiple conversion-calls; this
 ensures that the conversion is independent of the new library structure.
-The class-name used as argument to \lstinline!convertElement! and \lstinline!convertModifiers!
+The name of the class used as argument to \lstinline!convertElement! and \lstinline!convertModifiers!
 is similarly the old name of the class, i.e.\ the name before it is
 possibly converted by \lstinline!convertClass!.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -490,8 +490,8 @@ Then the following applications are equivalent:
 
 A functional input argument to a function is an argument of function
 type. The declared type of such an input formal parameter in a function
-can be the class-name of a partial function that has no replaceable
-elements. It cannot be the class-name of a record or enumeration
+can be the type-specifier of a partial function that has no replaceable
+elements. It cannot be the type-specifier of a record or enumeration
 (i.e., record constructor functions and enumeration type
 conversions are not allowed in this context). Such an input formal
 parameter of function type can also have an optional functional default

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -269,7 +269,7 @@ For a Modelica-package stored as a single file, \filename{A.mo}, the resource
 directory as \filename{A.mo}, but using resources in this variant is not
 recommended since multiple packages will share resources.
 
-In case the class-name contains quoted identifiers, the single-quote `\lstinline!`!'
+In case the name of the class contains quoted identifiers, the single-quote `\lstinline!`!'
 and any reserved characters (`\lstinline!:!', `\lstinline!/!', `\lstinline!?!', `\lstinline!\#!', `\lstinline![!',
 `\lstinline!]!', `\lstinline!@!', `\lstinline!!!', `\lstinline!\$!', `\lstinline!\&!', `\lstinline!(!', `\lstinline!)!', `\lstinline!*!', `\lstinline!+!',
 `\lstinline!,!', `\lstinline!;!', `\lstinline!=!') should be percent-encoded as normal in URIs.


### PR DESCRIPTION
Previously the grammar had class-name, but we have changed to `type-specifier` - which is based on plain `name` and also includes the possibility of leading `.`. However, the specification text still used "class-name" in a few places, and I changed to "type-specifier" where appropriate and in other cases to "name of class" (when it is a fully qualified name without the need for leading  `.`).

I noticed this when looking at one case in https://github.com/modelica/ModelicaSpecification/pull/2595 where it also has wrong language and some other issues in that code-fragment (also corrected).