### PR TITLE
Fix indentation of grammar in text

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -108,7 +108,8 @@ type-prefix :
 
 type-specifier :
   name
-  component-list :
+
+component-list :
   component-declaration { "," component-declaration }
 
 component-declaration :


### PR DESCRIPTION
Correct indentation of grammar fragment in text was.

Based on:
https://github.com/modelica/ModelicaSpecification/pull/2598#pullrequestreview-436162361