### PR TITLE
Say 'hold extrapolation' instead of 'constant extrapolation'

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -236,7 +236,7 @@ used, in other words the value of the clocked variable from the last event insta
   \begin{center}
     \includegraphics[width=3in]{clocked}
   \end{center}
-  \caption{A clocked variable.  The constant extrapolation of the value at the last event instant is illustrated with dashed green lines.}\doublelabel{fig:clocked-variable}
+  \caption{A clocked variable.  The \lstinline!hold! extrapolation of the value at the last event instant is illustrated with dashed green lines.}\doublelabel{fig:clocked-variable}
 \end{figure}
 
 \subsection{Base-Clock and Sub-Clock Partitions}\doublelabel{base-clock-and-sub-clock-partitions}


### PR DESCRIPTION
Addressing comment by @HansOlsson that got lost in #2601.