### PR TITLE
Make ndims constant.

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1292,6 +1292,14 @@ Constant expressions are:
   \lstinline!edge!, \lstinline!change!, \lstinline!sample!, and \lstinline!pre!, a function or operator with constant
   subexpressions as argument (and no parameters defined in the function)
   is a constant expression.
+\item
+  Some function calls are parameter expressions even if the arguments
+  are not:
+
+  \begin{itemize}
+  \item
+    \lstinline!ndims(A)!
+  \end{itemize}
 \end{itemize}
 
 Components declared as constant shall have an associated declaration
@@ -1321,8 +1329,6 @@ Parameter expressions are:
   are not:
 
   \begin{itemize}
-  \item
-    \lstinline!ndims(A)!
   \item
     \lstinline!cardinality(c)!, see restrictions for use in \autoref{cardinality-deprecated}.
   \item

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1294,7 +1294,6 @@ Constant expressions are:
   is a constant expression.
 \item
   Some function calls are constant expressions regardless of the arguments:
-
   \begin{itemize}
   \item
     \lstinline!ndims(A)!

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1293,8 +1293,7 @@ Constant expressions are:
   subexpressions as argument (and no parameters defined in the function)
   is a constant expression.
 \item
-  Some function calls are parameter expressions even if the arguments
-  are not:
+  Some function calls are constant expressions regardless of the arguments:
 
   \begin{itemize}
   \item


### PR DESCRIPTION
We need to make ndims(A) constant.

The reason is that otherwise the new promote-logic doesn't work as it is used as an argument to promote that need to be a constant that can be evaluated during translation.
https://github.com/modelica/ModelicaSpecification/pull/2590

I'm aware that the phrase "some function calls" and only "ndims" as item may be odd, but to me ndims() means every function call of ndims and thus it makes sense.