### PR TITLE
Use cleveref.sty for cross references

### DIFF
--- a/.CI/latexml/Dockerfile
+++ b/.CI/latexml/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i s,http://archive.ubuntu.com/ubuntu/,mirror://mirrors.ubuntu.com/mirro
  && $INSTALL/install-tl --profile texlive.profile \
  && rm texlive.profile \
  && tlmgr update --self --all --reinstall-forcibly-removed \
- && tlmgr install latexmk listings xcolor float multirow tocloft parskip etoolbox \
+ && tlmgr install latexmk listings cleveref xcolor float multirow tocloft parskip etoolbox \
  && cpanm JSON \
  && cpanm LaTeXML \
  && apt-get autoremove -qy make gcc curl wget git cpanminus libxml2-dev libxslt-dev \

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -47,7 +47,7 @@ taken in the preparation of this document no responsibility for errors
 or omissions is assumed.
 
 The contributors to this and to previous versions of this document are
-listed in \autoref{modelica-revision-history}. All contributors worked voluntarily and without
+listed in \cref{modelica-revision-history}. All contributors worked voluntarily and without
 compensation.
 
 \tableofcontents

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -508,7 +508,7 @@ P\textsubscript{1} and P\textsubscript{12} as well as between
 P\textsubscript{34} and P\textsubscript{4}.
 
 The values of the \lstinline!EllipseClosure! enumeration specify if and how the
-endpoints of an elliptical arc are to be joined (see \cref{ellipse} Ellipse).
+endpoints of an elliptical arc are to be joined (see \cref{ellipse}).
 
 \begin{lstlisting}[language=modelica]
 type Arrow = enumeration(None, Open, Filled, Half);

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -4,12 +4,12 @@
 Annotations are intended for storing extra information about a model,
 such as graphics, documentation or versioning, etc. A Modelica tool is
 free to define and use other annotations, in addition to those defined
-here, according to \autoref{vendor-specific-annotations}. The only requirement is that any tool
+here, according to \cref{vendor-specific-annotations}. The only requirement is that any tool
 shall save files with all annotations from this chapter and all
 vendor-specific annotations intact. To ensure this, annotations must be
 represented with constructs according to the Modelica grammar (for
 replaceable class declarations with a constraining-clause also refer to
-\autoref{constraining-clause-annotations}). The specification in this document defines the
+\cref{constraining-clause-annotations}). The specification in this document defines the
 semantic meaning if a tool implements any of these annotations.
 
 \section{Vendor-Specific Annotations}\doublelabel{vendor-specific-annotations}
@@ -53,9 +53,9 @@ unspecified. Within a string of the \lstinline!Documentation! annotation, the
 tags \lstinline!<HTML>! and \lstinline!</HTML>! or
 \lstinline!<html>! and \lstinline!</html>! define
 optionally begin and end of content that is HTML encoded. For external
-links see \autoref{external-resources}. Links to Modelica classes may be defined with
+links see \cref{external-resources}. Links to Modelica classes may be defined with
 the HTML link command using scheme \lstinline!Modelica!
-(using its lower case form in the URI, see \autoref{external-resources}), e.g.,
+(using its lower case form in the URI, see \cref{external-resources}), e.g.,
 \begin{lstlisting}[language=modelica]
 <a href="modelica://MultiBody.Tutorial">MultiBody.Tutorial</a>
 \end{lstlisting}
@@ -436,7 +436,7 @@ defined by the following priority:
 \item
   The coordinate systems of the first base-class where the extent on the
   extends-clause specifies a null-region (if any). Note that null-region
-  is the default for base-classes, see \autoref{extends-clause}.
+  is the default for base-classes, see \cref{extends-clause}.
 \item
   The default coordinate system CoordinateSystem(extent=\{\{-100,
   -100\}, \{100, 100\}\}).
@@ -508,7 +508,7 @@ P\textsubscript{1} and P\textsubscript{12} as well as between
 P\textsubscript{34} and P\textsubscript{4}.
 
 The values of the \lstinline!EllipseClosure! enumeration specify if and how the
-endpoints of an elliptical arc are to be joined (see \autoref{ellipse} Ellipse).
+endpoints of an elliptical arc are to be joined (see \cref{ellipse} Ellipse).
 
 \begin{lstlisting}[language=modelica]
 type Arrow = enumeration(None, Open, Filled, Half);
@@ -592,7 +592,7 @@ layer.
 
 \subsection{Extends clause}\doublelabel{extends-clause}
 
-Each extends-clause (and short-class-definition, as stated in \autoref{annotations-for-graphical-objects})
+Each extends-clause (and short-class-definition, as stated in \cref{annotations-for-graphical-objects})
 may have layer specific annotations which describe
 the rendering of the base class' icon and diagram layers in the
 subclass.
@@ -618,7 +618,7 @@ visible but graphical primitives are not.
   default), the base class contents is mapped to the same coordinates in
   the derived class, and the coordinate system (including
   preserveAspectRatio) can be inherited as described in
-  \autoref{coordinate-systems}.
+  \cref{coordinate-systems}.
 \item
   If the extent of the extends-clause defines a non-null region, the
   base class coordinate system is mapped to the region specified by the
@@ -907,7 +907,7 @@ rotation.
 
 When the attribute \lstinline!fileName! is specified, the string refers to an
 external file containing image data. The mapping from the string to the
-file is specified for some URIs in \autoref{external-resources}. The supported file
+file is specified for some URIs in \cref{external-resources}. The supported file
 formats include \lstinline!PNG!, \lstinline!BMP!, \lstinline!JPEG!,
 and \lstinline!SVG!.
 
@@ -1083,7 +1083,7 @@ annotation(missingInnerMessage = "message")
 
 When an \lstinline!outer! component of the class does not have a corresponding \lstinline!inner!
 component, the literal string message may be used as part of a diagnostic message (together with appropriate context), see
-\autoref{instance-hierarchy-name-lookup-of-inner-declarations}.
+\cref{instance-hierarchy-name-lookup-of-inner-declarations}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -1216,7 +1216,7 @@ presented for a vector of three elements and generate values 0..255 (the
 annotation should be useable both for vectors of Integers and Reals).
 
 The annotation \lstinline!groupImage! references an image using an URI (see
-\autoref{external-resources}), and the image is intended to be shown together with the
+\cref{external-resources}), and the image is intended to be shown together with the
 parameter-group (only one image per group is supported). Disabling the
 input field will not disable the image.
 
@@ -1477,7 +1477,7 @@ annotations:
   to-tag is missing this is the \lstinline!CURRENT-VERSION-NUMBER!) of the current
   class by applying the given conversion rules. The script consists of
   an unordered sequence of  \lstinline!conversionRule();! (and optionally Modelica
-  comments). The  \lstinline!conversionRule! functions are defined in \autoref{conversion-rules}.
+  comments). The  \lstinline!conversionRule! functions are defined in \cref{conversion-rules}.
 
   \begin{nonnormative}
   The to-tag is added for clarity and optionally allows a tool to convert in multiple steps.
@@ -1539,7 +1539,7 @@ Whenever possible tools should preserve the original style of the model, e.g.\ u
 \end{nonnormative}
 
 These functions can be called with literal strings or array of strings
-and vectorize according to \autoref{scalar-functions-applied-to-array-arguments}.
+and vectorize according to \cref{scalar-functions-applied-to-array-arguments}.
 
 All of these convert-functions only use inheritance among user
 models, and not in the library that is used for the conversion -- thus
@@ -1817,7 +1817,7 @@ The meaning of these annotation is:
 \begin{itemize}
 \item
   \lstinline!version! is the version number of the released library,
-  see \autoref{version-handling}.
+  see \cref{version-handling}.
 \item
   \lstinline!versionDate! is the date in UTC format (according to ISO
   8601) when the library was released. This string is updated by the
@@ -1937,13 +1937,13 @@ The items of the Access enumeration have the following meaning:
   \lstinline!Access.icon!\\
   The class can be instantiated and public parameter, constant, input,
   output variables as well as public connectors can be accessed, as well
-  as the icon annotation, as defined in \autoref{annotations-for-graphical-objects} (the declared
+  as the icon annotation, as defined in \cref{annotations-for-graphical-objects} (the declared
   information of these elements can be shown). Additionally, the class
   name and its description text can be accessed.
 \item
   \lstinline!Access.documentation!\\
   Same as \lstinline!Access.icon! and additionally the documentation annotation (as
-  defined in \autoref{annotations-for-documentation}) can be accessed. HTML-generation in the
+  defined in \cref{annotations-for-documentation}) can be accessed. HTML-generation in the
   documentation annotation is normally performed before encryption, but
   the generated HTML is intended to be used with the encrypted package.
   Thus the HTML-generation should use the same access as the encrypted
@@ -2151,20 +2151,20 @@ end MyLibraryAuthorization_Tool;
 
 \subsection{Function Derivative Annotations}\doublelabel{function-derivative-annotations}
 
-See \autoref{using-the-derivative-annotation}
+See \cref{using-the-derivative-annotation}
 
 \subsection{Inverse Function Annotation}\doublelabel{inverse-function-annotation}
 
-See \autoref{declaring-inverses-of-functions}.
+See \cref{declaring-inverses-of-functions}.
 
 \subsection{External Function Annotations}\doublelabel{external-function-annotations}
 
-See \autoref{annotations-for-external-libraries-and-include-files}.
+See \cref{annotations-for-external-libraries-and-include-files}.
 
 \section{Annotation Choices for Modifications and Redeclarations}\doublelabel{annotation-choices-for-modifications-and-redeclarations}
 
-See \autoref{annotation-choices-for-suggested-redeclarations-and-modifications}.
+See \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
 
 \section{Annotation for External Libraries and Include Files}\doublelabel{annotation-for-external-libraries-and-include-files}
 
-See \autoref{annotations-for-external-libraries-and-include-files}.
+See \cref{annotations-for-external-libraries-and-include-files}.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1,5 +1,5 @@
 
-\chapter{Annotations}\doublelabel{annotations}
+\chapter{Annotations}\label{annotations}
 
 Annotations are intended for storing extra information about a model,
 such as graphics, documentation or versioning, etc. A Modelica tool is
@@ -12,7 +12,7 @@ replaceable class declarations with a constraining-clause also refer to
 \cref{constraining-clause-annotations}). The specification in this document defines the
 semantic meaning if a tool implements any of these annotations.
 
-\section{Vendor-Specific Annotations}\doublelabel{vendor-specific-annotations}
+\section{Vendor-Specific Annotations}\label{vendor-specific-annotations}
 
 A vendor may -- anywhere inside an annotation -- add specific, possibly
 undocumented, annotations which are not intended to be interpreted by
@@ -39,7 +39,7 @@ for the \lstinline!Rectangle! primitive using the simple variant of
 vendor-specific annotations.
 \end{example}
 
-\section{Annotations for Documentation}\doublelabel{annotations-for-documentation}
+\section{Annotations for Documentation}\label{annotations-for-documentation}
 
 \begin{lstlisting}[language=grammar]
 documentation-annotation:
@@ -96,7 +96,7 @@ A tool may display such classes in special ways.  For example, the description t
 of the class names, and if no icon is defined, a special information default icon may be displayed in the package browser.
 \end{nonnormative}
 
-\section{Annotations for Code Generation}\doublelabel{annotations-for-code-generation}
+\section{Annotations for Code Generation}\label{annotations-for-code-generation}
 \begin{lstlisting}[language=grammar]
 code-annotation:
    annotation"(" codeGenerationFlag "=" ( false | true ) ")"
@@ -259,7 +259,7 @@ This annotation is used by many functions of the \lstinline!Modelica.Fluid! libr
 arguments to these functions are usually constant.
 \end{nonnormative}
 
-\section{Annotations for Simulation Experiments}\doublelabel{annotations-for-simulation-experiments}
+\section{Annotations for Simulation Experiments}\label{annotations-for-simulation-experiments}
 \begin{lstlisting}[language=grammar]
 experiment-annotation:
    annotation "(" "experiment" [ "(" [experimentOption
@@ -278,7 +278,7 @@ The experiment annotation defines the default start time (StartTime) in
 relative integration tolerance (Tolerance) for simulation experiments to
 be carried out with the model or block at hand. If StartTime is not specified it is assumed to be \lstinline!0.0!.
 
-\section{Annotation for single use of class}\doublelabel{annotation-for-single-use-of-class}
+\section{Annotation for single use of class}\label{annotation-for-single-use-of-class}
 
 For state machines it is useful to have single instances of local
 classes. This can be done using:
@@ -292,7 +292,7 @@ same scope as the class is defined. The intent is to remove the class
 when the component is removed and to prevent duplication of the
 component.
 
-\section{Annotations for Graphical Objects}\doublelabel{annotations-for-graphical-objects}
+\section{Annotations for Graphical Objects}\label{annotations-for-graphical-objects}
 
 A graphical representation of a class consists of two abstraction
 layers, icon layer and diagram layer showing graphical objects,
@@ -344,7 +344,7 @@ directly in classes (e.g.\ not on components or connections). The allowed
 annotations for a short class definition is the union of the allowed
 annotations in classes and on extends-clauses.
 
-\subsection{Common Definitions}\doublelabel{common-definitions}
+\subsection{Common Definitions}\label{common-definitions}
 
 The following common definitions are used to define graphical
 annotations in the later sections.
@@ -375,7 +375,7 @@ relative the \lstinline!origin! attribute, which by default is \{0, 0\}.
 The \lstinline!rotation! attribute specifies the rotation of the graphical item
 counter-clockwise around the point defined by the \lstinline!origin! attribute.
 
-\subsubsection{Coordinate Systems}\doublelabel{coordinate-systems}
+\subsubsection{Coordinate Systems}\label{coordinate-systems}
 
 Each of the layers has its own coordinate system. A coordinate system is
 defined by the coordinates of two points, the left (x1) lower (y1)
@@ -442,7 +442,7 @@ defined by the following priority:
   -100\}, \{100, 100\}\}).
 \end{enumerate}
 
-\subsubsection{Graphical Properties}\doublelabel{graphical-properties}
+\subsubsection{Graphical Properties}\label{graphical-properties}
 
 Properties of graphical objects and connection lines are described using
 the following attribute types.
@@ -530,7 +530,7 @@ The extent/points of the filled shape describe the theoretical
 zero-thickness filled shape, and the actual rendered border is then half
 inside and half outside the extent.
 
-\subsection{Component Instance}\doublelabel{component-instance}
+\subsection{Component Instance}\label{component-instance}
 
 A component instance can be placed within a diagram or icon layer. It
 has an annotation with a \lstinline!Placement! modifier to describe the placement.
@@ -590,7 +590,7 @@ layer. Public connectors are shown in both the diagram layer and the
 icon layer. Non-connector components are only shown in the diagram
 layer.
 
-\subsection{Extends clause}\doublelabel{extends-clause}
+\subsection{Extends clause}\label{extends-clause}
 
 Each extends-clause (and short-class-definition, as stated in \cref{annotations-for-graphical-objects})
 may have layer specific annotations which describe
@@ -647,7 +647,7 @@ from \lstinline!B! are rescaled, and the icon of \lstinline!A! contains the grap
 from \lstinline!A! (but neither from \lstinline!B! nor from \lstinline!C!).
 \end{example}
 
-\subsection{Connections}\doublelabel{connections1}
+\subsection{Connections}\label{connections1}
 
 A connection is specified with an annotation containing a \lstinline!Line! primitive
 and optionally a Text-primitive, as specified below.
@@ -704,12 +704,12 @@ ending at \{-6, 3\}+\{-25, -65\} and 4 vertical units of space for the text.
 Using a height of zero, such as \lstinline!extent=[-6,3; -6,3]! is deprecated, but gives similar result.
 \end{example}
 
-\subsection{Graphical primitives}\doublelabel{graphical-primitives}
+\subsection{Graphical primitives}\label{graphical-primitives}
 
 This section describes the graphical primitives that can be used to
 define the graphical objects in an annotation.
 
-\subsubsection{Line}\doublelabel{line}
+\subsubsection{Line}\label{line}
 
 A line is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -743,7 +743,7 @@ mid-line and with Open or Filled extend 1~mm to each side, in total making the b
   The lines for the Open and Half variants are drawn with lineThickness.
 \end{itemize}
 
-\subsubsection{Polygon}\doublelabel{polygon}
+\subsubsection{Polygon}\label{polygon}
 
 A polygon is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -757,7 +757,7 @@ end Polygon;
 The polygon is automatically closed, if the first and the last points
 are not identical.
 
-\subsubsection{Rectangle}\doublelabel{rectangle}
+\subsubsection{Rectangle}\label{rectangle}
 
 A rectangle is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -773,7 +773,7 @@ The \lstinline!extent! attribute specifies the bounding box of the rectangle. If
 \lstinline!radius! attribute is specified, the rectangle is drawn with rounded
 corners of the given radius.
 
-\subsubsection{Ellipse}\doublelabel{ellipse}
+\subsubsection{Ellipse}\label{ellipse}
 
 An ellipse is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -814,7 +814,7 @@ and \lstinline!fillPattern! being ignored, making it impossible to draw a filled
 is equivalent in this case, since the chord will be of zero length.
 \end{nonnormative}
 
-\subsubsection{Text}\doublelabel{text}
+\subsubsection{Text}\label{text}
 
 A text string is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -884,7 +884,7 @@ or treat as if font-name was empty.
 
 The style attribute \lstinline!textStyle! specifies variations of the font.
 
-\subsubsection{Bitmap}\doublelabel{bitmap}
+\subsubsection{Bitmap}\label{bitmap}
 
 A bitmap image is specified as follows:
 \begin{lstlisting}[language=modelica]
@@ -919,7 +919,7 @@ The image is represented as a Base64 encoding of the image file format
 The image is uniformly scaled (preserving the aspect ratio) so it exactly fits within the extent (touching the
 extent along one axis).  The center of the image is positioned at the center of the extent.
 
-\subsection{Variable Graphics and Schematic Animation}\doublelabel{variable-graphics-and-schematic-animation}
+\subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
 Any value (coordinates, color, text, etc.) in graphical annotations can
 be dependent on class variables using the \lstinline!DynamicSelect! expression.
@@ -943,7 +943,7 @@ annotation (
 \end{lstlisting}
 \end{example}
 
-\subsection{User input}\doublelabel{user-input}
+\subsection{User input}\label{user-input}
 
 It is possible to interactively modify variables during a simulation.
 The variables may either be parameters, discrete variables or states.
@@ -954,7 +954,7 @@ may be associated with a \lstinline!GraphicItem! or a component as an array name
 graphic primitive, an attribute of a component annotation or as an
 attribute of the layer annotation of a class.
 
-\subsubsection{Mouse input}\doublelabel{mouse-input}
+\subsubsection{Mouse input}\label{mouse-input}
 
 A Boolean variable can be changed when the cursor is held over a
 graphical item or component and the selection button is pressed if the
@@ -1016,7 +1016,7 @@ record OnMouseMoveYSetReal
   Real maxValue;
 end OnMouseMoveYSetReal;
 \end{lstlisting}
-\subsubsection{Edit input}\doublelabel{edit-input}
+\subsubsection{Edit input}\label{edit-input}
 
 The \lstinline!OnMouseDownEditInteger! interaction object presents an input field
 when the graphical item or component is clicked on. The field shows the
@@ -1049,7 +1049,7 @@ record OnMouseDownEditString
   String variable "Name of variable to change";
 end OnMouseDownEditString;
 \end{lstlisting}
-\section{Annotations for the Graphical User Interface}\doublelabel{annotations-for-the-graphical-user-interface}
+\section{Annotations for the Graphical User Interface}\label{annotations-for-the-graphical-user-interface}
 
 A class may have the following annotations to define properties of the
 graphical user interface:
@@ -1424,7 +1424,7 @@ equation
 \end{lstlisting}
 \end{nonnormative}
 
-\section{Annotations for Version Handling}\doublelabel{annotations-for-version-handling}
+\section{Annotations for Version Handling}\label{annotations-for-version-handling}
 
 A top-level package or model can specify the version of top-level
 classes it uses, its own version number, and if possible how to convert
@@ -1432,7 +1432,7 @@ from previous versions. This can be used by a tool to guarantee that
 consistent versions are used, and if possible to upgrade usage from an
 earlier version to a current one.
 
-\subsection{Version Numbering}\doublelabel{version-numbering}
+\subsection{Version Numbering}\label{version-numbering}
 
 Version numbers are of the forms:
 \begin{itemize}
@@ -1452,7 +1452,7 @@ names, and follow the corresponding pre-release versions. The
 pre-release versions of the same main release version are internally
 ordered alphabetically.
 
-\subsection{Version Handling}\doublelabel{version-handling}
+\subsection{Version Handling}\label{version-handling}
 
 In a top-level class, the version number and the dependency to earlier
 versions of this class are defined using one or more of the following
@@ -1521,7 +1521,7 @@ Modelica library and can be upgraded using the given script, and model
 required when upgrading.
 \end{example}
 
-\subsubsection{Conversion rules}\doublelabel{conversion-rules}
+\subsubsection{Conversion rules}\label{conversion-rules}
 
 There are a number of functions: \lstinline!convertClass!, \lstinline!convertClassIf!,
 \lstinline!convertElement!, \lstinline!convertModifiers!, \lstinline!convertMessage! defined as follows. The
@@ -1555,7 +1555,7 @@ version of the library (by suitable modifications of the lookup).  Another alter
 of the library during the conversion.
 \end{nonnormative}
 
-\paragraph*{convertClass("OldClass", "NewClass")}\doublelabel{convertclassoldclassnewclass}
+\paragraph*{convertClass("OldClass", "NewClass")}\label{convertclassoldclassnewclass}
 
 Convert class \lstinline!OldClass! to \lstinline!NewClass!.
 
@@ -1573,7 +1573,7 @@ This ensures that for example \lstinline!Modelica.SIunits.Length! is converted t
 and \lstinline!Modelica.SIunits.Icons! is converted to \lstinline!Modelica.SIunits.Icons!.
 \end{example}
 
-\paragraph*{convertClassIf("OldClass", "oldElement", "whenValue", "NewClass")}\doublelabel{convertclassifoldclass-oldelement-whenvalue-newclass}
+\paragraph*{convertClassIf("OldClass", "oldElement", "whenValue", "NewClass")}\label{convertclassifoldclass-oldelement-whenvalue-newclass}
 
 Convert class \lstinline!OldClass! to \lstinline!NewClass! if the literal modifier for
 \lstinline!oldElement! has the value \lstinline!whenValue!, and also remove the modifier for
@@ -1588,7 +1588,7 @@ For string elements the value argument to \lstinline!convertClassIf! shall be up
 and for enumeration literals only the enumeration literal part of the old value matters, e.g., \lstinline!red!
 for \lstinline!"Colors.red"!.
 
-\paragraph*{convertElement("OldClass", "OldName", "NewName")}\doublelabel{convertelementoldclassoldnamenewname}
+\paragraph*{convertElement("OldClass", "OldName", "NewName")}\label{convertelementoldclassoldnamenewname}
 
 In \lstinline!OldClass! convert element \lstinline!OldName! to \lstinline!NewName!.
 Both \lstinline!OldName! and \lstinline!NewName!
@@ -1623,7 +1623,7 @@ function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mu=4);
 \end{lstlisting}
 \end{example}
 
-\paragraph*{convertModifiers}\doublelabel{convertmodifiers}
+\paragraph*{convertModifiers}\label{convertmodifiers}
 
 \begin{lstlisting}[language=modelica]
 convertModifiers("OldClass",
@@ -1745,7 +1745,7 @@ in the original library where \lstinline!DC_ElectricalExcited! inherits from \ls
 However, the inheritance among the models to convert (in this case \lstinline!B! inherits from \lstinline!A!) should be handled.
 \end{example}
 
-\paragraph*{convertMessage("OldClass", "Failed Message");}\doublelabel{convertmessageoldclass-failed-message}
+\paragraph*{convertMessage("OldClass", "Failed Message");}\label{convertmessageoldclass-failed-message}
 
 For any use of \lstinline!OldClass! (or element of \lstinline!OldClass!) report that conversion
 could not be applied with the given message.
@@ -1755,7 +1755,7 @@ This may be useful if there is no possibility to convert a specific class.  An a
 cases, which may be more work but allows users to directly run the models after the conversion and later convert them.
 \end{nonnormative}
 
-\subsection{Mapping of Versions to File System}\doublelabel{mapping-of-versions-to-file-system}
+\subsection{Mapping of Versions to File System}\label{mapping-of-versions-to-file-system}
 
 A top-level class, \lstinline!IDENT!, with version \lstinline!VERSION-NUMBER! can be stored in
 one of the following ways in a directory given in the \lstinline!MODELICAPATH!:
@@ -1776,7 +1776,7 @@ one of the following ways in a directory given in the \lstinline!MODELICAPATH!:
 
 This allows a tool to access multiple versions of the same package.
 
-\subsection{Version Date and Build Information}\doublelabel{version-date-and-build-information}
+\subsection{Version Date and Build Information}\label{version-date-and-build-information}
 
 Besides version information, a top level class can have additionally the
 following top-level annotations to specify associated information to the
@@ -1860,7 +1860,7 @@ the \lstinline!uses! annotation (together with the version number).
 It is recommended that tools do not automatically store \lstinline!versionBuild! and \lstinline!dateModified! in the \lstinline!uses! annotation.
 \end{nonnormative}
 
-\section{Annotations for Access Control to Protect Intellectual Property}\doublelabel{annotations-for-access-control-to-protect-intellectual-property}
+\section{Annotations for Access Control to Protect Intellectual Property}\label{annotations-for-access-control-to-protect-intellectual-property}
 
 This section presents annotations to define the protection and the
 licensing of packages. The goal is to unify basic mechanisms to control
@@ -1914,7 +1914,7 @@ Protection and licensing are both defined inside the \lstinline!Protection! anno
 annotation(Protection($\ldots$));
 \end{lstlisting}
 
-\subsection{Protection of Classes}\doublelabel{protection-of-classes}
+\subsection{Protection of Classes}\label{protection-of-classes}
 
 A class may have the following annotations to define what parts of a
 class are visible, and only the parts explicitly listed as visible below can be accessed
@@ -2025,7 +2025,7 @@ end CommercialFluid;
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{Licensing}\doublelabel{licensing}
+\subsection{Licensing}\label{licensing}
 
 In this section annotations within the \lstinline!Protection! annotation are
 defined to restrict the usage of the encrypted package:
@@ -2147,24 +2147,24 @@ end MyLibraryAuthorization_Tool;
 \end{lstlisting}
 \end{example}
 
-\section{Annotations for Functions}\doublelabel{annotations-for-functions}
+\section{Annotations for Functions}\label{annotations-for-functions}
 
-\subsection{Function Derivative Annotations}\doublelabel{function-derivative-annotations}
+\subsection{Function Derivative Annotations}\label{function-derivative-annotations}
 
 See \cref{using-the-derivative-annotation}
 
-\subsection{Inverse Function Annotation}\doublelabel{inverse-function-annotation}
+\subsection{Inverse Function Annotation}\label{inverse-function-annotation}
 
 See \cref{declaring-inverses-of-functions}.
 
-\subsection{External Function Annotations}\doublelabel{external-function-annotations}
+\subsection{External Function Annotations}\label{external-function-annotations}
 
 See \cref{annotations-for-external-libraries-and-include-files}.
 
-\section{Annotation Choices for Modifications and Redeclarations}\doublelabel{annotation-choices-for-modifications-and-redeclarations}
+\section{Annotation Choices for Modifications and Redeclarations}\label{annotation-choices-for-modifications-and-redeclarations}
 
 See \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
 
-\section{Annotation for External Libraries and Include Files}\doublelabel{annotation-for-external-libraries-and-include-files}
+\section{Annotation for External Libraries and Include Files}\label{annotation-for-external-libraries-and-include-files}
 
 See \cref{annotations-for-external-libraries-and-include-files}.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -50,10 +50,10 @@ that is an enumeration type or subtype of the \lstinline!Boolean! type.
 
 Colon (\lstinline!:!) indicates that the dimension upper bound is unknown and is a subtype of
 \lstinline!Integer!. The size of such a variable can be determined from its binding equation, or the size
-of any of its array attributes --- see also \autoref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
+of any of its array attributes --- see also \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 The size cannot be determined from other equations or algorithm.
 
-Upper and lower array dimension index bounds are described in \autoref{array-dimension-lower-and-upper-index-bounds}.
+Upper and lower array dimension index bounds are described in \cref{array-dimension-lower-and-upper-index-bounds}.
 
 An array indexed by \lstinline!Boolean! or enumeration type can only be used in the following ways:
 \begin{itemize}
@@ -178,7 +178,7 @@ The lower and upper index bounds for a dimension of an array indexed by \lstinli
 \section{Flexible Array Sizes}\doublelabel{flexible-array-sizes}
 
 Regarding flexible array sizes and resizing of arrays in functions, see
-\autoref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
+\cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 
 \section{Built-in Array Functions}\doublelabel{built-in-array-functions}
 
@@ -205,7 +205,7 @@ can change matrix-equations in subtle ways (e.g.\ changing inner products to mat
 
 \begin{nonnormative}
 Some examples of using the functions defined in the following
-\autoref{array-dimension-and-size-functions} to \autoref{matrix-and-vector-algebra-functions}:
+\cref{array-dimension-and-size-functions} to \cref{matrix-and-vector-algebra-functions}:
 \begin{lstlisting}[language=modelica]
 Real x[4,1,6];
 size(x,1) = 4;
@@ -268,7 +268,7 @@ from its arguments. Most of the constructor functions in the table below
 construct an array by filling in values according to a certain pattern,
 in several cases just giving all array elements the same value. The
 general array constructor with syntax \lstinline!array! (\ldots{}) or \{\ldots{}\}
-is described in \autoref{vector-matrix-and-array-constructors}.
+is described in \cref{vector-matrix-and-array-constructors}.
 
 \begin{longtable}[]{|l|p{11cm}|}
 \caption{Specialized array constructor functions.}\\
@@ -310,7 +310,7 @@ It is required that $n \geq 2$.  The arguments $x_{1}$ and $x_{2}$ shall be nume
 
 A reduction function ``reduces'' an array (or several scalars) to one value (normally a scalar, but the \lstinline!sum! reduction function may give an array as result
 and also be applied to an operator record).  Note that none of these operators (particularly \lstinline!min! and \lstinline!max!) generate events themselves (but arguments
-could generate events).  The restriction on the type of the input in \autoref{reduction-expressions} for reduction expressions also applies to the array elements/scalar
+could generate events).  The restriction on the type of the input in \cref{reduction-expressions} for reduction expressions also applies to the array elements/scalar
 inputs for the reduction operator with the same name.
 
 The \lstinline!sum! reduction function (both variants) may be applied to an operator record, provided that the operator record defines \lstinline!'0'! and \lstinline!'+'!.
@@ -335,7 +335,7 @@ Returns the least element of the scalars \lstinline!x! and \lstinline!y!; as def
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the least value (as defined by \lstinline!<!) of the scalar expression
+Also described in \cref{reduction-expressions}.  Returns the least value (as defined by \lstinline!<!) of the scalar expression
 \lstinline!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
 \end{tabular}\\ \hline
 \lstinline!max(A)!
@@ -353,7 +353,7 @@ Returns the greatest element of the scalars \lstinline!x! and \lstinline!y!; as 
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the greatest value (as defined by \lstinline!>!) of the scalar expression
+Also described in \cref{reduction-expressions}.  Returns the greatest value (as defined by \lstinline!>!) of the scalar expression
 \lstinline!e(i, $\ldots$, j)! evaluated for all combinations of \lstinline!i! in \lstinline!u!, \ldots, \lstinline!j! in \lstinline!v!.
 \end{tabular}\\ \hline
 \lstinline!sum(A)!
@@ -369,7 +369,7 @@ Returns the scalar sum of all the elements of array expression \lstinline!A!:\\
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the sum of the expression \lstinline!e(i, $\ldots$, j)! evaluated for all
+Also described in \cref{reduction-expressions}.  Returns the sum of the expression \lstinline!e(i, $\ldots$, j)! evaluated for all
 combinations of \lstinline!i in u!, $\ldots$, \lstinline!j in v!: For \lstinline!Integer! indexing this is
 \begin{lstlisting}[language=modelica]
 e(u[1], $\ldots$, v[1]) + e(u[2], $\ldots$, v[1]) + $\ldots$
@@ -392,7 +392,7 @@ Returns the scalar product of all the elements of array expression \lstinline!A!
 \end{tabular}
 &
 \begin{tabular}{@{}p{10cm}@{}}
-Also described in \autoref{reduction-expressions}.  Returns the product of the scalar expression \lstinline!e(i, $\ldots$, j)! evaluated for
+Also described in \cref{reduction-expressions}.  Returns the product of the scalar expression \lstinline!e(i, $\ldots$, j)! evaluated for
 all combinations of \lstinline!i in u!, \ldots, \lstinline!j in v!: For \lstinline!Integer! indexing this is
 \begin{lstlisting}[language=modelica]
 e(u[1], $\ldots$, v[1]) * e(u[2], $\ldots$, v[1]) * $\ldots$
@@ -427,14 +427,14 @@ loop-variable may hide other variables, as in for-clauses. The result
 depends on the \lstinline!function-name!, and currently the only legal
 function-names are the built-in operators \lstinline!array!, \lstinline!sum!,
 \lstinline!product!, \lstinline!min!, and
-\lstinline!max!. For array, see \autoref{vector-matrix-and-array-constructors}. If \lstinline!function-name! is
+\lstinline!max!. For array, see \cref{vector-matrix-and-array-constructors}. If \lstinline!function-name! is
 \lstinline!sum!, \lstinline!product!, \lstinline!min!,
 or \lstinline!max! the result is of the same type as \lstinline!expression1! and is constructed
 by evaluating \lstinline!expression1! for each value of the loop-variable and
 computing the \lstinline!sum!, \lstinline!product!, \lstinline!min!, or
 \lstinline!max! of the computed elements. For
-deduction of ranges, see \autoref{implicit-iteration-ranges}; and for using types as ranges
-see \autoref{types-as-iteration-ranges}.
+deduction of ranges, see \cref{implicit-iteration-ranges}; and for using types as ranges
+see \cref{types-as-iteration-ranges}.
 
 \begin{longtable}{|p{3cm}|p{5cm}|p{6cm}|}
 \caption{Reduction expressions with iterators.}\\
@@ -525,7 +525,7 @@ The constructor function \lstinline!array(A, B, C, $\ldots$)! constructs an arra
   Size matching: All arguments must have the same sizes, i.e.,
   \lstinline!size(A)! = \lstinline!size(B)! = \lstinline!size(C)! = \ldots
 \item
-  All arguments must be type compatible expressions (\autoref{type-compatible-expressions}) giving the type of the elements.  The data type of the result array is the
+  All arguments must be type compatible expressions (\cref{type-compatible-expressions}) giving the type of the elements.  The data type of the result array is the
   maximally expanded type of the arguments. \lstinline!Real! and \lstinline!Integer! subtypes can be mixed resulting in a \lstinline!Real! result array where the
   \lstinline!Integer! numbers have been transformed to \lstinline!Real! numbers.
 \item
@@ -582,8 +582,8 @@ elements of array\_expression; and can be simple type as well as a
 record type. The loop-variable will have the same type for the entire
 loop - i.e.\ for an array\_expression \{1,3.2\} the iterator will have
 the type of the type-compatible expression (Real) for all iterations.
-For deduction of ranges, see \autoref{implicit-iteration-ranges}; and for using types as
-range see \autoref{types-as-iteration-ranges}.
+For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using types as
+range see \cref{types-as-iteration-ranges}.
 
 \subsubsection{Array Constructor with One Iterator}\doublelabel{array-constructor-with-one-iterator}
 
@@ -628,7 +628,7 @@ dimension $k$ according to the following rules:
   Arrays \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots must have the same number of dimensions, i.e.,
   \lstinline!ndims(A)! = \lstinline!ndims(B)! = \ldots
 \item
-  Arrays \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots must be type compatible expressions (\autoref{type-compatible-expressions})
+  Arrays \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots must be type compatible expressions (\cref{type-compatible-expressions})
   giving the type of the elements of the result. The maximally expanded
   types should be equivalent. \lstinline!Real! and \lstinline!Integer! subtypes can be mixed
   resulting in a \lstinline!Real! result array where the \lstinline!Integer! numbers have been
@@ -764,7 +764,7 @@ Colors ec[3] = Colors.red : Colors.green;
 The array indexing operator \emph{name}\lstinline![!\emph{...}\lstinline!]! is used to
 access array elements for retrieval of their values or for updating
 these values. An indexing operation is subject to upper and lower array
-dimension index bounds (\autoref{array-dimension-lower-and-upper-index-bounds}).  The indexing operator takes two or more
+dimension index bounds (\cref{array-dimension-lower-and-upper-index-bounds}).  The indexing operator takes two or more
 operands, where the first operand is the array to be indexed and the rest of the operands are index expressions:
 
 \lstinline!$\mathit{arrayname}$[$\mathit{indexexpr}_{1}$, $\mathit{indexexpr}_{2}$, $\ldots$]!
@@ -859,7 +859,7 @@ A[v[end], end] !is! A[v[size(v,1)], size(A,2)] // !\emph{First}! end !\emph{is r
 The mathematical operations defined on scalars, vectors, and matrices are the subject of linear algebra.
 
 The term numeric or numeric class is used below for a subtype of the \lstinline!Real! or \lstinline!Integer! type classes.  The standard type coercion defined
-in \autoref{standard-type-coercion} applies.
+in \cref{standard-type-coercion} applies.
 
 \subsection{Equality and Assignment}\doublelabel{equality-and-assignment}
 
@@ -1132,17 +1132,17 @@ but it is still possible to perform some operations on them.
 
 Relational operators \lstinline!<!, \lstinline!<=!, \lstinline!>!,
 \lstinline!>=!, \lstinline!==!, \lstinline!<>!, are only defined for
-scalar operands of simple types, not for arrays, see \autoref{equality-relational-and-logical-operators}
+scalar operands of simple types, not for arrays, see \cref{equality-relational-and-logical-operators}
 
 \subsection{Boolean Operators}\doublelabel{boolean-operators}
 
 The operators \lstinline!and! and \lstinline!or! take expressions of \lstinline!Boolean! type, which are either scalars or arrays of matching dimensions.  The operator \lstinline!not!
 takes an expression of \lstinline!Boolean! type, which is either scalar or an array.  The result is the element-wise logical operation.  For short-circuit evaluation of \lstinline!and!
-and \lstinline!or!, see \autoref{evaluation-order}.
+and \lstinline!or!, see \cref{evaluation-order}.
 
 \subsection{Vectorized Calls of Functions}\doublelabel{vectorized-calls-of-functions}
 
-See \autoref{scalar-functions-applied-to-array-arguments}.
+See \cref{scalar-functions-applied-to-array-arguments}.
 
 \subsection{Standard Type Coercion}\doublelabel{standard-type-coercion}
 In all contexts that require an expression which is a subtype of \lstinline!Real!, an expression which is a subtype of \lstinline!Integer! can also be used;

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1,4 +1,4 @@
-\chapter{Arrays}\doublelabel{arrays}
+\chapter{Arrays}\label{arrays}
 
 An array can be regarded as a collection of values, all of the same
 type. Modelica arrays can be multidimensional and are ``rectangular'',
@@ -32,7 +32,7 @@ An array is allocated by declaring an array variable or calling an array
 constructor. Elements of an array can be indexed by \lstinline!Integer!, \lstinline!Boolean!, or
 \lstinline!enumeration! values.
 
-\section{Array Declarations}\doublelabel{array-declarations}
+\section{Array Declarations}\label{array-declarations}
 
 The Modelica type system includes scalar number, vector, matrix (number
 of dimensions, ndim=2), and arrays of more than two dimensions.
@@ -162,7 +162,7 @@ statement \lstinline!assert(1 <= i and i <= size(A, di), $\ldots$)! is generated
 For efficiency reasons, these implicit assert statements may be optionally suppressed.
 \end{nonnormative}
 
-\subsection{Array Dimension Lower and Upper Index Bounds}\doublelabel{array-dimension-lower-and-upper-index-bounds}
+\subsection{Array Dimension Lower and Upper Index Bounds}\label{array-dimension-lower-and-upper-index-bounds}
 
 The lower and upper index bounds for a dimension of an array indexed by \lstinline!Integer!, \lstinline!Boolean!, or \lstinline!enumeration! values are as follows:
 \begin{itemize}
@@ -175,12 +175,12 @@ The lower and upper index bounds for a dimension of an array indexed by \lstinli
   has the lower bound \lstinline!E.e1! and the upper bound \lstinline!E.en!.
 \end{itemize}
 
-\section{Flexible Array Sizes}\doublelabel{flexible-array-sizes}
+\section{Flexible Array Sizes}\label{flexible-array-sizes}
 
 Regarding flexible array sizes and resizing of arrays in functions, see
 \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 
-\section{Built-in Array Functions}\doublelabel{built-in-array-functions}
+\section{Built-in Array Functions}\label{built-in-array-functions}
 
 Modelica provides a number of built-in functions that are applicable to arrays.
 
@@ -218,7 +218,7 @@ Boolean check[3,4] = fill(true, 3, 4);
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{Array Dimension and Size Functions}\doublelabel{array-dimension-and-size-functions}
+\subsection{Array Dimension and Size Functions}\label{array-dimension-and-size-functions}
 
 The following built-in functions for array dimensions and dimension
 sizes are provided:
@@ -236,7 +236,7 @@ Returns the size of dimension $i$ of array expression \lstinline!A! where $0 \le
 Returns a vector of length \lstinline!ndims(A)! containing the dimension sizes of \lstinline!A!.\\ \hline
 \end{longtable}
 
-\subsection{Dimensionality Conversion Functions}\doublelabel{dimensionality-conversion-functions}
+\subsection{Dimensionality Conversion Functions}\label{dimensionality-conversion-functions}
 
 The following built-in conversion functions convert scalars, vectors,
 and arrays to scalars, vectors, or matrices by adding or removing
@@ -261,7 +261,7 @@ the elements of the first two dimensions as a matrix. $\text{\lstinline!size(A, 
 required for $2 < \text{\lstinline!i!} \leq \text{\lstinline!ndims(A)!}$.\\ \hline
 \end{longtable}
 
-\subsection{Specialized Array Constructor Functions}\doublelabel{specialized-array-constructor-functions}
+\subsection{Specialized Array Constructor Functions}\label{specialized-array-constructor-functions}
 
 An array constructor function constructs and returns an array computed
 from its arguments. Most of the constructor functions in the table below
@@ -306,7 +306,7 @@ Returns a \lstinline!Real! vector with $n$ equally spaced elements, such that \l
 It is required that $n \geq 2$.  The arguments $x_{1}$ and $x_{2}$ shall be numeric scalar expressions.\\ \hline
 \end{longtable}
 
-\subsection{Reduction Functions and Operators}\doublelabel{reduction-functions-and-operators}
+\subsection{Reduction Functions and Operators}\label{reduction-functions-and-operators}
 
 A reduction function ``reduces'' an array (or several scalars) to one value (normally a scalar, but the \lstinline!sum! reduction function may give an array as result
 and also be applied to an operator record).  Note that none of these operators (particularly \lstinline!min! and \lstinline!max!) generate events themselves (but arguments
@@ -405,7 +405,7 @@ The type of \lstinline!product(e(i, $\ldots$, j) for i in u, $\ldots$, j in v)! 
 \\ \hline
 \end{longtable}
 
-\subsubsection{Reduction Expressions}\doublelabel{reduction-expressions}
+\subsubsection{Reduction Expressions}\label{reduction-expressions}
 
 An expression:
 \begin{lstlisting}[language=grammar]
@@ -466,7 +466,7 @@ max(i^2 for  i in {3,7,6}) // Gives 49
 \end{lstlisting}
 \end{example}
 
-\subsection{Matrix and Vector Algebra Functions}\doublelabel{matrix-and-vector-algebra-functions}
+\subsection{Matrix and Vector Algebra Functions}\label{matrix-and-vector-algebra-functions}
 
 The following set of built-in matrix and vector algebra functions are available.  The function transpose and symmetric can be applied to any matrix.
 The functions \lstinline!outerProduct!, \lstinline!cross! and \lstinline!skew! require \lstinline!Real!/\lstinline!Integer! vector(s) or matrix as input(s)
@@ -517,7 +517,7 @@ Returns the $3 \times 3$ skew symmetric matrix associated with a 3-vector, i.e.,
 \end{tabular}\\ \hline
 \end{longtable}
 
-\section{Vector, Matrix and Array Constructors}\doublelabel{vector-matrix-and-array-constructors}
+\section{Vector, Matrix and Array Constructors}\label{vector-matrix-and-array-constructors}
 
 The constructor function \lstinline!array(A, B, C, $\ldots$)! constructs an array from its arguments according to the following rules:
 \begin{itemize}
@@ -554,7 +554,7 @@ Angle[3] a = {1.0, alpha, 4}; // type of a is Real[3].
 \end{lstlisting}
 \end{example}
 
-\subsection{Array Constructor with Iterators}\doublelabel{array-constructor-with-iterators}
+\subsection{Array Constructor with Iterators}\label{array-constructor-with-iterators}
 
 An expression:
 \begin{lstlisting}[language=grammar]
@@ -585,7 +585,7 @@ the type of the type-compatible expression (Real) for all iterations.
 For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using types as
 range see \cref{types-as-iteration-ranges}.
 
-\subsubsection{Array Constructor with One Iterator}\doublelabel{array-constructor-with-one-iterator}
+\subsubsection{Array Constructor with One Iterator}\label{array-constructor-with-one-iterator}
 
 If only one iterator is used, the result is a vector constructed by
 evaluating expression for each value of the loop-variable and forming an
@@ -604,7 +604,7 @@ array(i for i in 1:10)
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Array Constructor with Several Iterators}\doublelabel{array-constructor-with-several-iterators}
+\subsubsection{Array Constructor with Several Iterators}\label{array-constructor-with-several-iterators}
 
 The notation with several iterators is a shorthand notation for nested
 array constructors. The notation can be expanded into the usual form by
@@ -618,7 +618,7 @@ Real hilb2[:,:]={{ 1/(i+j-1) for  j in 1:n} for i in 1:n};
 \end{lstlisting}
 \end{example}
 
-\subsection{Array Concatenation}\doublelabel{array-concatenation}
+\subsection{Array Concatenation}\label{array-concatenation}
 
 The function \lstinline!cat($k$, A, B, C, $\ldots$)! concatenates arrays
 \lstinline!A!, \lstinline!B!, \lstinline!C!, \ldots along
@@ -666,7 +666,7 @@ $\ldots$
 where $1 \leq i_{j} \leq$ \lstinline!size(R,$j$)! for $1 \leq j \leq n$.
 
 
-\subsubsection{Array Concatenation along First and Second Dimensions}\doublelabel{array-concatenation-along-first-and-second-dimensions}
+\subsubsection{Array Concatenation along First and Second Dimensions}\label{array-concatenation-along-first-and-second-dimensions}
 
 For convenience, a special syntax is supported for the concatenation along the first and second dimensions:
 \begin{itemize}
@@ -715,7 +715,7 @@ Real[3,1] m5 = [1; 2; 3];
 \end{lstlisting}
 \end{example}
 
-\subsection{Vector Construction}\doublelabel{vector-construction}
+\subsection{Vector Construction}\label{vector-construction}
 
 Vectors can be constructed with the general array constructor, e.g.,
 \begin{lstlisting}[language=modelica]
@@ -759,7 +759,7 @@ Colors ec[3] = Colors.red : Colors.green;
 \end{lstlisting}
 \end{example}
 
-\section{Array Indexing}\doublelabel{array-indexing}
+\section{Array Indexing}\label{array-indexing}
 
 The array indexing operator \emph{name}\lstinline![!\emph{...}\lstinline!]! is used to
 access array elements for retrieval of their values or for updating
@@ -823,7 +823,7 @@ Array slicing given the declarations \lstinline!x[$n$, $m$]!, \lstinline!v[$k$]!
 \end{longtable}
 \end{example}
 
-\subsection{Indexing with Boolean or Enumeration Values}\doublelabel{indexing-with-boolean-or-enumeration-values}
+\subsection{Indexing with Boolean or Enumeration Values}\label{indexing-with-boolean-or-enumeration-values}
 
 Arrays can be indexed using values of enumeration types or the \lstinline!Boolean! type, not only by \lstinline!Integer!.  The type of the index should correspond to
 the type used for declaring the dimension of the array.
@@ -841,7 +841,7 @@ algorithm
 \end{lstlisting}
 \end{example}
 
-\subsection{Indexing with end}\doublelabel{indexing-with-end}
+\subsection{Indexing with end}\label{indexing-with-end}
 
 The expression \lstinline!end! may only appear inside array subscripts, and if used in the $i$:th subscript of an array expression \lstinline!A! it is equivalent
 to \lstinline!size(A, $i$)! provided indices to \lstinline!A! are a subtype of \lstinline!Integer!.  If used inside nested array subscripts it refers
@@ -854,14 +854,14 @@ A[v[end], end] !is! A[v[size(v,1)], size(A,2)] // !\emph{First}! end !\emph{is r
 \end{lstlisting}
 \end{example}
 
-\section{Scalar, Vector, Matrix, and Array Operator Functions}\doublelabel{scalar-vector-matrix-and-array-operator-functions}
+\section{Scalar, Vector, Matrix, and Array Operator Functions}\label{scalar-vector-matrix-and-array-operator-functions}
 
 The mathematical operations defined on scalars, vectors, and matrices are the subject of linear algebra.
 
 The term numeric or numeric class is used below for a subtype of the \lstinline!Real! or \lstinline!Integer! type classes.  The standard type coercion defined
 in \cref{standard-type-coercion} applies.
 
-\subsection{Equality and Assignment}\doublelabel{equality-and-assignment}
+\subsection{Equality and Assignment}\label{equality-and-assignment}
 
 Equality \lstinline!a = b! and assignment \lstinline!a := b! of scalars, vectors, matrices, and
 arrays is defined element-wise and require both objects to have the same
@@ -881,7 +881,7 @@ Matrix{[}n, m{]} & Matrix{[}n, m{]} & Matrix{[}n, m{]} & a{[}j, k{]} = b{[}j, k{
 Array{[}n, m, \ldots{}{]} & Array{[}n, m, \ldots{}{]} & Array{[}n, m, \ldots{}{]} & a{[}j, k, \ldots{}{]} = b{[}j, k, \ldots{}{]}\\ \hline
 \end{longtable}
 
-\subsection{Array Element-wise Addition, Subtraction, and String Concatenation}\doublelabel{array-element-wise-addition-subtraction-and-string-concatenation}
+\subsection{Array Element-wise Addition, Subtraction, and String Concatenation}\label{array-element-wise-addition-subtraction-and-string-concatenation}
 
 Addition \lstinline!a+b! and subtraction \lstinline!a-b! of numeric scalars, vectors, matrices,
 and arrays is defined element-wise and require \lstinline!size(a)=size(b)! and a
@@ -932,7 +932,7 @@ Scalar & Scalar & \lstinline!c := +/- a!\\ \hline
 Array{[}n, m, \ldots{}{]} & Array{[}n, m, \ldots{}{]} & c{[}j, k, \ldots{}{]} := +/-a{[}j, k, \ldots{}{]}\\ \hline
 \end{longtable}
 
-\subsection{Array Element-wise Multiplication}\doublelabel{array-element-wise-multiplication}
+\subsection{Array Element-wise Multiplication}\label{array-element-wise-multiplication}
 
 Scalar multiplication \lstinline!s*a! or \lstinline!a*s! with numeric scalar s and numeric
 scalar, vector, matrix or array \lstinline!a! is defined element-wise:
@@ -968,7 +968,7 @@ Array{[}n, m, \ldots{}{]} & Array{[}n, m, ...{]} & Array {[}n, m, ...{]}
 \ldots{}{]}\\ \hline
 \end{longtable}
 
-\subsection{Matrix and Vector Multiplication of Numeric Arrays}\doublelabel{matrix-and-vector-multiplication-of-numeric-arrays}
+\subsection{Matrix and Vector Multiplication of Numeric Arrays}\label{matrix-and-vector-multiplication-of-numeric-arrays}
 
 Multiplication \lstinline!a * b! of numeric vectors and matrices is defined only for the following combinations:
 \begin{longtable}[]{|l|l|l|l|}
@@ -994,7 +994,7 @@ tranpose([v]) * A * v // vector with one element
 \end{lstlisting}
 \end{example}
 
-\subsection{Division of Scalars or Numeric Arrays by Numeric Scalars}\doublelabel{division-of-scalars-or-numeric-arrays-by-numeric-scalars}
+\subsection{Division of Scalars or Numeric Arrays by Numeric Scalars}\label{division-of-scalars-or-numeric-arrays-by-numeric-scalars}
 
 Division \lstinline!a / s! of numeric scalars, vectors, matrices, or arrays \lstinline!a! and numeric scalars \lstinline!s! is defined element-wise.
 The result is always of \lstinline!Real! type.  In order to get integer division with truncation, use the function \lstinline!div!.
@@ -1013,7 +1013,7 @@ Array{[}n, m, \ldots{}{]} & Scalar & Array{[}n, m, \ldots{}{]} & c{[}j,
 k, \ldots{}{]} := a{[}j, k, \ldots{}{]} / s\\ \hline
 \end{longtable}
 
-\subsection{Array Element-wise Division}\doublelabel{array-element-wise-division}
+\subsection{Array Element-wise Division}\label{array-element-wise-division}
 
 Element-wise division \lstinline!a ./ b! of numeric scalars, vectors, matrices or arrays \lstinline!a! and \lstinline!b! requires a numeric type class for \lstinline!a! and \lstinline!b!
 and either \lstinline!size(a) = size(b)! or scalar \lstinline!a! or scalar \lstinline!b!.  The result is always of \lstinline!Real! type.  In order to get integer division with truncation,
@@ -1043,7 +1043,7 @@ Element-wise division by scalar (\lstinline!./!) and division by scalar (\lstinl
 This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical unit.  Using a space after the literal solves the problem.
 \end{example}
 
-\subsection{Exponentiation of Scalars of Numeric Elements}\doublelabel{exponentiation-of-scalars-of-numeric-elements}
+\subsection{Exponentiation of Scalars of Numeric Elements}\label{exponentiation-of-scalars-of-numeric-elements}
 
 Exponentiation \lstinline!a ^ b! is defined as \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library if both \lstinline!a! and \lstinline!b! are
 \lstinline!Real! scalars. A \lstinline!Real! scalar value is returned.  If \lstinline!a! or \lstinline!b! are \lstinline!Integer! scalars, they are
@@ -1074,7 +1074,7 @@ This is a consequence of the parsing rules, i.e.\ since \lstinline!2.! could be 
 literals solves the problem.
 \end{example}
 
-\subsection{Scalar Exponentiation of Square Matrices of Numeric Elements}\doublelabel{scalar-exponentiation-of-square-matrices-of-numeric-elements}
+\subsection{Scalar Exponentiation of Square Matrices of Numeric Elements}\label{scalar-exponentiation-of-square-matrices-of-numeric-elements}
 
 Exponentiation \lstinline!a ^ s! is defined if \lstinline!a! is a square numeric matrix and \lstinline!s! is a scalar as a subtype of \lstinline!Integer!
 with $\text{\lstinline!s!} \geq 0$.  The exponentiation is done by repeated multiplication, e.g.:
@@ -1091,7 +1091,7 @@ computing the eigenvalues and eigenvectors of \lstinline!a! and this is no
 longer an elementary operation.
 \end{nonnormative}
 
-\subsection{Slice Operation}\doublelabel{slice-operation}
+\subsection{Slice Operation}\label{slice-operation}
 
 The following holds for slice operations:
 \begin{itemize}
@@ -1128,23 +1128,23 @@ In this example the different \lstinline!x1! vectors have different lengths,
 but it is still possible to perform some operations on them.
 \end{example}
 
-\subsection{Relational Operators}\doublelabel{relational-operators}
+\subsection{Relational Operators}\label{relational-operators}
 
 Relational operators \lstinline!<!, \lstinline!<=!, \lstinline!>!,
 \lstinline!>=!, \lstinline!==!, \lstinline!<>!, are only defined for
 scalar operands of simple types, not for arrays, see \cref{equality-relational-and-logical-operators}
 
-\subsection{Boolean Operators}\doublelabel{boolean-operators}
+\subsection{Boolean Operators}\label{boolean-operators}
 
 The operators \lstinline!and! and \lstinline!or! take expressions of \lstinline!Boolean! type, which are either scalars or arrays of matching dimensions.  The operator \lstinline!not!
 takes an expression of \lstinline!Boolean! type, which is either scalar or an array.  The result is the element-wise logical operation.  For short-circuit evaluation of \lstinline!and!
 and \lstinline!or!, see \cref{evaluation-order}.
 
-\subsection{Vectorized Calls of Functions}\doublelabel{vectorized-calls-of-functions}
+\subsection{Vectorized Calls of Functions}\label{vectorized-calls-of-functions}
 
 See \cref{scalar-functions-applied-to-array-arguments}.
 
-\subsection{Standard Type Coercion}\doublelabel{standard-type-coercion}
+\subsection{Standard Type Coercion}\label{standard-type-coercion}
 In all contexts that require an expression which is a subtype of \lstinline!Real!, an expression which is a subtype of \lstinline!Integer! can also be used;
 the \lstinline!Integer! expression is automatically converted to \lstinline!Real!.
 
@@ -1165,7 +1165,7 @@ RealR r2 = RealR(a, a);    // Ok, a is automatically coerced to Real
 \end{lstlisting}
 \end{example}
 
-\section{Empty Arrays}\doublelabel{empty-arrays}
+\section{Empty Arrays}\label{empty-arrays}
 
 Arrays may have dimension sizes of 0.  For example:
 \begin{lstlisting}[language=modelica]

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -48,7 +48,7 @@ end A;
 
 All elements defined under the heading \lstinline!protected! are regarded as protected.  All other elements (i.e., defined
 under the heading \lstinline!public!, without headings or in a separate file) are public (i.e.\ not protected).  Regarding
-inheritance of protected and public elements, see \autoref{inheritance-of-protected-and-public-elements}.
+inheritance of protected and public elements, see \cref{inheritance-of-protected-and-public-elements}.
 
 
 \section{Double Declaration not Allowed}\doublelabel{double-declaration-not-allowed}
@@ -56,8 +56,8 @@ inheritance of protected and public elements, see \autoref{inheritance-of-protec
 The name of a declared element shall not have the same name as any other
 element in its partially flattened enclosing class. However, the internal
 flattening of a class can in some cases be interpreted as having two
-elements with the same name; these cases are described in \autoref{simultaneous-inner-outer-declarations},
-and \autoref{redeclaration}.
+elements with the same name; these cases are described in \cref{simultaneous-inner-outer-declarations},
+and \cref{redeclaration}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -80,13 +80,13 @@ Variables and classes can be used before they are declared.
 In fact, declaration order is only significant for:
 \begin{itemize}
 \item
-  Functions with more than one input variable called with positional arguments, \autoref{positional-or-named-input-arguments-of-functions}.
+  Functions with more than one input variable called with positional arguments, \cref{positional-or-named-input-arguments-of-functions}.
 \item
-  Functions with more than one output variable, \autoref{output-formal-parameters-of-functions}.
+  Functions with more than one output variable, \cref{output-formal-parameters-of-functions}.
 \item
-  Records that are used as arguments to external functions, \autoref{records}.
+  Records that are used as arguments to external functions, \cref{records}.
 \item
-  Enumeration literal order within enumeration types, \autoref{enumeration-types}.
+  Enumeration literal order within enumeration types, \cref{enumeration-types}.
 \end{itemize}
 \end{nonnormative}
 
@@ -163,7 +163,7 @@ type (\lstinline!RealType!, \lstinline!IntegerType!, etc.), the flattened or ins
 component has the same type.
 
 If the \lstinline!type-specifier! of the component does not denote a built-in type,
-the name of the type is looked up (\autoref{static-name-lookup}). The found type is
+the name of the type is looked up (\cref{static-name-lookup}). The found type is
 flattened with a new environment and the partially flattened enclosing
 class of the component. It is an error if the type is partial in a
 simulation model, or if a simulation model itself is partial. The new
@@ -179,8 +179,8 @@ environment is the result of merging
 in that order.
 
 Array dimensions shall be scalar non-negative parameter expressions of type Integer,
-a reference to a type (which must an enumeration type or Boolean, see \autoref{enumeration-types}),
-or the colon operator denoting that the array dimension is left unspecified (see \autoref{array-declarations}).
+a reference to a type (which must an enumeration type or Boolean, see \cref{enumeration-types}),
+or the colon operator denoting that the array dimension is left unspecified (see \cref{array-declarations}).
 All variants can also be part of short class definitions.
 
 \begin{nonnormative}
@@ -200,9 +200,9 @@ end ArrayVariants;
 \end{lstlisting}
 \end{nonnormative}
 
-The rules for components in functions are described in \autoref{function-as-a-specialized-class}.
+The rules for components in functions are described in \cref{function-as-a-specialized-class}.
 
-Conditional declarations of components are described in \autoref{conditional-component-declaration}.
+Conditional declarations of components are described in \cref{conditional-component-declaration}.
 
 \subsubsection{Declaration Equations}\doublelabel{declaration-equations}
 
@@ -212,7 +212,7 @@ component. For declarations of vectors and matrices, declaration
 equations are associated with each element.
 
 Only components of the restricted classes type, record, operator record, and connector, or components of classes inheriting from ExternalObject
-may have declaration equations. See also the corresponding rule for algorithms, \autoref{restrictions-on-assigned-variables}.
+may have declaration equations. See also the corresponding rule for algorithms, \cref{restrictions-on-assigned-variables}.
 
 \subsubsection{Prefix Rules}\doublelabel{prefix-rules}
 
@@ -222,17 +222,17 @@ subtype of Real.
 Type prefixes (that is , \lstinline!flow!, \lstinline!stream!, \lstinline!discrete!,
 \lstinline!parameter!, \lstinline!constant!,
 \lstinline!input!, \lstinline!output!) shall only be applied for type, record and connector
-components -- see also record specialized class, \autoref{specialized-classes}.
+components -- see also record specialized class, \cref{specialized-classes}.
 
 An exception is \lstinline!input! for components whose type is of the special class
 function type (these can only be used for function formal parameters and
-has special semantics, see \autoref{functional-input-arguments-to-functions}), and the \lstinline!input! prefix is not
+has special semantics, see \cref{functional-input-arguments-to-functions}), and the \lstinline!input! prefix is not
 applied to the elements of the component and is allowed even if the
 elements have input or output prefix.
 
 In addition, instances of classes extending from ExternalObject may have
 type prefixes \lstinline!parameter! and \lstinline!constant!, and in functions also type
-prefixes \lstinline!input! and \lstinline!output! - see \autoref{external-objects}.
+prefixes \lstinline!input! and \lstinline!output! - see \cref{external-objects}.
 
 The type prefixes \lstinline!flow!, \lstinline!stream!, \lstinline!input!
 and \lstinline!output! of a structured
@@ -245,7 +245,7 @@ declared with the flow prefix). When any of the type prefixes \lstinline!flow!,
 \lstinline!stream!, \lstinline!input! and \lstinline!output! are applied for a structured component, no
 element of the component may have any of these type prefixes.
 The corresponding rules for the type prefixes \lstinline!discrete!,
-\lstinline!parameter! and \lstinline!constant! are described in \autoref{variability-of-structured-entities} for structured
+\lstinline!parameter! and \lstinline!constant! are described in \cref{variability-of-structured-entities} for structured
 components.
 
 \begin{example}
@@ -260,7 +260,7 @@ depending on the context where they are used:
   In \emph{functions}, these prefixes define the computational causality
   of the function body, i.e., given the variables declared as \lstinline!input!, the
   variables declared as \lstinline!output! are computed in the function body, see
-  \autoref{function-call}.
+  \cref{function-call}.
 \item
   In \emph{simulation} \emph{models} and \emph{blocks} (i.e., on the top
   level of a model or block that shall be simulated), these prefixes
@@ -269,13 +269,13 @@ depending on the context where they are used:
   such a variable have to be provided from the simulation environment
   and the \lstinline!output! prefix defines that the values of the corresponding
   variable can be directly utilized in the simulation environment, see
-  the notion of Globally balanced in \autoref{balanced-models}.
+  the notion of Globally balanced in \cref{balanced-models}.
 \item
   In component \emph{models} and \emph{blocks}, the \lstinline!input! prefix defines
   that a binding equation has to be provided for the corresponding
   variable when the component is utilized in order to guarantee a
   locally balanced model (i.e., the number of local equations is
-  identical to the local number of unknowns), see \autoref{balanced-models}.
+  identical to the local number of unknowns), see \cref{balanced-models}.
 \begin{example}
 \begin{lstlisting}[language=modelica]
 block FirstOrder
@@ -293,11 +293,11 @@ end UseFirstOrder;
 \item
   In \emph{connectors}, prefixes \lstinline!input! and \lstinline!output! define that the
   corresponding connectors can only be connected according to block
-  diagram semantics, see \autoref{connect-equations-and-connectors} (e.g., a connector with an \lstinline!output!
+  diagram semantics, see \cref{connect-equations-and-connectors} (e.g., a connector with an \lstinline!output!
   variable can only be connected to a connector where the corresponding
   variable is declared as \lstinline!input!). There is the restriction that
   connectors which have at least one variable declared as \lstinline!input! must be
-  externally connected, see \autoref{balanced-models} (in order to get a locally
+  externally connected, see \cref{balanced-models} (in order to get a locally
   balanced model, where the number of local unknowns is identical to the
   number of unknown equations). Together with the block diagram
   semantics rule this means, that such connectors must be connected
@@ -364,8 +364,8 @@ end HasCycles;
 
 The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! of a component declaration
 are called variability prefixes and define in which situation the
-variable values of a component are initialized (see \autoref{events-and-synchronization} and
-\autoref{initialization-initial-equation-and-initial-algorithm}) and when they are changed in transient analysis (= solution
+variable values of a component are initialized (see \cref{events-and-synchronization} and
+\cref{initialization-initial-equation-and-initial-algorithm}) and when they are changed in transient analysis (= solution
 of initial value problem of the hybrid DAE):
 \begin{itemize}
 \item
@@ -380,12 +380,12 @@ of initial value problem of the hybrid DAE):
   as the derivative is not even defined at the events, and it is not legal
   to apply \lstinline!der! to discrete-time variables as they are not continuous. During transient analysis the variable
   can only change its value at event
-  instants (see \autoref{events-and-synchronization}).
+  instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time} variable \lstinline!vn! may have a non-vanishing time
   derivative (\lstinline!der(vn)<>0! possible) and may also
   change its value discontinuously at any time during transient analysis
-  (see \autoref{events-and-synchronization}). If there are any discontinuities the variable is
+  (see \cref{events-and-synchronization}). If there are any discontinuities the variable is
   not differentiable.
 \end{itemize}
 
@@ -409,11 +409,11 @@ continuous-time \lstinline!Integer!, \lstinline!String!, \lstinline!Boolean!, or
 \begin{nonnormative}
 The restriction that discrete-valued variables (of type \lstinline!Boolean!, etc) cannot be
 declared with continuous-time variability is one of the foundations of the expression variability rules
-that will ensure that any discrete-valued expression has at most discrete-time variability, see \autoref{variability-of-expressions}.
+that will ensure that any discrete-valued expression has at most discrete-time variability, see \cref{variability-of-expressions}.
 \end{nonnormative}
 
 The variability of expressions and restrictions on variability for
-definition equations is given in \autoref{variability-of-expressions}.
+definition equations is given in \cref{variability-of-expressions}.
 
 \begin{nonnormative}
 A discrete-time variable is a piecewise constant signal which
@@ -536,7 +536,7 @@ A parameter-expression is required since it shall be evaluated at compile time.
 
 A redeclaration of a component may not include a condition attribute;
 and the condition attribute is kept from the original declaration (see
-\autoref{interface-compatibility-or-subtyping}).
+\cref{interface-compatibility-or-subtyping}).
 
 If the \lstinline!Boolean! expression is false the component (including its modifier) is removed from the flattened DAE, and
 connections to/from the component are removed.  A component declared with a condition-attribute can only be modified and/or
@@ -684,7 +684,7 @@ array class
 \end{lstlisting}
 
 Such an array class has exactly one anonymous component (\_); see also
-\autoref{restriction-on-combining-base-classes-and-other-elements}.
+\cref{restriction-on-combining-base-classes-and-other-elements}.
 When a component of such an array class type is
 flattened, the resulting flattened component type is an array type with
 the same dimensions as \_ and with the optional modifier applied.
@@ -715,7 +715,7 @@ applies iteratively and also for redeclare).
 
 A base-prefix applied in the short-class definition does not influence
 its type, but is applied to components declared of this type or types
-derived from it; see also \autoref{restriction-on-combining-base-classes-and-other-elements}.
+derived from it; see also \cref{restriction-on-combining-base-classes-and-other-elements}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -802,7 +802,7 @@ Specialized kinds of classes (earlier known as \emph{restricted classes})
 have the properties of a general class, apart from restrictions.
 Moreover, they have additional properties called enhancements. The
 following table summarizes the definition of the specialized classes
-(additional restrictions on inheritance are in \autoref{restrictions-on-the-kind-of-base-class}):
+(additional restrictions on inheritance are in \cref{restrictions-on-the-kind-of-base-class}):
 \begin{longtable}{|p{4cm}|p{9cm}|}
 \hline \endhead
 \lstinline!record! & Only public sections are allowed in the definition or
@@ -811,7 +811,7 @@ initial algorithm and protected sections are not allowed). The elements
 of a record may not have prefixes \lstinline!input!, \lstinline!output!,
 \lstinline!inner!, \lstinline!outer!, \lstinline!stream,!
 or \lstinline!flow!. Enhanced with implicitly available record constructor function,
-see \autoref{record-constructor-functions}. The components
+see \cref{record-constructor-functions}. The components
 directly declared in a record may only be of specialized class record
 or type.\\ \hline
 \lstinline!type! & May only be predefined types, enumerations, array of
@@ -826,7 +826,7 @@ The purpose is to model input/output blocks of block diagrams.  Due to the restr
 connections between blocks are only possible according to block diagram semantic.
 \end{nonnormative*}
 \\ \hline
-\lstinline!function! & See \autoref{function-as-a-specialized-class} for restrictions
+\lstinline!function! & See \cref{function-as-a-specialized-class} for restrictions
 and enhancements of functions. Enhanced to allow the
 function to contain an external function interface.
 \par
@@ -844,20 +844,20 @@ contain components of specialized class connector, record and
 type.\\ \hline
 \lstinline!package! & May only contain declarations of classes and
 constants. Enhanced to allow \lstinline!import! of elements of packages. (See also
-\autoref{packages} on packages.)\\ \hline
+\cref{packages} on packages.)\\ \hline
 \lstinline!operator record! & Similar to record; but operator overloading
 is possible, and due to this the typing rules are different -- see
-\autoref{interface-or-type-relationships}. It is not legal to extend from an operator record (or
+\cref{interface-or-type-relationships}. It is not legal to extend from an operator record (or
 connector inheriting from operator record), except if the new class is
 an operator record or connector that is declared as a short class
 definition, whose modifier is either empty or only modify the default
 attributes for the component elements directly inside the operator
 record. An operator record can only extend from an operator record. It is not legal to extend
-from any of its enclosing scopes. (See \autoref{overloaded-operators}).
+from any of its enclosing scopes. (See \cref{overloaded-operators}).
 \\ \hline
 \lstinline!operator! & Similar to package; but may only contain
 declarations of functions. May only be placed directly in an operator
-record. (See also \autoref{overloaded-operators}).\\ \hline
+record. (See also \cref{overloaded-operators}).\\ \hline
 \lstinline!operator function! & Shorthand for an
 operator with exactly one function; same restriction as function class
 and in addition may only be placed directly in an operator
@@ -959,7 +959,7 @@ redeclaration cannot lead to an unbalanced model any more.
 
 The restrictions below apply after flattening -- i.e.\ inherited
 components are included -- possibly modified. The corresponding
-restrictions on connectors and connections are in \autoref{restrictions-of-connections-and-connectors}.
+restrictions on connectors and connections are in \cref{restrictions-of-connections-and-connectors}.
 
 \begin{definition}[Local number of unknowns]
 The local number of unknowns of a model or block class is the sum based on the components:
@@ -999,8 +999,8 @@ The local equation size of a model or block class is the sum of the following nu
   block component), including binding equations, and equations generated
   from connect-equations.
   \begin{nonnormative}
-  This includes the proper count for when-clauses (see \autoref{when-equations}), and algorithms (see \autoref{algorithm-sections}), and is also used for
-  the flat Hybrid DAE formulation (see \autoref{modelica-dae-representation}).
+  This includes the proper count for when-clauses (see \cref{when-equations}), and algorithms (see \cref{algorithm-sections}), and is also used for
+  the flat Hybrid DAE formulation (see \cref{modelica-dae-representation}).
   \end{nonnormative}
 \item
   The number of input and flow-variables present in each (top-level) public connector component.
@@ -1449,7 +1449,7 @@ end Real;
 \end{lstlisting}
 
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
-define tolerances in relative terms, see \autoref{attributes-start-fixed-nominal-and-unbounded}.
+define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,
@@ -1526,10 +1526,10 @@ type Size2 = enumeration(small "1st", medium "2nd", large "3rd", xlarge "4th");
 \end{example}
 
 An enumeration type is a simple type and the attributes are defined in
-\autoref{attributes-of-enumeration-types}. The \lstinline!Boolean! type name or an enumeration type name can
+\cref{attributes-of-enumeration-types}. The \lstinline!Boolean! type name or an enumeration type name can
 be used to specify the dimension range for a dimension in an array
 declaration and to specify the range in a for loop range expression; see
-\autoref{types-as-iteration-ranges}. An element of an enumeration type can be accessed in
+\cref{types-as-iteration-ranges}. An element of an enumeration type can be accessed in
 an expression.
 
 \begin{nonnormative}
@@ -1644,14 +1644,14 @@ value.
 \lstinline!String(E.Small)! gives \lstinline!"Small"!.
 \end{example}
 
-See also \autoref{numeric-functions-and-conversion-functions}.
+See also \cref{numeric-functions-and-conversion-functions}.
 
 \subsubsection{Type Conversion of Integer to Enumeration Values}\doublelabel{type-conversion-of-integer-to-enumeration-values}
 
 Whenever an enumeration type is defined, a type conversion function with
 the same name and in the same scope as the enumeration type is
 implicitly defined. This function can be used in an expression to
-convert an integer value to the corresponding (as described in \autoref{type-conversion-of-enumeration-values-to-string-or-integer}) enumeration value.
+convert an integer value to the corresponding (as described in \cref{type-conversion-of-enumeration-values-to-string-or-integer}) enumeration value.
 
 For an enumeration type named \lstinline!EnumTypeName!, the expression
 \lstinline!EnumTypeName(<Integer expression>)! returns the
@@ -1732,13 +1732,13 @@ always "Do use it as a state."
 
 \subsubsection{ExternalObject}\doublelabel{externalobject}
 
-See \autoref{external-objects} for information about the predefined type
+See \cref{external-objects} for information about the predefined type
 \lstinline!ExternalObject!.
 
 \subsubsection{AssertionLevel}\doublelabel{assertionlevel}
 
 The predefined \lstinline!AssertionLevel! enumeration type is used together with
-\lstinline!assert!, \autoref{assert}.
+\lstinline!assert!, \cref{assert}.
 \begin{lstlisting}[language=modelica]
 type AssertionLevel=enumeration(warning, error);
 \end{lstlisting}
@@ -1746,15 +1746,15 @@ type AssertionLevel=enumeration(warning, error);
 \subsubsection{Connections}\doublelabel{connections}
 
 The package Connections is used for over-constrained connection graphs,
-\autoref{equation-operators-for-overconstrained-connection-based-equation-systems}.
+\cref{equation-operators-for-overconstrained-connection-based-equation-systems}.
 
 \subsubsection{Graphical Annotation Types}\doublelabel{graphical-annotation-types}
 
 A number of ``predefined'' record types and enumeration types for
-graphical annotations are described in \autoref{annotations}. These types are not
+graphical annotations are described in \cref{annotations}. These types are not
 predefined in the usual sense since they cannot be referenced in
 ordinary Modelica code, only within annotations.
 
 \subsubsection{Clock Types}\doublelabel{clock-types}
 
-See \autoref{clocks-and-clocked-variables} and \autoref{clock-constructors}.
+See \cref{clocks-and-clocked-variables} and \cref{clock-constructors}.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1,4 +1,4 @@
-\chapter{Classes, Predefined Types, and Declarations}\doublelabel{class-predefined-types-and-declarations}
+\chapter{Classes, Predefined Types, and Declarations}\label{class-predefined-types-and-declarations}
 
 The fundamental structuring unit of modeling in Modelica is the class.
 Classes provide the structure for objects, also known as instances.
@@ -12,7 +12,7 @@ classes or class schemata.
 Declarations are the syntactic constructs needed to introduce classes
 and objects (i.e., components).
 
-\section{Access Control -- Public and Protected Elements}\doublelabel{access-control-public-and-protected-elements}
+\section{Access Control -- Public and Protected Elements}\label{access-control-public-and-protected-elements}
 
 Members of a Modelica class can have two levels of visibility: \lstinline!public! or
 \lstinline!protected!. The default is \lstinline!public! if nothing else is specified
@@ -51,7 +51,7 @@ under the heading \lstinline!public!, without headings or in a separate file) ar
 inheritance of protected and public elements, see \cref{inheritance-of-protected-and-public-elements}.
 
 
-\section{Double Declaration not Allowed}\doublelabel{double-declaration-not-allowed}
+\section{Double Declaration not Allowed}\label{double-declaration-not-allowed}
 
 The name of a declared element shall not have the same name as any other
 element in its partially flattened enclosing class. However, the internal
@@ -72,7 +72,7 @@ end M;
 \end{lstlisting}
 \end{example}
 
-\section{Declaration Order and Usage before Declaration}\doublelabel{declaration-order-and-usage-before-declaration}
+\section{Declaration Order and Usage before Declaration}\label{declaration-order-and-usage-before-declaration}
 
 Variables and classes can be used before they are declared.
 
@@ -90,11 +90,11 @@ In fact, declaration order is only significant for:
 \end{itemize}
 \end{nonnormative}
 
-\section{Component Declarations}\doublelabel{component-declarations}
+\section{Component Declarations}\label{component-declarations}
 
 Component declarations are described in this section.
 
-\subsection{Syntax and Examples of Component Declarations}\doublelabel{syntax-and-examples-of-component-declarations}
+\subsection{Syntax and Examples of Component Declarations}\label{syntax-and-examples-of-component-declarations}
 
 The formal syntax of a component declaration clause is given by the
 following syntactic rules:
@@ -156,7 +156,7 @@ Real a, B[2,2];
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{Component Declaration Static Semantics}\doublelabel{component-declaration-static-semantics}
+\subsection{Component Declaration Static Semantics}\label{component-declaration-static-semantics}
 
 If the \lstinline!type-specifier! of the component declaration denotes a built-in
 type (\lstinline!RealType!, \lstinline!IntegerType!, etc.), the flattened or instantiated
@@ -204,7 +204,7 @@ The rules for components in functions are described in \cref{function-as-a-speci
 
 Conditional declarations of components are described in \cref{conditional-component-declaration}.
 
-\subsubsection{Declaration Equations}\doublelabel{declaration-equations}
+\subsubsection{Declaration Equations}\label{declaration-equations}
 
 An environment that defines the value of a component of built-in type is
 said to define a declaration equation associated with the declared
@@ -214,7 +214,7 @@ equations are associated with each element.
 Only components of the restricted classes type, record, operator record, and connector, or components of classes inheriting from ExternalObject
 may have declaration equations. See also the corresponding rule for algorithms, \cref{restrictions-on-assigned-variables}.
 
-\subsubsection{Prefix Rules}\doublelabel{prefix-rules}
+\subsubsection{Prefix Rules}\label{prefix-rules}
 
 Variables declared with the \lstinline!flow! or the \lstinline!stream! type prefix shall be a
 subtype of Real.
@@ -308,7 +308,7 @@ end UseFirstOrder;
   function.
 \end{itemize}
 
-\subsection{Acyclic Bindings of Constants and Parameters}\doublelabel{acyclic-bindings-of-constants-and-parameters}
+\subsection{Acyclic Bindings of Constants and Parameters}\label{acyclic-bindings-of-constants-and-parameters}
 
 The unexpanded binding equations for parameters and constants in the
 translated model must be acyclic after flattening; except that cycles
@@ -360,7 +360,7 @@ end HasCycles;
 \end{lstlisting}
 \end{example}
 
-\subsection{Component Variability Prefixes discrete, parameter, constant}\doublelabel{component-variability-prefixes-discrete-parameter-constant}
+\subsection{Component Variability Prefixes discrete, parameter, constant}\label{component-variability-prefixes-discrete-parameter-constant}
 
 The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! of a component declaration
 are called variability prefixes and define in which situation the
@@ -480,7 +480,7 @@ Therefore, \lstinline!u1! is guaranteed to be continuous during continuous
 integration whereas no such guarantee exists for \lstinline!u2!.
 \end{nonnormative}
 
-\subsubsection{Variability of Structured Entities}\doublelabel{variability-of-structured-entities}
+\subsubsection{Variability of Structured Entities}\label{variability-of-structured-entities}
 
 For elements of structured entities with variability prefixes the most
 restrictive of the variability prefix and the variability of the
@@ -506,7 +506,7 @@ A b;
 \end{lstlisting}
 \end{example}
 
-\subsection{Conditional Component Declaration}\doublelabel{conditional-component-declaration}
+\subsection{Conditional Component Declaration}\label{conditional-component-declaration}
 
 A component declaration can have a \lstinline!condition-attribute!: \lstinline!if!~\emph{expression}.
 
@@ -557,7 +557,7 @@ The reason for this restriction is that the default flow equation is probably in
 be an unconditional connector) and the model cannot check that connector is connected.
 \end{nonnormative}
 
-\section{Class Declarations}\doublelabel{class-declarations}
+\section{Class Declarations}\label{class-declarations}
 
 Essentially everything in Modelica is a class, from the predefined
 classes \lstinline!Integer! and \lstinline!Real!, to large packages such as the Modelica
@@ -629,7 +629,7 @@ composition :
   [ annotation ";" ]
 \end{lstlisting}
 
-\subsection{Short Class Definitions}\doublelabel{short-class-definitions}
+\subsection{Short Class Definitions}\label{short-class-definitions}
 
 A class definition of the form
 \begin{lstlisting}[language=modelica]
@@ -733,7 +733,7 @@ Real x[:]=foo(time);
 \end{lstlisting}
 \end{example}
 
-\subsection{Restriction on combining base-classes and other elements}\doublelabel{restriction-on-combining-base-classes-and-other-elements}
+\subsection{Restriction on combining base-classes and other elements}\label{restriction-on-combining-base-classes-and-other-elements}
 
 It is not legal to combine other components or base-classes with an
 extends from an array class, a class with non-empty base-prefix, a
@@ -766,7 +766,7 @@ end IllegalConnector;
 \end{lstlisting}
 \end{example}
 
-\subsection{Local Class Definitions -- Nested Classes}\doublelabel{local-class-definitions-nested-classes}
+\subsection{Local Class Definitions -- Nested Classes}\label{local-class-definitions-nested-classes}
 
 The local class should be statically flattenable with the partially
 flattened enclosing class of the local class apart from local class
@@ -795,7 +795,7 @@ Flattening of class \lstinline!C2! yields a local class \lstinline!Voltage! with
 instances of this local class and thus have a nominal value of 1000.
 \end{example}
 
-\section{Specialized Classes}\doublelabel{specialized-classes}
+\section{Specialized Classes}\label{specialized-classes}
 
 Specialized kinds of classes (earlier known as \emph{restricted classes})
 \lstinline!record!, \lstinline!type!, \lstinline!model!, \lstinline!block!, \lstinline!package!, \lstinline!function! and \lstinline!connector!
@@ -908,7 +908,7 @@ operator record ComplexVoltage = Complex(re(unit="V"),im(unit="V")); // allowed
 \end{lstlisting}
 \end{example}
 
-\section{Balanced Models}\doublelabel{balanced-models}
+\section{Balanced Models}\label{balanced-models}
 
 \begin{nonnormative}
 In this section restrictions for model and block classes are
@@ -1403,7 +1403,7 @@ medium equations.  Again, this demonstrates, that an \lstinline!input! just defi
 necessarily defines the computational causality.
 \end{example}
 
-\section{Predefined Types and Classes}\doublelabel{predefined-types-and-classes}
+\section{Predefined Types and Classes}\label{predefined-types-and-classes}
 
 The attributes of the predefined variable types (\lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!,
 \lstinline!String!) and \lstinline!enumeration! types are described below with Modelica syntax
@@ -1427,7 +1427,7 @@ It also follows that the only way to declare a subtype of e.g.\ \lstinline!Real!
 The definitions use \lstinline!RealType!, \lstinline!IntegerType!, \lstinline!BooleanType!, \lstinline!StringType!, \lstinline!EnumType!
 as mnemonics corresponding to machine representations.
 
-\subsection{Real Type}\doublelabel{real-type}
+\subsection{Real Type}\label{real-type}
 
 The following is the predefined \lstinline!Real! type:
 \begin{lstlisting}[language=modelica]
@@ -1456,7 +1456,7 @@ For external functions in C89, \lstinline!RealType! maps to \lstinline[language=
 \lstinline!RealType!/\lstinline[language=C]!double! matches the IEC~60559:1989 (ANSI/IEEE~754-1985) \lstinline[language=C]!double! format.
 \end{nonnormative}
 
-\subsection{Integer Type}\doublelabel{integer-type}
+\subsection{Integer Type}\label{integer-type}
 The following is the predefined \lstinline!Integer! type:
 \begin{lstlisting}[language=modelica]
 type Integer // Note: Defined with Modelica syntax although predefined
@@ -1473,7 +1473,7 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
-\subsection{Boolean Type}\doublelabel{boolean-type}
+\subsection{Boolean Type}\label{boolean-type}
 The following is the predefined \lstinline!Boolean! type:
 \begin{lstlisting}[language=modelica]
 type Boolean // Note: Defined with Modelica syntax although predefined
@@ -1485,7 +1485,7 @@ type Boolean // Note: Defined with Modelica syntax although predefined
 end Boolean;
 \end{lstlisting}
 
-\subsection{String Type}\doublelabel{string-type}
+\subsection{String Type}\label{string-type}
 
 The following is the predefined \lstinline!String! type:
 \begin{lstlisting}[language=modelica]
@@ -1498,7 +1498,7 @@ type String // Note: Defined with Modelica syntax although predefined
 end String;
 \end{lstlisting}
 
-\subsection{Enumeration Types}\doublelabel{enumeration-types}
+\subsection{Enumeration Types}\label{enumeration-types}
 
 A declaration of the form
 \begin{lstlisting}[language=modelica]
@@ -1599,7 +1599,7 @@ end Mixing2;
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Attributes of Enumeration Types}\doublelabel{attributes-of-enumeration-types}
+\subsubsection{Attributes of Enumeration Types}\label{attributes-of-enumeration-types}
 
 For each enumeration:
 \begin{lstlisting}[language=modelica]
@@ -1630,7 +1630,7 @@ level, it is not possible to use the enumeration attribute names
 (\lstinline!quantity!, \lstinline!min!, \lstinline!max!, \lstinline!start!, \lstinline!fixed!) as enumeration literals.
 \end{nonnormative}
 
-\subsubsection{Type Conversion of Enumeration Values to String or Integer}\doublelabel{type-conversion-of-enumeration-values-to-string-or-integer}
+\subsubsection{Type Conversion of Enumeration Values to String or Integer}\label{type-conversion-of-enumeration-values-to-string-or-integer}
 
 The type conversion function \lstinline!Integer(<expression of enumeration type>)! returns the ordinal number of the
 enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated,
@@ -1646,7 +1646,7 @@ value.
 
 See also \cref{numeric-functions-and-conversion-functions}.
 
-\subsubsection{Type Conversion of Integer to Enumeration Values}\doublelabel{type-conversion-of-integer-to-enumeration-values}
+\subsubsection{Type Conversion of Integer to Enumeration Values}\label{type-conversion-of-integer-to-enumeration-values}
 
 Whenever an enumeration type is defined, a type conversion function with
 the same name and in the same scope as the enumeration type is
@@ -1673,7 +1673,7 @@ c = Colors(10); // An error
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Unspecified enumeration}\doublelabel{unspecified-enumeration}
+\subsubsection{Unspecified enumeration}\label{unspecified-enumeration}
 
 An enumeration type defined using \lstinline!enumeration(:)! is unspecified and can
 be used as a replaceable enumeration type that can be freely redeclared
@@ -1682,7 +1682,7 @@ using \lstinline!enumeration(:)! in a simulation model.
 
 
 
-\subsection{Attributes start, fixed, nominal, and unbounded}\doublelabel{attributes-start-fixed-nominal-and-unbounded}
+\subsection{Attributes start, fixed, nominal, and unbounded}\label{attributes-start-fixed-nominal-and-unbounded}
 
 The attributes \lstinline!start! and \lstinline!fixed! define the initial conditions for a
 variable. \lstinline!fixed=false! means an initial guess, i.e., value may be
@@ -1707,9 +1707,9 @@ value can be propagated to the other variable).
 \end{nonnormative}
 
 
-\subsection{Other Predefined Types}\doublelabel{other-predefined-types}
+\subsection{Other Predefined Types}\label{other-predefined-types}
 
-\subsubsection{StateSelect}\doublelabel{stateselect}
+\subsubsection{StateSelect}\label{stateselect}
 
 The predefined \lstinline!StateSelect! enumeration type is the type of the
 \lstinline!stateSelect! attribute of the \lstinline!Real! type. It is used to explicitly control
@@ -1730,12 +1730,12 @@ always "Do use it as a state."
 );
 \end{lstlisting}
 
-\subsubsection{ExternalObject}\doublelabel{externalobject}
+\subsubsection{ExternalObject}\label{externalobject}
 
 See \cref{external-objects} for information about the predefined type
 \lstinline!ExternalObject!.
 
-\subsubsection{AssertionLevel}\doublelabel{assertionlevel}
+\subsubsection{AssertionLevel}\label{assertionlevel}
 
 The predefined \lstinline!AssertionLevel! enumeration type is used together with
 \lstinline!assert!, \cref{assert}.
@@ -1743,18 +1743,18 @@ The predefined \lstinline!AssertionLevel! enumeration type is used together with
 type AssertionLevel=enumeration(warning, error);
 \end{lstlisting}
 
-\subsubsection{Connections}\doublelabel{connections}
+\subsubsection{Connections}\label{connections}
 
 The package Connections is used for over-constrained connection graphs,
 \cref{equation-operators-for-overconstrained-connection-based-equation-systems}.
 
-\subsubsection{Graphical Annotation Types}\doublelabel{graphical-annotation-types}
+\subsubsection{Graphical Annotation Types}\label{graphical-annotation-types}
 
 A number of ``predefined'' record types and enumeration types for
 graphical annotations are described in \cref{annotations}. These types are not
 predefined in the usual sense since they cannot be referenced in
 ordinary Modelica code, only within annotations.
 
-\subsubsection{Clock Types}\doublelabel{clock-types}
+\subsubsection{Clock Types}\label{clock-types}
 
 See \cref{clocks-and-clocked-variables} and \cref{clock-constructors}.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -1,11 +1,11 @@
-\chapter{Connectors and Connections}\doublelabel{connectors-and-connections}
+\chapter{Connectors and Connections}\label{connectors-and-connections}
 
 This chapter covers connectors, connect-equations, and connections.
 
 The special functions \lstinline!cardinality!, \lstinline!rooted! (deprecated),
 \lstinline!Connections.isRoot!, and \lstinline!Connections.rooted! may not be used to control them.
 
-\section{Connect-Equations and Connectors}\doublelabel{connect-equations-and-connectors}
+\section{Connect-Equations and Connectors}\label{connect-equations-and-connectors}
 
 Connections between objects are introduced by connect-equations in the
 equation part of a class. A connect-equation has the following syntax:
@@ -68,13 +68,13 @@ The three main tasks are to:
   Generate equations for the complete model.
 \end{itemize}
 
-\subsection{Connection Sets}\doublelabel{connection-sets}
+\subsection{Connection Sets}\label{connection-sets}
 
 A connection set is a set of variables connected by means of
 connect-equations. A connection set shall contain either only flow
 variables or only non-flow variables.
 
-\subsection{Inside and Outside Connectors}\doublelabel{inside-and-outside-connectors}
+\subsection{Inside and Outside Connectors}\label{inside-and-outside-connectors}
 
 In an element instance M, each connector element of M is called an
 outside connector with respect to M. All other connector elements that
@@ -109,7 +109,7 @@ connect(d, m7.c); // d is an outside connector, m7.c is an inside connector
 \end{lstlisting}
 \end{example}
 
-\subsection{Expandable Connectors}\doublelabel{expandable-connectors}
+\subsection{Expandable Connectors}\label{expandable-connectors}
 
 If the \lstinline!expandable! qualifier is present on a connector definition, all
 instances of that connector are referred to as expandable connectors.
@@ -361,7 +361,7 @@ CylinderBus cylinder_bus[4];
 \end{lstlisting}
 \end{example}
 
-\section{Generation of Connection Equations}\doublelabel{generation-of-connection-equations}
+\section{Generation of Connection Equations}\label{generation-of-connection-equations}
 
 When generating connection equations, \lstinline!outer! elements are resolved to the
 corresponding \lstinline!inner! elements in the instance hierarchy (see instance
@@ -566,7 +566,7 @@ load.p.v = ground.p.v;
 This corresponds to a direct connection of the resistor.
 \end{example}
 
-\section{Restrictions of Connections and Connectors}\doublelabel{restrictions-of-connections-and-connectors}
+\section{Restrictions of Connections and Connectors}\label{restrictions-of-connections-and-connectors}
 
 \begin{itemize}
 \item
@@ -650,7 +650,7 @@ covers the case where a connector of a component is left unconnected and the sou
   For conditional connectors, see \cref{conditional-component-declaration}.
 \end{itemize}
 
-\subsection{Balancing Restriction and Size of Connectors}\doublelabel{balancing-restriction-and-size-of-connectors}
+\subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
 For each non-partial non-expandable connector class the number of flow variables shall
 be equal to the number of variables that are neither \lstinline!parameter!,
@@ -757,7 +757,7 @@ end Plug_Expanded_Illegal;
 \end{lstlisting}
 \end{example}
 
-\section{Equation Operators for Overconstrained Connection-Based Equation Systems}\doublelabel{equation-operators-for-overconstrained-connection-based-equation-systems1}
+\section{Equation Operators for Overconstrained Connection-Based Equation Systems}\label{equation-operators-for-overconstrained-connection-based-equation-systems1}
 
 There is a special problem regarding equation systems resulting from
 \emph{loops} in connection graphs where the connectors contain
@@ -804,7 +804,7 @@ causes of overdetermined systems, e.g., explicit zero-sum equations for
 flow variables, that are not handled by the method described below.
 \end{nonnormative}
 
-\subsection{Overconstrained Equation Operators for Connection Graphs}\doublelabel{overconstrained-equation-operators-for-connection-graphs}
+\subsection{Overconstrained Equation Operators for Connection Graphs}\label{overconstrained-equation-operators-for-connection-graphs}
 
 A type or record declaration may have an optional definition of function
 \lstinline!equalityConstraint! that shall have the following prototype:
@@ -949,7 +949,7 @@ generate nodes and edges in the virtual graph for analysis purposes.
 \end{nonnormative}
 
 
-\subsection{Converting the Connection Graph into Trees and Generating Connection Equations}\doublelabel{converting-the-connection-graph-into-trees-and-generating-connection-equations}
+\subsection{Converting the Connection Graph into Trees and Generating Connection Equations}\label{converting-the-connection-graph-into-trees-and-generating-connection-equations}
 
 Before \lstinline!connect! equations are generated, the virtual connection
 graph is transformed into a set of spanning trees by removing optional spanning tree edges
@@ -988,7 +988,7 @@ following way:
   of \lstinline!A.R = B.R!.
 \end{enumerate}
 
-\subsection{Examples of Overconstrained Connection Graphs}\doublelabel{examples-of-overconstrained-connection-graphs}
+\subsection{Examples of Overconstrained Connection Graphs}\label{examples-of-overconstrained-connection-graphs}
 
 \begin{example}
 \begin{figure}[H]
@@ -998,7 +998,7 @@ following way:
 \end{figure}
 \end{example}
 
-\subsubsection{An Overdetermined Connector for Power Systems}\doublelabel{an-overdetermined-connector-for-power-systems}
+\subsubsection{An Overdetermined Connector for Power Systems}\label{an-overdetermined-connector-for-power-systems}
 
 \begin{nonnormative}
 An overdetermined connector for power systems based on the
@@ -1062,7 +1062,7 @@ identifies the connectors, where the \lstinline!AC_Angle! needs not to be
 passed between components, in order to avoid redundant equations.
 \end{nonnormative}
 
-\subsubsection{An Overdetermined Connector for 3-dimensional Mechanical Systems}\doublelabel{an-overdetermined-connector-for-3-dimensional-mechanical-systems}
+\subsubsection{An Overdetermined Connector for 3-dimensional Mechanical Systems}\label{an-overdetermined-connector-for-3-dimensional-mechanical-systems}
 
 \begin{nonnormative}
 An overdetermined connector for 3-dimensional mechanical systems

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -139,7 +139,7 @@ Then connections containing expandable connectors are elaborated:
     array gives an array with at least the specified elements, other elements are either not created or have a default value (i.e.\ as if they were only potentially present).
   \item
     If the variable on the other side of the connect-equation is input or output the new component will be either input or output to satisfy the restrictions in
-    \autoref{restrictions-of-connections-and-connectors} for a non-expandable connector.
+    \cref{restrictions-of-connections-and-connectors} for a non-expandable connector.
     \begin{nonnormative}
     If the existing side refers to an inside connector (i.e.\ a connector of a component) the new variable will copy its causality, i.e.\ input
     if input and output if output, since the expandable connector must be an outside connector.
@@ -159,7 +159,7 @@ Then connections containing expandable connectors are elaborated:
 
 \item
   The variables introduced in the elaboration follow additional rules
-  for generating connection sets (given in \autoref{generation-of-connection-equations}).
+  for generating connection sets (given in \cref{generation-of-connection-equations}).
 
 \item
   If a variable appears as an input in one expandable connector, it
@@ -365,7 +365,7 @@ CylinderBus cylinder_bus[4];
 
 When generating connection equations, \lstinline!outer! elements are resolved to the
 corresponding \lstinline!inner! elements in the instance hierarchy (see instance
-hierarchy name lookup \autoref{instance-hierarchy-name-lookup-of-inner-declarations}). The arguments to each \lstinline!connect!-equation are
+hierarchy name lookup \cref{instance-hierarchy-name-lookup-of-inner-declarations}). The arguments to each \lstinline!connect!-equation are
 resolved to two connector elements.
 
 For every use of the \lstinline!connect!-equation
@@ -583,7 +583,7 @@ This corresponds to a direct connection of the resistor.
   variables to constant variables.
 \item
   The connect-equation construct only accepts forms of connector
-  references as specified in \autoref{connect-equations-and-connectors}.
+  references as specified in \cref{connect-equations-and-connectors}.
 \item
   In a connect-equation the two connectors must have the same named
   component elements with the same dimensions; recursively down to the
@@ -618,7 +618,7 @@ This corresponds to a direct connection of the resistor.
   connector that is not part of an expandable connector. \label{enum:exc-conn-case}
 \end{enumerate}
 \begin{nonnormative}
-I.e., a connection set must -- unless the model or block is partial -- contain one source of a signal (the last item (\autoref{enum:exc-conn-case})
+I.e., a connection set must -- unless the model or block is partial -- contain one source of a signal (the last item (\cref{enum:exc-conn-case})
 covers the case where a connector of a component is left unconnected and the source given textually).
 \end{nonnormative}
 \item
@@ -647,7 +647,7 @@ covers the case where a connector of a component is left unconnected and the sou
   assert statements to check that they have the same value; connections
   are not generated.
 \item
-  For conditional connectors, see \autoref{conditional-component-declaration}.
+  For conditional connectors, see \cref{conditional-component-declaration}.
 \end{itemize}
 
 \subsection{Balancing Restriction and Size of Connectors}\doublelabel{balancing-restriction-and-size-of-connectors}
@@ -658,7 +658,7 @@ be equal to the number of variables that are neither \lstinline!parameter!,
 nor \lstinline!flow!. The \emph{number of variables} is
 the number of all elements in the connector class after expanding all
 records and arrays to a set of scalars of primitive types. The number of
-variables of an overdetermined type or record class (see \autoref{overconstrained-equation-operators-for-connection-graphs})
+variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs})
 is the size of the output argument of the corresponding
 \lstinline!equalityConstraint!() function.
 \begin{nonnormative}
@@ -856,7 +856,7 @@ overdetermined connector. An overdetermined type or record may neither
 have flow components nor may be used as a type of flow components. If an
 array is used as argument to any of the Connections.* functions it is
 treated as one unit -- there is no special treatment of this case --
-however, there is for connect -- see \autoref{connect-equations-and-connectors}.
+however, there is for connect -- see \cref{connect-equations-and-connectors}.
 
 Every instance of an overdetermined type or record in an overdetermined
 connector is a node in a virtual connection graph that is used to
@@ -979,10 +979,10 @@ following way:
 \item
   For every optional spanning-tree edge (i.e., a \lstinline!connect(A, B)!
   equation), in one of the spanning trees, the connection
-  equations are generated according to \autoref{generation-of-connection-equations}.
+  equations are generated according to \cref{generation-of-connection-equations}.
 \item
   For every optional spanning-tree edge not in any of the spanning trees, the
-  connection equations are generated according to \autoref{generation-of-connection-equations}, except
+  connection equations are generated according to \cref{generation-of-connection-equations}, except
   for overdetermined type or record instances R. Here the equations
   \lstinline!0 = R.equalityConstraint(A.R, B.R)! are generated instead
   of \lstinline!A.R = B.R!.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -618,7 +618,7 @@ This corresponds to a direct connection of the resistor.
   connector that is not part of an expandable connector. \label{enum:exc-conn-case}
 \end{enumerate}
 \begin{nonnormative}
-I.e., a connection set must -- unless the model or block is partial -- contain one source of a signal (the last item (\cref{enum:exc-conn-case})
+I.e., a connection set must --- unless the model or block is partial --- contain one source of a signal (\cref{enum:exc-conn-case}
 covers the case where a connector of a component is left unconnected and the source given textually).
 \end{nonnormative}
 \item

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -1,4 +1,4 @@
-\chapter{Modelica DAE Representation}\doublelabel{modelica-dae-representation}
+\chapter{Modelica DAE Representation}\label{modelica-dae-representation}
 
 In this appendix, the mapping of a Modelica model into an appropriate
 mathematical description form is discussed.

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -68,20 +68,20 @@ by a discrete-event system. Such types of systems are called
 \emph{hybrid DAEs}. Simulation is performed in the following way:
 \begin{enumerate}
 \item
-  The DAE (\ref{eq:dae}) is solved by a numerical integration method. In this
+  The DAE \cref{eq:dae} is solved by a numerical integration method. In this
   phase the conditions $c$ of the if- and when-clauses, as well as the
-  discrete variables $m$ are kept constant. Therefore, (\ref{eq:dae}) is a
+  discrete variables $m$ are kept constant. Therefore, \cref{eq:dae} is a
   continuous function of continuous variables and the most basic
   requirement of numerical integrators is fulfilled.
 \item
-  During integration, all relations from (\ref{eq:crossing}) are monitored. If one of
+  During integration, all relations from \cref{eq:crossing} are monitored. If one of
   the relations changes its value an event is triggered, i.e., the exact
   time instant of the change is determined and the integration is
   halted. As discussed in \cref{events-and-synchronization}, relations which depend only on
   time are usually treated in a special way, because this allows to
   determine the time instant of the next event in advance.
 \item
-  At an event instant, (\ref{eq:hydrid-dae}) is a mixed set of algebraic equations which
+  At an event instant, \cref{eq:hydrid-dae} is a mixed set of algebraic equations which
   is solved for the Real, Boolean and Integer unknowns.
 \item
   After an event is processed, the integration is restarted with 1.
@@ -98,7 +98,7 @@ structure of a DAE where elements of the state vector $x$ are
 algebraic variables and residue equations of a DAE may change at event
 instants by disabling the appropriate part of the DAE. For clarity of
 the equations, this is not explicitly shown by an additional index in
-(\ref{eq:hydrid-dae}).
+\cref{eq:hydrid-dae}.
 
 At an event instant, including the initial event, the model equations
 are reinitialized according to the following iteration procedure:
@@ -113,7 +113,7 @@ loop
   pre(m) := m
 end loop
 \end{lstlisting}
-Solving (\ref{eq:hydrid-dae}) for the unknowns is non-trivial, because this set of
+Solving \cref{eq:hydrid-dae} for the unknowns is non-trivial, because this set of
 equations contains not only Real, but also Boolean and Integer unknowns.
 Usually, in a first step these equations are sorted and in many cases
 the Boolean and Integer unknowns can be just computed by a forward
@@ -122,8 +122,8 @@ evaluation sequence. In some cases, there remain systems of equations
 algorithms have to be used to solve them.
 
 Due to the construction of the equations by \emph{flattening} a Modelica
-model, the hybrid DAE (\ref{eq:hydrid-dae}) contains a huge number of sparse equations.
-Therefore, direct simulation of (\ref{eq:hydrid-dae}) requires sparse matrix methods.
+model, the hybrid DAE \cref{eq:hydrid-dae} contains a huge number of sparse equations.
+Therefore, direct simulation of \cref{eq:hydrid-dae} requires sparse matrix methods.
 However, solving this initial set of equations directly with a numerical
 method is both unreliable and inefficient. One reason is that many
 Modelica models, like the mechanical ones, have a DAE index of 2 or 3,
@@ -141,13 +141,13 @@ To summarize, symbolic transformation techniques are needed to transform
 important, the algorithm of Pantelides should to be applied to
 differentiate certain parts of the equations in order to reduce the
 index. Note, that also explicit integration methods, such as Runge-Kutta
-algorithms, can be used to solve (\ref{eq:dae}), after the index of (\ref{eq:dae}) has been
+algorithms, can be used to solve \cref{eq:dae}, after the index of \cref{eq:dae} has been
 reduced by the Pantelides algorithm: During continuous integration, the
-integrator provides $x$ and $t$. Then, (\ref{eq:dae}) is a linear or nonlinear system
+integrator provides $x$ and $t$. Then, \cref{eq:dae} is a linear or nonlinear system
 of equations to compute the algebraic variables $y$ and the state
 % TODO: Structured formatting of inline "upright 'd' fraction".
 derivatives $\mathrm{d}x/\mathrm{d}t$ and the model returns $\mathrm{d}x/\mathrm{d}t$ to the integrator by
-solving these systems of equations. Often, (\ref{eq:dae}) is just a linear system
+solving these systems of equations. Often, \cref{eq:dae} is just a linear system
 of equations in these unknowns, so that the solution is straightforward.
 This procedure is especially useful for real-time simulation where
 usually explicit one-step methods are used.

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -14,11 +14,11 @@ used components by:
   for every instance of the model.
 \item
   Replacing all connect-equations by the corresponding equations of the
-  connection set (see \autoref{generation-of-connection-equations}).
+  connection set (see \cref{generation-of-connection-equations}).
 \item
   Mapping all algorithm sections to equation sets.
 \item
-  Mapping all when-clauses to equation sets (see \autoref{when-equations}).
+  Mapping all when-clauses to equation sets (see \cref{when-equations}).
 \end{itemize}
 
 As a result of this transformation process, a set of equations is
@@ -50,7 +50,7 @@ These variables change their value only at event instants t\textsubscript{e}. \l
 \hline
 $y(t)$ & Modelica variables of type \lstinline!Real! which do not fall into any other category (= algebraic variables).\\
 \hline
-$c(t_{\mathrm{e}})$ & The conditions of all if-expressions generated including when-clauses after conversion, see \autoref{when-equations}).\\
+$c(t_{\mathrm{e}})$ & The conditions of all if-expressions generated including when-clauses after conversion, see \cref{when-equations}).\\
 \hline
 $\mathit{relation}(v)$ & A relation containing variables $v_{i}$, e.g.\ $v_{1} > v_{2}$, $v_{3} \geq 0$.\\
 \hline
@@ -61,7 +61,7 @@ above and are not discussed below.
 
 The generated set of equations is used for simulation and other analysis
 activities. Simulation means that an initial value problem is solved,
-i.e., initial values have to be provided for the states $x$, \autoref{initialization-initial-equation-and-initial-algorithm}.
+i.e., initial values have to be provided for the states $x$, \cref{initialization-initial-equation-and-initial-algorithm}.
 The equations define a DAE (Differential Algebraic Equations) which may
 have discontinuities, a variable structure and/or which are controlled
 by a discrete-event system. Such types of systems are called
@@ -77,7 +77,7 @@ by a discrete-event system. Such types of systems are called
   During integration, all relations from (\ref{eq:crossing}) are monitored. If one of
   the relations changes its value an event is triggered, i.e., the exact
   time instant of the change is determined and the integration is
-  halted. As discussed in \autoref{events-and-synchronization}, relations which depend only on
+  halted. As discussed in \cref{events-and-synchronization}, relations which depend only on
   time are usually treated in a special way, because this allows to
   determine the time instant of the next event in advance.
 \item

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -68,20 +68,20 @@ by a discrete-event system. Such types of systems are called
 \emph{hybrid DAEs}. Simulation is performed in the following way:
 \begin{enumerate}
 \item
-  The DAE \cref{eq:dae} is solved by a numerical integration method. In this
+  The DAE \eqref{eq:dae} is solved by a numerical integration method. In this
   phase the conditions $c$ of the if- and when-clauses, as well as the
-  discrete variables $m$ are kept constant. Therefore, \cref{eq:dae} is a
+  discrete variables $m$ are kept constant. Therefore, \eqref{eq:dae} is a
   continuous function of continuous variables and the most basic
   requirement of numerical integrators is fulfilled.
 \item
-  During integration, all relations from \cref{eq:crossing} are monitored. If one of
+  During integration, all relations from \eqref{eq:crossing} are monitored. If one of
   the relations changes its value an event is triggered, i.e., the exact
   time instant of the change is determined and the integration is
   halted. As discussed in \cref{events-and-synchronization}, relations which depend only on
   time are usually treated in a special way, because this allows to
   determine the time instant of the next event in advance.
 \item
-  At an event instant, \cref{eq:hydrid-dae} is a mixed set of algebraic equations which
+  At an event instant, \eqref{eq:hydrid-dae} is a mixed set of algebraic equations which
   is solved for the Real, Boolean and Integer unknowns.
 \item
   After an event is processed, the integration is restarted with 1.
@@ -98,7 +98,7 @@ structure of a DAE where elements of the state vector $x$ are
 algebraic variables and residue equations of a DAE may change at event
 instants by disabling the appropriate part of the DAE. For clarity of
 the equations, this is not explicitly shown by an additional index in
-\cref{eq:hydrid-dae}.
+\eqref{eq:hydrid-dae}.
 
 At an event instant, including the initial event, the model equations
 are reinitialized according to the following iteration procedure:
@@ -113,7 +113,7 @@ loop
   pre(m) := m
 end loop
 \end{lstlisting}
-Solving \cref{eq:hydrid-dae} for the unknowns is non-trivial, because this set of
+Solving \eqref{eq:hydrid-dae} for the unknowns is non-trivial, because this set of
 equations contains not only Real, but also Boolean and Integer unknowns.
 Usually, in a first step these equations are sorted and in many cases
 the Boolean and Integer unknowns can be just computed by a forward
@@ -122,8 +122,8 @@ evaluation sequence. In some cases, there remain systems of equations
 algorithms have to be used to solve them.
 
 Due to the construction of the equations by \emph{flattening} a Modelica
-model, the hybrid DAE \cref{eq:hydrid-dae} contains a huge number of sparse equations.
-Therefore, direct simulation of \cref{eq:hydrid-dae} requires sparse matrix methods.
+model, the hybrid DAE \eqref{eq:hydrid-dae} contains a huge number of sparse equations.
+Therefore, direct simulation of \eqref{eq:hydrid-dae} requires sparse matrix methods.
 However, solving this initial set of equations directly with a numerical
 method is both unreliable and inefficient. One reason is that many
 Modelica models, like the mechanical ones, have a DAE index of 2 or 3,
@@ -141,13 +141,13 @@ To summarize, symbolic transformation techniques are needed to transform
 important, the algorithm of Pantelides should to be applied to
 differentiate certain parts of the equations in order to reduce the
 index. Note, that also explicit integration methods, such as Runge-Kutta
-algorithms, can be used to solve \cref{eq:dae}, after the index of \cref{eq:dae} has been
+algorithms, can be used to solve \eqref{eq:dae}, after the index of \eqref{eq:dae} has been
 reduced by the Pantelides algorithm: During continuous integration, the
-integrator provides $x$ and $t$. Then, \cref{eq:dae} is a linear or nonlinear system
+integrator provides $x$ and $t$. Then, \eqref{eq:dae} is a linear or nonlinear system
 of equations to compute the algebraic variables $y$ and the state
 % TODO: Structured formatting of inline "upright 'd' fraction".
 derivatives $\mathrm{d}x/\mathrm{d}t$ and the model returns $\mathrm{d}x/\mathrm{d}t$ to the integrator by
-solving these systems of equations. Often, \cref{eq:dae} is just a linear system
+solving these systems of equations. Often, \eqref{eq:dae} is just a linear system
 of equations in these unknowns, so that the solution is straightforward.
 This procedure is especially useful for real-time simulation where
 usually explicit one-step methods are used.

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -1,7 +1,7 @@
 \chapter{Derivation of Stream Equations}\doublelabel{derivation-of-stream-equations}
 
 This appendix contains a derivation of the equation for stream
-connectors from \autoref{stream-connectors}.
+connectors from \cref{stream-connectors}.
 
 \section{Reasons for avoiding the actual mixing enthalpy in connector definitions}\doublelabel{reasons-for-avoiding-the-actual-mixing-enthalpy-in-connector-definitions}
 

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -105,12 +105,12 @@ the piecewise expressions, taking care of the different flow directions:
 \label{eq:D2}
 \end{subequations}
 
-Equation (\ref{eq:D2a}) is solved for $h_{mix}$
+Equation \cref{eq:D2a} is solved for $h_{mix}$
 \begin{equation*}
 h_{mix}=\frac{\text{max}(-\dot{m}_1,0)h_{outflow,1}+\text{max}(-\dot{m}_2,0)h_{outflow,2}+\text{max}(-\dot{m}_3,0)h_{outflow,3}}
 {\text{max}(\dot{m}_1,0)+\text{max}(\dot{m}_2,0)+\text{max}(\dot{m}_3,0)}
 \end{equation*}
-Using (\ref{eq:D2b}), the denominator can be changed to:
+Using \cref{eq:D2b}, the denominator can be changed to:
 \begin{equation*}
 h_{mix}=\frac{\text{max}(-\dot{m}_1,0)h_{outflow,1}+\text{max}(-\dot{m}_2,0)h_{outflow,2}+\text{max}(-\dot{m}_3,0)h_{outflow,3}}
 {\text{max}(-\dot{m}_1,0)+\text{max}(-\dot{m}_2,0)+\text{max}(-\dot{m}_3,0)}
@@ -249,8 +249,8 @@ This means that utilizing the information about uni-directional flow is
 very important.
 
 To summarize, if all mass flow rates are zero, the balance equations for
-stream variables (\ref{eq:D1}) and for flows (\ref{eq:D2}) are identically fulfilled. In
-such a case, any value of h\_mix fulfills (\ref{eq:D1}), i.e., a unique
+stream variables \cref{eq:D1} and for flows \cref{eq:D2} are identically fulfilled. In
+such a case, any value of h\_mix fulfills \cref{eq:D1}, i.e., a unique
 mathematical solution does not exist. This specification only requires
 that a solution fulfills the balance equations. Additionally, a
 recommendation is given to compute all unknowns in a unique way, by

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -1,9 +1,9 @@
-\chapter{Derivation of Stream Equations}\doublelabel{derivation-of-stream-equations}
+\chapter{Derivation of Stream Equations}\label{derivation-of-stream-equations}
 
 This appendix contains a derivation of the equation for stream
 connectors from \cref{stream-connectors}.
 
-\section{Reasons for avoiding the actual mixing enthalpy in connector definitions}\doublelabel{reasons-for-avoiding-the-actual-mixing-enthalpy-in-connector-definitions}
+\section{Reasons for avoiding the actual mixing enthalpy in connector definitions}\label{reasons-for-avoiding-the-actual-mixing-enthalpy-in-connector-definitions}
 
 Consider a connection set with \emph{n} connectors. The mixing enthalpy
 is defined by the mass balance
@@ -47,7 +47,7 @@ equations. The stream connectors provide a suitable alternative.
 \end{center}
 \end{figure}
 
-\section{Rationale for the formulation of inStream}\doublelabel{rationale-for-the-formulation-of-the-instream-operator}
+\section{Rationale for the formulation of inStream}\label{rationale-for-the-formulation-of-the-instream-operator}
 
 For simplicity, the derivation of \lstinline!inStream! is shown at hand of 3 model components that are connected together.
 The case for $N$ connections follows correspondingly.
@@ -149,12 +149,12 @@ similar considerations lead to the following.
 \text{\lstinline!inStream!}(h_{outflow,i})=\frac{\sum_{j=1,...,n;j\neq i}\text{max}(-\dot{m}_j,0)h_{outflow,j}}{\sum_{j=1,...,n;j\neq i}\text{max}(-\dot{m}_j,0)}
 \end{equation*}
 
-\section{Special cases covered by inStream definition}\doublelabel{special-cases-covered-by-the-instream-operator-definition}
-\subsection{Stream connector is not connected (N = 1)}\doublelabel{stream-connector-is-not-connected-n-1}
+\section{Special cases covered by inStream definition}\label{special-cases-covered-by-the-instream-operator-definition}
+\subsection{Stream connector is not connected (N = 1)}\label{stream-connector-is-not-connected-n-1}
 For this case, the return value of \lstinline!inStream! is arbitrary.
 Therefore, it is set to the outflow value.
 
-\subsection{Connection of 2 stream connectors, one to one connections (N = 2)}\doublelabel{connection-of-2-stream-connectors-one-to-one-connections-n-2}
+\subsection{Connection of 2 stream connectors, one to one connections (N = 2)}\label{connection-of-2-stream-connectors-one-to-one-connections-n-2}
 
 \begin{align*}
 \text{\lstinline!inStream!}(h_{outflow,1}) &= \frac{\text{max}(-\dot{m}_2,0)h_{outflow,2}}{\text{max}(-\dot{m}_2,0)}=h_{outflow,2}\\
@@ -167,7 +167,7 @@ may remove nonlinear systems of equations, which requires that either
 simplifications of the form $a * b / a = b$ must be provided, or that this
 case is treated directly.
 
-\subsection{Connection of 3 stream connectors where one mass flow rate is identical to zero}\doublelabel{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}
+\subsection{Connection of 3 stream connectors where one mass flow rate is identical to zero}\label{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}
 The case where N=3 and $\dot{m}_3=0$ occurs when a one-port sensor (like a temperature sensor) is
 connected to two connected components. For the sensor, the min attribute
 of the mass flow rate should be set to zero (no fluid exiting the
@@ -206,7 +206,7 @@ with direct feedthrough, since the discontinuous equation is then not
 part of an algebraic loop. Otherwise, it is advisable to regularize or
 filter the sensor signal.
 
-\subsection{Connection of 3 stream connectors where two mass flow rates are positive (ideal splitting junction for uni-directional flow)}\doublelabel{connection-of-3-stream-connectors-where-two-mass-flow-rates-are-positive-ideal-splitting-junction-for-uni-directional-flow}
+\subsection{Connection of 3 stream connectors where two mass flow rates are positive (ideal splitting junction for uni-directional flow)}\label{connection-of-3-stream-connectors-where-two-mass-flow-rates-are-positive-ideal-splitting-junction-for-uni-directional-flow}
 
 If uni-directional flow is present and an ideal splitter is modelled,
 the required flow direction should be defined in the connector instance

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -105,12 +105,12 @@ the piecewise expressions, taking care of the different flow directions:
 \label{eq:D2}
 \end{subequations}
 
-Equation \cref{eq:D2a} is solved for $h_{mix}$
+Equation \eqref{eq:D2a} is solved for $h_{mix}$
 \begin{equation*}
 h_{mix}=\frac{\text{max}(-\dot{m}_1,0)h_{outflow,1}+\text{max}(-\dot{m}_2,0)h_{outflow,2}+\text{max}(-\dot{m}_3,0)h_{outflow,3}}
 {\text{max}(\dot{m}_1,0)+\text{max}(\dot{m}_2,0)+\text{max}(\dot{m}_3,0)}
 \end{equation*}
-Using \cref{eq:D2b}, the denominator can be changed to:
+Using \eqref{eq:D2b}, the denominator can be changed to:
 \begin{equation*}
 h_{mix}=\frac{\text{max}(-\dot{m}_1,0)h_{outflow,1}+\text{max}(-\dot{m}_2,0)h_{outflow,2}+\text{max}(-\dot{m}_3,0)h_{outflow,3}}
 {\text{max}(-\dot{m}_1,0)+\text{max}(-\dot{m}_2,0)+\text{max}(-\dot{m}_3,0)}
@@ -249,8 +249,8 @@ This means that utilizing the information about uni-directional flow is
 very important.
 
 To summarize, if all mass flow rates are zero, the balance equations for
-stream variables \cref{eq:D1} and for flows \cref{eq:D2} are identically fulfilled. In
-such a case, any value of h\_mix fulfills \cref{eq:D1}, i.e., a unique
+stream variables \eqref{eq:D1} and for flows \eqref{eq:D2} are identically fulfilled. In
+such a case, any value of h\_mix fulfills \eqref{eq:D1}, i.e., a unique
 mathematical solution does not exist. This specification only requires
 that a solution fulfills the balance equations. Additionally, a
 recommendation is given to compute all unknowns in a unique way, by

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -8,19 +8,19 @@ depending on the syntactic context in which they occur:
 \item
   \emph{Normal equality equations} occurring in equation sections,
   including connect-equations and other equation types of special
-  syntactic form (\autoref{equations-in-equation-sections}).
+  syntactic form (\cref{equations-in-equation-sections}).
 \item
   \emph{Declaration equations}, which are part of variable, parameter,
-  or constant declarations (\autoref{declaration-equations}).
+  or constant declarations (\cref{declaration-equations}).
 \item
   \emph{Modification equations}, which are commonly used to modify
-  attributes of classes (\autoref{modifications}).
+  attributes of classes (\cref{modifications}).
 \item
   \emph{Binding equations}, which include both declaration equations and
   modification equations (for the value itself).
 \item
   \emph{Initial equations}, which are used to express equations for
-  solving initialization problems (\autoref{initialization-initial-equation-and-initial-algorithm}).
+  solving initialization problems (\cref{initialization-initial-equation-and-initial-algorithm}).
 \end{itemize}
 
 \section{Flattening and Lookup in Equations}\doublelabel{flattening-and-lookup-in-equations}
@@ -62,7 +62,7 @@ simple-expression "=" expression
 \end{lstlisting}
 The types of the left-hand-side and the right-hand-side of an equation
 need to be compatible in the same way as two arguments of binary
-operators (\autoref{type-compatible-expressions}).
+operators (\cref{type-compatible-expressions}).
 
 Three examples:
 \begin{itemize}
@@ -74,7 +74,7 @@ Three examples:
 \begin{nonnormative}
 Note: According to the grammar the if-then-else expression in
 the second example needs to be enclosed in parentheses to avoid parsing
-ambiguities. Also compare with \autoref{assignments-from-called-functions-with-multiple-results} about calling
+ambiguities. Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling
 functions with several results in assignment statements.
 \end{nonnormative}
 
@@ -88,7 +88,7 @@ for for-indices loop
 \end{lstlisting}
 
 For-equations may optionally use several iterators (for-indices), see
-\autoref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
+\cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
 \begin{lstlisting}[language=grammar]
 for-indices:
    for-index {"," for-index}
@@ -109,7 +109,7 @@ It is evaluated once for each for-equation, and is evaluated in the scope
 immediately enclosing the for-equation. The expression of a for-equation
 shall be a parameter expression. The iteration range of a for-equation
 can also be specified as Boolean or as an enumeration type, see
-\autoref{types-as-iteration-ranges} for more information. The loop-variable (\lstinline!IDENT!) is in scope
+\cref{types-as-iteration-ranges} for more information. The loop-variable (\lstinline!IDENT!) is in scope
 inside the loop-construct and shall not be assigned to.
 For each element of the evaluated vector expression, in the normal order, the loop-variable
 gets the value of that element and that is used to evaluate the body of the for-loop.
@@ -140,7 +140,7 @@ equation
 \subsubsection{Implicit Iteration Ranges of For-Equations}\doublelabel{implicit-iteration-ranges-of-for-equations}
 
 The iteration range of a loop variable may sometimes be inferred from
-its use as an array index. See \autoref{implicit-iteration-ranges} for more information.
+its use as an array index. See \cref{implicit-iteration-ranges} for more information.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -163,11 +163,11 @@ indices of the for-loop and conditions of the if-clause are parameter
 expressions that do not depend on cardinality, rooted,
 Connections.rooted, or Connections.isRoot. The
 for-equations/if-equations are expanded. Connect-equations are described
-in detail in \autoref{connect-equations-and-connectors}.
+in detail in \cref{connect-equations-and-connectors}.
 
 The same restrictions apply to Connections\allowbreak{}.branch, Connections\allowbreak{}.root, and
 Connections\allowbreak{}.potentialRoot; which after expansion are handled according
-to \autoref{equation-operators-for-overconstrained-connection-based-equation-systems1}.
+to \cref{equation-operators-for-overconstrained-connection-based-equation-systems1}.
 
 \subsection{If-Equations}\doublelabel{if-equations}
 
@@ -358,7 +358,7 @@ value of \lstinline!y! from the previous event instant.
 
 \subsubsection{Application of the Single-assignment Rule to When-Equations}\doublelabel{application-of-the-single-assignment-rule-to-when-equations}
 
-The Modelica single-assignment rule (\autoref{synchronous-data-flow-principle-and-single-assignment-rule}) has implications for
+The Modelica single-assignment rule (\cref{synchronous-data-flow-principle-and-single-assignment-rule}) has implications for
 when-equations:
 \begin{itemize}
 \item  Two when-equations may \emph{not} define the same variable.
@@ -388,7 +388,7 @@ end DoubleWhenConflict;
 One way to resolve the conflict would be to give one of the two
 when-equations higher priority. This is possible by rewriting the
 when-equation using \lstinline!elsewhen!, as in the \lstinline!WhenPriority! model
-below or using the statement version of the when-construct, see \autoref{when-statements}.
+below or using the statement version of the when-construct, see \cref{when-statements}.
 \end{nonnormative}
 
 \item  When-equations involving elsewhen-parts can be used to resolve
@@ -431,7 +431,7 @@ variables) only be applied (either as an individual variable or as part
 of an array of variables) in one equation (having \lstinline!reinit! of the same
 variable in when and else-when of the same variable is allowed). In case
 of \lstinline!reinit! active during initialization (due to when initial), see
-\autoref{initialization-initial-equation-and-initial-algorithm}.
+\cref{initialization-initial-equation-and-initial-algorithm}.
 
 \lstinline!reinit! does not break the single assignment rule, because \lstinline!reinit(x, expr)! in equations evaluates expr to a value (value),
 then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is
@@ -526,7 +526,7 @@ assert(T > 200 and T < 500, "Medium model outside feasible region");
 
 The \lstinline!terminate! equation or statement (using function
 syntax) successfully terminates the analysis which was carried out,
-see also \autoref{assert}. The termination is not immediate at the place
+see also \cref{assert}. The termination is not immediate at the place
 where it is defined since not all variable results might be available
 that are necessary for a successful stop. Instead, the termination
 actually takes place when the current integrator step is successfully
@@ -554,7 +554,7 @@ end ThrowingBall;
 
 \subsection{Equation Operators for Overconstrained Connection-Based Equation Systems}\doublelabel{equation-operators-for-overconstrained-connection-based-equation-systems}
 
-See \autoref{equation-operators-for-overconstrained-connection-based-equation-systems1} for a description of this topic.
+See \cref{equation-operators-for-overconstrained-connection-based-equation-systems1} for a description of this topic.
 
 \section{Synchronous Data-flow Principle and Single Assignment Rule}\doublelabel{synchronous-data-flow-principle-and-single-assignment-rule}
 
@@ -563,7 +563,7 @@ assignment rule, which are defined in the following way:
 \begin{enumerate}
 \item Discrete variables keep their actual values until these variables are explicitly changed.
 Differentiated variables have \lstinline!der(x)! corresponding to the time-derivative of \lstinline!x!,
-and \lstinline!x! is continuous, except when reinit is triggered - see \autoref{reinit}.
+and \lstinline!x! is continuous, except when reinit is triggered - see \cref{reinit}.
 Variable values can be accessed at any time instant during continuous integration and at event instants.
 
 \item At every time instant, during continuous integration and at event instants,
@@ -576,7 +576,7 @@ If computation or communication time has to be simulated, this property has to b
 
 \item There must exist a perfect matching of variables to equations after flattening, where a variable can only
 be matched to equations that can contribute to solving for the variable
-(\firstuse{perfect matching rule} --- previously called \emph{single assignment rule}); see also globally balanced \autoref{balanced-models}.
+(\firstuse{perfect matching rule} --- previously called \emph{single assignment rule}); see also globally balanced \cref{balanced-models}.
 \end{enumerate}
 
 \section{Events and Synchronization}\doublelabel{events-and-synchronization}
@@ -668,7 +668,7 @@ end when;
 \end{lstlisting}
 \end{example}
 
-Modelica is based on the synchronous data flow principle (\autoref{synchronous-data-flow-principle-and-single-assignment-rule}).
+Modelica is based on the synchronous data flow principle (\cref{synchronous-data-flow-principle-and-single-assignment-rule}).
 
 \begin{nonnormative}
 The rules for the synchronous data flow principle guarantee
@@ -775,7 +775,7 @@ In this case, the algorithmic statements within the when-statement remain active
 \begin{nonnormative}
 There is no special handling of inactive when-statements during initialization, instead
 variables assigned in when-statements are initialized using \lstinline!v:=pre(v)!
-before the body of the algorithm (since they are discrete), see \autoref{execution-of-an-algorithm-in-a-model}.
+before the body of the algorithm (since they are discrete), see \cref{execution-of-an-algorithm-in-a-model}.
 \end{nonnormative}
 
 Further constraints, necessary to determine the initial values of all
@@ -821,7 +821,7 @@ guesses, in case iterative solvers are used in the initialization phase.
 
 \begin{nonnormative}
 In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but which only have the default
-value of the start attribute as defined in \autoref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
+value of the start attribute as defined in \cref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
 \end{nonnormative}
 
 If a parameter has a modifier for the \lstinline!start!-attribute, does not have
@@ -963,7 +963,7 @@ Regarding DAEs, only that at most $n$ additional equations are
 needed to arrive at $2n+m$ equations in the initialization system. The
 reason is that in a higher index DAE problem the number of dynamic
 continuous-time state variables might be less than the number of state
-variables $n$. As noted in \autoref{initialization-initial-equation-and-initial-algorithm} a tool may add/remove
+variables $n$. As noted in \cref{initialization-initial-equation-and-initial-algorithm} a tool may add/remove
 initial equations to fulfill this requirement, if appropriate
 diagnostics are given.
 \end{example}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -1,6 +1,6 @@
-\chapter{Equations}\doublelabel{equations}
+\chapter{Equations}\label{equations}
 
-\section{Equation Categories}\doublelabel{equation-categories}
+\section{Equation Categories}\label{equation-categories}
 
 Equations in Modelica can be classified into different categories
 depending on the syntactic context in which they occur:
@@ -23,7 +23,7 @@ depending on the syntactic context in which they occur:
   solving initialization problems (\cref{initialization-initial-equation-and-initial-algorithm}).
 \end{itemize}
 
-\section{Flattening and Lookup in Equations}\doublelabel{flattening-and-lookup-in-equations}
+\section{Flattening and Lookup in Equations}\label{flattening-and-lookup-in-equations}
 
 A flattened equation is identical to the corresponding nonflattened
 equation.
@@ -31,7 +31,7 @@ equation.
 Names in an equation shall be found by looking up in the partially
 flattened enclosing class of the equation.
 
-\section{Equations in Equation Sections}\doublelabel{equations-in-equation-sections}
+\section{Equations in Equation Sections}\label{equations-in-equation-sections}
 
 The following kinds of equations may occur in equation sections. The
 syntax is defined as follows:
@@ -48,7 +48,7 @@ equation :
 No statements are allowed in equation sections, including the assignment
 statement using the := operator.
 
-\subsection{Simple Equality Equations}\doublelabel{simple-equality-equations}
+\subsection{Simple Equality Equations}\label{simple-equality-equations}
 
 Simple equality equations are the traditional kinds of equations known
 from mathematics that express an equality relation between two
@@ -78,7 +78,7 @@ ambiguities. Also compare with \cref{assignments-from-called-functions-with-mult
 functions with several results in assignment statements.
 \end{nonnormative}
 
-\subsection{For-Equations -- Repetitive Equation Structures}\doublelabel{for-equations-repetitive-equation-structures}
+\subsection{For-Equations -- Repetitive Equation Structures}\label{for-equations-repetitive-equation-structures}
 
 The syntax of a for-equation is as follows:
 \begin{lstlisting}[language=grammar]
@@ -102,7 +102,7 @@ The following is one example of a prefix of a for-equation:
 for IDENT in expression loop
 \end{lstlisting}
 
-\subsubsection{Explicit Iteration Ranges of For-Equations}\doublelabel{explicit-iteration-ranges-of-for-equations}
+\subsubsection{Explicit Iteration Ranges of For-Equations}\label{explicit-iteration-ranges-of-for-equations}
 The \lstinline!expression! of a for-equation shall be a vector expression,
 where more general array expressions are treated as vector of vectors or vector of matrices.
 It is evaluated once for each for-equation, and is evaluated in the scope
@@ -137,7 +137,7 @@ equation
 \end{example}
 
 
-\subsubsection{Implicit Iteration Ranges of For-Equations}\doublelabel{implicit-iteration-ranges-of-for-equations}
+\subsubsection{Implicit Iteration Ranges of For-Equations}\label{implicit-iteration-ranges-of-for-equations}
 
 The iteration range of a loop variable may sometimes be inferred from
 its use as an array index. See \cref{implicit-iteration-ranges} for more information.
@@ -151,7 +151,7 @@ end for;
 \end{lstlisting}
 \end{example}
 
-\subsection{Connect-Equations}\doublelabel{connect-equations}
+\subsection{Connect-Equations}\label{connect-equations}
 
 A connect-equation has the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -169,7 +169,7 @@ The same restrictions apply to Connections\allowbreak{}.branch, Connections\allo
 Connections\allowbreak{}.potentialRoot; which after expansion are handled according
 to \cref{equation-operators-for-overconstrained-connection-based-equation-systems1}.
 
-\subsection{If-Equations}\doublelabel{if-equations}
+\subsection{If-Equations}\label{if-equations}
 
 If-equations have the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -206,7 +206,7 @@ If this condition is violated, the single assignment rule would not hold, becaus
 although the number of unknowns remains the same.
 \end{nonnormative}
 
-\subsection{When-Equations}\doublelabel{when-equations}
+\subsection{When-Equations}\label{when-equations}
 
 When-equations have the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -234,7 +234,7 @@ equation
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Defining When-Equations by If-Expressions in Equality Equations}\doublelabel{defining-when-equations-by-if-expressions-in-equality-equations}
+\subsubsection{Defining When-Equations by If-Expressions in Equality Equations}\label{defining-when-equations-by-if-expressions-in-equality-equations}
 
 A when-equation:
 \begin{lstlisting}[language=modelica]
@@ -285,7 +285,7 @@ taking the start-value of the when-condition, as above where \lstinline!b! is a
 parameter variable. The start-values of the special functions \lstinline!initial!,
 \lstinline!terminal!, and \lstinline!sample! is false.
 
-\subsubsection{Restrictions on Equations within When-Equations}\doublelabel{restrictions-on-equations-within-when-equations}
+\subsubsection{Restrictions on Equations within When-Equations}\label{restrictions-on-equations-within-when-equations}
 
 \begin{itemize}
 \item
@@ -356,7 +356,7 @@ deactivated and \lstinline!x! is computed from the first equation using the
 value of \lstinline!y! from the previous event instant.
 \end{nonnormative}
 
-\subsubsection{Application of the Single-assignment Rule to When-Equations}\doublelabel{application-of-the-single-assignment-rule-to-when-equations}
+\subsubsection{Application of the Single-assignment Rule to When-Equations}\label{application-of-the-single-assignment-rule-to-when-equations}
 
 The Modelica single-assignment rule (\cref{synchronous-data-flow-principle-and-single-assignment-rule}) has implications for
 when-equations:
@@ -414,7 +414,7 @@ end WhenPriority;
 \end{nonnormative}
 \end{itemize}
 
-\subsection{reinit}\doublelabel{reinit}
+\subsection{reinit}\label{reinit}
 
 \lstinline!reinit! can only be used in the body of a when-equation.  It has the following syntax:
 \begin{lstlisting}[language=modelica]
@@ -457,7 +457,7 @@ end when
 \end{lstlisting}
 \end{example}
 
-\subsection{assert}\doublelabel{assert}
+\subsection{assert}\label{assert}
 
 An equation or statement of one of the following forms:
 \begin{lstlisting}[language=modelica]
@@ -522,7 +522,7 @@ assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{terminate}\doublelabel{terminate}
+\subsection{terminate}\label{terminate}
 
 The \lstinline!terminate! equation or statement (using function
 syntax) successfully terminates the analysis which was carried out,
@@ -552,11 +552,11 @@ end ThrowingBall;
 \end{lstlisting}
 \end{example}
 
-\subsection{Equation Operators for Overconstrained Connection-Based Equation Systems}\doublelabel{equation-operators-for-overconstrained-connection-based-equation-systems}
+\subsection{Equation Operators for Overconstrained Connection-Based Equation Systems}\label{equation-operators-for-overconstrained-connection-based-equation-systems}
 
 See \cref{equation-operators-for-overconstrained-connection-based-equation-systems1} for a description of this topic.
 
-\section{Synchronous Data-flow Principle and Single Assignment Rule}\doublelabel{synchronous-data-flow-principle-and-single-assignment-rule}
+\section{Synchronous Data-flow Principle and Single Assignment Rule}\label{synchronous-data-flow-principle-and-single-assignment-rule}
 
 Modelica is based on the synchronous data flow principle and the single
 assignment rule, which are defined in the following way:
@@ -579,7 +579,7 @@ be matched to equations that can contribute to solving for the variable
 (\firstuse{perfect matching rule} --- previously called \emph{single assignment rule}); see also globally balanced \cref{balanced-models}.
 \end{enumerate}
 
-\section{Events and Synchronization}\doublelabel{events-and-synchronization}
+\section{Events and Synchronization}\label{events-and-synchronization}
 
 The integration is halted and an event occurs whenever an event
 generation expression, e.g.\ \lstinline!x > 2! o or \lstinline!floor(x)!, changes
@@ -743,7 +743,7 @@ program the synchronization of events allow a certain degree of model
 verification already at compile time.
 \end{nonnormative}
 
-\section{Initialization, initial equation, and initial algorithm}\doublelabel{initialization-initial-equation-and-initial-algorithm}
+\section{Initialization, initial equation, and initial algorithm}\label{initialization-initial-equation-and-initial-algorithm}
 
 Before any operation is carried out with a Modelica model (e.g.,
 simulation or linearization), initialization takes place to assign
@@ -931,7 +931,7 @@ pre(y) := y;
 \end{lstlisting}
 \end{example}
 
-\subsection{The Number of Equations Needed for Initialization}\doublelabel{the-number-of-equations-needed-for-initialization}
+\subsection{The Number of Equations Needed for Initialization}\label{the-number-of-equations-needed-for-initialization}
 
 \begin{nonnormative}
 In general, for the case of a pure (first order) ordinary
@@ -968,7 +968,7 @@ initial equations to fulfill this requirement, if appropriate
 diagnostics are given.
 \end{example}
 
-\subsection{Recommended selection of start-values}\doublelabel{recommended-selection-of-start-values}
+\subsection{Recommended selection of start-values}\label{recommended-selection-of-start-values}
 
 In general many variables have start-values that are not fixed and
 selecting a sub-set of these can give a consistent set of start-values

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -4,11 +4,11 @@ This chapter describes the Modelica function construct.
 
 \section{Function Declaration}\doublelabel{function-declaration}
 
-A Modelica function is a specialized class (\autoref{function-as-a-specialized-class}) using the
+A Modelica function is a specialized class (\cref{function-as-a-specialized-class}) using the
 keyword \lstinline!function!. The body of a Modelica function is an algorithm
 section that contains procedural algorithmic code to be executed when
 the function is called, or alternatively an external function specifier
-(\autoref{external-function-interface}). Formal parameters are specified using the \lstinline!input! keyword,
+(\cref{external-function-interface}). Formal parameters are specified using the \lstinline!input! keyword,
 whereas results are denoted using the \lstinline!output! keyword. This makes the
 syntax of function definitions quite close to Modelica class
 definitions, but using the keyword \lstinline!function! instead of \lstinline!class!.
@@ -82,7 +82,7 @@ end !\emph{\textless{}functionname\textgreater{}}!;
 
 \subsection{Function return-statements}\doublelabel{function-return-statements}
 
-The return-statement terminates the current function call, see \autoref{function-call}.
+The return-statement terminates the current function call, see \cref{function-call}.
 It can only be used in an algorithm section of a function. It has
 the following form:
 \begin{lstlisting}[language=modelica]
@@ -112,7 +112,7 @@ end findValue;
 \subsection{Inheritance of Functions}\doublelabel{inheritance-of-functions}
 
 It is allowed for a function to inherit and/or modify another function
-following the usual rules for inheritance of classes (\autoref{inheritance-modification-and-redeclaration}).
+following the usual rules for inheritance of classes (\cref{inheritance-modification-and-redeclaration}).
 
 \begin{nonnormative}
 For example, it is possible to modify and extend a function class to add default values for input variables.
@@ -120,7 +120,7 @@ For example, it is possible to modify and extend a function class to add default
 
 \section{Function as a Specialized Class}\doublelabel{function-as-a-specialized-class}
 
-The function concept in Modelica is a specialized class (\autoref{specialized-classes}).
+The function concept in Modelica is a specialized class (\cref{specialized-classes}).
 
 \begin{nonnormative}
 The syntax and semantics of a function have many similarities to those of the \lstinline!block! specialized class. A function has many of the properties
@@ -173,16 +173,16 @@ Modelica \lstinline!class!:
 	\lstinline!reinit!, \lstinline!delay!, \lstinline!cardinality!,
 	\lstinline!inStream!, \lstinline!actualStream!,
   to the operators of the built-in package \lstinline!Connections!, to the operators
-  defined in \autoref{synchronous-language-elements} and \autoref{state-machines}, and is not allowed to contain
+  defined in \cref{synchronous-language-elements} and \cref{state-machines}, and is not allowed to contain
   when-statements.
 \item
   The dimension \emph{sizes} not declared with (:) of each array result
   or array local variable (i.e., a non-input components) of a
   function must be either given by the input formal parameters, or given
   by constant or parameter expressions, or by expressions containing
-  combinations of those (\autoref{initialization-and-binding-equations-of-components-in-functions}).
+  combinations of those (\cref{initialization-and-binding-equations-of-components-in-functions}).
 \item
-  For initialization of local variables of a function see \autoref{initialization-and-binding-equations-of-components-in-functions}).
+  For initialization of local variables of a function see \cref{initialization-and-binding-equations-of-components-in-functions}).
 \item
   Components of a function will inside the function behave as though
   they had discrete-time variability.
@@ -192,24 +192,24 @@ Modelica functions have the following enhancements compared to a general
 Modelica \lstinline!class!:
 \begin{itemize}
 \item
-  Functions can be called, \autoref{function-call}.
+  Functions can be called, \cref{function-call}.
 
   \begin{itemize}
   \item
     The calls can use a mix of positional and named arguments, see
-    \autoref{positional-or-named-input-arguments-of-functions}.
+    \cref{positional-or-named-input-arguments-of-functions}.
   \item
-    Instances of functions have a special meaning, see \autoref{functional-input-arguments-to-functions}.
+    Instances of functions have a special meaning, see \cref{functional-input-arguments-to-functions}.
   \item
     The lookup of the function class to be called is extended, see
-    \autoref{composite-name-lookup}.
+    \cref{composite-name-lookup}.
   \end{itemize}
 \item
   A function can be \emph{recursive}.
 \item
   A formal parameter or local variable may be initialized through a
   \emph{binding} (=) of a default value in its declaration,
-  see \autoref{initialization-and-binding-equations-of-components-in-functions}.
+  see \cref{initialization-and-binding-equations-of-components-in-functions}.
   Using assignment (:=) is deprecated. If a non-input component in the
   function uses a record class that contain one or more binding
   equations they are viewed as initialization of those component of the
@@ -225,7 +225,7 @@ Modelica \lstinline!class!:
   A function may have a return statement in its algorithm section body.
 \item
   A function allows dimension sizes declared with (:) to be resized for
-  non-input array variables, see \autoref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
+  non-input array variables, see \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 \item
   A function may be defined in a short function definition to be a
   function partial derivative.
@@ -406,8 +406,8 @@ algorithm
 
 \section{Function Call}\doublelabel{function-call}
 
-Function classes and record constructors (\autoref{record-constructor-functions}) and enumeration type
-conversions (\autoref{type-conversion-of-integer-to-enumeration-values}) can be called as described in this section.
+Function classes and record constructors (\cref{record-constructor-functions}) and enumeration type
+conversions (\cref{type-conversion-of-integer-to-enumeration-values}) can be called as described in this section.
 
 \subsection{Positional or Named Input Arguments of Functions}\doublelabel{positional-or-named-input-arguments-of-functions}
 
@@ -419,7 +419,7 @@ f(3.5, 5.76, arg3=5, arg6=8.3);
 \end{lstlisting}
 
 The formal syntax of a function call (simplified by removing reduction
-expression, \autoref{reduction-expressions}):
+expression, \cref{reduction-expressions}):
 \begin{lstlisting}[language=grammar]
 primary :
    component-reference function-call-args
@@ -459,8 +459,8 @@ specification may not be called with named arguments, unless otherwise
 noted.
 
 The type of each argument must agree with the type of the corresponding
-parameter, except where the standard type coercion, \autoref{standard-type-coercion}, can be used to make
-the types agree. (See also \autoref{scalar-functions-applied-to-array-arguments} on applying scalar functions
+parameter, except where the standard type coercion, \cref{standard-type-coercion}, can be used to make
+the types agree. (See also \cref{scalar-functions-applied-to-array-arguments} on applying scalar functions
 to arrays.)
 
 \begin{example}
@@ -526,16 +526,16 @@ call:
 \item
   as a function type-specifier (\lstinline!Parabola! example below),
 \item
-  as a function partial application (\autoref{function-partial-application} below),
+  as a function partial application (\cref{function-partial-application} below),
 \item
   as a function that is a component (i.e., a formal parameter of function type of the enclosing function),
 \item
   as a function partial application of a function that is a component
-  (example in \autoref{function-partial-application} below).
+  (example in \cref{function-partial-application} below).
 \end{enumerate}
 
 In all cases the provided function must be \firstuse{function type compatible}
-(\autoref{function-compatibility-or-function-subtyping-for-functions}) to the corresponding formal parameter of function type.
+(\cref{function-compatibility-or-function-subtyping-for-functions}) to the corresponding formal parameter of function type.
 
 \begin{example}
 A function as a positional input argument according to case (a):
@@ -566,7 +566,7 @@ end quadrature2;
 A function partial application is similar to a function call with
 certain formal parameters bound to expressions, the specific rules are
 specified in this section and are not identical to the ones for function
-call in \autoref{positional-or-named-input-arguments-of-functions}. A function partial application returns a partially
+call in \cref{positional-or-named-input-arguments-of-functions}. A function partial application returns a partially
 evaluated function that is also a function, with the remaining not bound
 formal parameters still present in the same order as in the original
 function declaration. A function partial application is specified by the
@@ -588,7 +588,7 @@ The function created by the function partial application acts as the
 original function but with the bound formal input parameters(s) removed,
 i.e., they cannot be supplied arguments at function call. The binding
 occurs when the partially evaluated function is created. A partially
-evaluated function is \firstuse{function compatible} (see \autoref{function-compatibility-or-function-subtyping-for-functions}) to the
+evaluated function is \firstuse{function compatible} (see \cref{function-compatibility-or-function-subtyping-for-functions}) to the
 same function where all bound arguments are removed.
 
 \begin{nonnormative}
@@ -783,7 +783,7 @@ variable is uninitialized (except for record components where modifiers
 may also initialize that component). It is an error to use (or return)
 an uninitialized variable in a function.  Binding equations for input
 formal parameters are interpreted as default arguments, as described in
-\autoref{positional-or-named-input-arguments-of-functions}.
+\cref{positional-or-named-input-arguments-of-functions}.
 
 \begin{nonnormative}
 It is recommended to check for use of uninitialized variables statically --- if this is not possible a warning is recommended
@@ -792,14 +792,14 @@ combined with a run-time check.
 
 \begin{nonnormative}
 The properties of components in functions described in this
-section are also briefly described in \autoref{function-as-a-specialized-class}.
+section are also briefly described in \cref{function-as-a-specialized-class}.
 \end{nonnormative}
 
 \subsection{Flexible Array Sizes and Resizing of Arrays in Functions}\doublelabel{flexible-array-sizes-and-resizing-of-arrays-in-functions}
 
 \begin{nonnormative}
 Flexible setting of array dimension sizes of arrays in
-functions is also briefly described in \autoref{function-as-a-specialized-class}.
+functions is also briefly described in \cref{function-as-a-specialized-class}.
 \end{nonnormative}
 
 A dimension size not specified with colon(\lstinline!:!) for a non-input array
@@ -853,7 +853,7 @@ Functions with one scalar return value can be applied to arrays
 element-wise, e.g.\ if \lstinline!A! is a vector of reals, then \lstinline!sin(A)! is a vector
 where each element is the result of applying the function \lstinline!sin! to the
 corresponding element in \lstinline!A!. Only function classes that are transitively
-non-replaceable (\autoref{transitively-non-replaceable} and \autoref{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}) may be called vectorized.
+non-replaceable (\cref{transitively-non-replaceable} and \cref{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}) may be called vectorized.
 
 Consider the expression \lstinline!f(arg1,...,argn)!, an application of the function
 \lstinline!f! to the arguments \lstinline!arg1,..., argn! is defined.
@@ -953,14 +953,14 @@ algorithm
 There are basically four groups of built-in functions in Modelica:
 \begin{itemize}
 \item
-  Intrinsic mathematical and conversion functions, see \autoref{numeric-functions-and-conversion-functions}.
+  Intrinsic mathematical and conversion functions, see \cref{numeric-functions-and-conversion-functions}.
 \item
   Derivative and special operators with function syntax,
-  see \autoref{derivative-and-special-purpose-operators-with-function-syntax}.
+  see \cref{derivative-and-special-purpose-operators-with-function-syntax}.
 \item
-  Event-related operators with function syntax, see \autoref{event-related-operators-with-function-syntax}.
+  Event-related operators with function syntax, see \cref{event-related-operators-with-function-syntax}.
 \item
-  Built-in array functions, see \autoref{built-in-array-functions}.
+  Built-in array functions, see \cref{built-in-array-functions}.
 
   Note that when the specification references a function having the name
   of a built-in function it references the built-in function, not a
@@ -1151,7 +1151,7 @@ argument to the record constructor of \lstinline!R!. The interpretation is that 
 is replaced by a record constructor of type \lstinline!R! where all public
 components of \lstinline!M! that are present in \lstinline!R! are assigned to the corresponding
 components of \lstinline!R!. The record cast can be used in vectorized form
-according to \autoref{scalar-functions-applied-to-array-arguments}.
+according to \cref{scalar-functions-applied-to-array-arguments}.
 
 \begin{nonnormative}
 The problem if \lstinline!R! would be a conditional component is that the corresponding binding would be illegal since it is not a
@@ -1230,16 +1230,16 @@ end ModelExpanded;
 \section{Declaring Derivatives of Functions}\doublelabel{declaring-derivatives-of-functions}
 
 Derivatives of functions can be declared explicitly using the \lstinline!derivative!
-annotation, see \autoref{using-the-derivative-annotation}, whereas a function can be defined as a
+annotation, see \cref{using-the-derivative-annotation}, whereas a function can be defined as a
 partial derivative of another function using the \lstinline!der!-operator in a short
-function definition, see \autoref{partial-derivatives-of-functions}.
+function definition, see \cref{partial-derivatives-of-functions}.
 
 \subsection{Using the Derivative Annotation}\doublelabel{using-the-derivative-annotation}
 
 A function declaration can have an annotation \lstinline!derivative! specifying the
 derivative function or preferably, for a function written in Modelica,
 use the smoothOrder annotation to indicate that the tool can construct
-the derivative function automatically, \autoref{annotations-for-code-generation}. The derivative
+the derivative function automatically, \cref{annotations-for-code-generation}. The derivative
 annotation can influence simulation time and accuracy and can be applied
 to both functions written in Modelica and to external functions. A
 derivative annotation can state that it is only valid under certain
@@ -1626,7 +1626,7 @@ the equality \lstinline!y = $f_1$(..., $u_k$, ...,)! up to a certain precision.
 Function $f_1$ can have any number and types of formal
 Function $f_1$ can have any number and types of formal
 parameters with and without default value. The restriction is that the
-\emph{number of unknown variables} (see \autoref{balanced-models}) in the output formal
+\emph{number of unknown variables} (see \cref{balanced-models}) in the output formal
 parameter of both $f_1$ and $f_2$ must be
 the same and that $f_2$ should have a union of output and formal
 parameters that is the same or a sub-set of that union for $f_1$, but the order of the formal
@@ -1784,7 +1784,7 @@ A component reference to a component that is part of an input or output
 is treated the same way as a top-level input or output in the external
 call.
 
-If the function has \lstinline!annotation(Include="includeDirective")!, \autoref{annotations-for-external-libraries-and-include-files}
+If the function has \lstinline!annotation(Include="includeDirective")!, \cref{annotations-for-external-libraries-and-include-files}
 it is assumed that it contains an actual prototype and no prototype shall be automatically generated.
 In that case the input argument pointers shall be const pointers (indicating that they do not modify the inputs),
 and non-const pointers are deprecated.
@@ -1818,7 +1818,7 @@ An exception is made when the argument is of the form \lstinline!size!(\ldots{},
 
 Strings are NUL-terminated (i.e., terminated by '\lstinline!\0!') to
 facilitate calling of C functions. When returning a non-literal string,
-see \autoref{utility-functions-for-allocating-strings} for details on memory allocation.
+see \cref{utility-functions-for-allocating-strings} for details on memory allocation.
 
 Boolean values are mapped to C such that false in Modelica is 0 in C and
 true in Modelica is 1 in C.  If the returned value from C
@@ -1875,8 +1875,8 @@ example below.
 The table below shows the mapping of an array argument in the absence of
 an explicit external function call when calling a C function. The type \lstinline!T!
 is allowed to be any of the simple types which can be passed to C as
-defined in \autoref{simple-types} or a record type as defined in
-\autoref{records} and it is mapped to the type \lstinline!T'! as defined in these sections
+defined in \cref{simple-types} or a record type as defined in
+\cref{records} and it is mapped to the type \lstinline!T'! as defined in these sections
 for input arguments.
 
 \begin{longtable}[]{|l|l|}
@@ -1900,7 +1900,7 @@ absence of an explicit external function call is similar to the one
 defined above for C: first the address of the array, then the dimension
 sizes as integers. See the table below. The type T is allowed to be any
 of the simple types which can be passed to FORTRAN~77 as defined in
-\autoref{simple-types} and it is mapped to the type T' as defined in that
+\cref{simple-types} and it is mapped to the type T' as defined in that
 section.
 
 \begin{longtable}[]{|l|l|}
@@ -2055,7 +2055,7 @@ not to return anything; i.e., it is really a procedure or, in C, a
 void-function.
 
 \begin{nonnormative}
-In the case of an external function not returning anything, argument type mapping according to \autoref{simple-types} is performed in the absence
+In the case of an external function not returning anything, argument type mapping according to \cref{simple-types} is performed in the absence
 of any explicit external function call.
 \end{nonnormative}
 
@@ -2070,12 +2070,12 @@ Return types are by default mapped as follows for C and FORTRAN~77:
 \lstinline!String! & \lstinline!const char*! & Not allowed.\\ \hline
 \lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! & Not allowed. & Not allowed.\\ \hline
 Enumeration type & \lstinline!int! & \lstinline!INTEGER!\\ \hline
-Record & See \autoref{records}. & Not allowed.\\ \hline
+Record & See \cref{records}. & Not allowed.\\ \hline
 \end{longtable}
 
 The element type \lstinline!T! of an array can be any simple type as defined in
-\autoref{simple-types} or, for C, a record type is returned as a value of the
-record type defined in \autoref{records}.
+\cref{simple-types} or, for C, a record type is returned as a value of the
+record type defined in \cref{records}.
 
 \subsection{Aliasing}\doublelabel{aliasing}
 
@@ -2180,13 +2180,13 @@ indicated below for annotation (Library=\ldots{}):
   \lstinline!annotation(IncludeDirectory="modelica://ModelicaLibraryName/Resources/Include")!,
   used to specify a location for header files. The preceding one is the
   default and need not be specified; but another location could be
-  specified by using an URI name for the include directory, see \autoref{external-resources}.
+  specified by using an URI name for the include directory, see \cref{external-resources}.
 \item
   The
   \lstinline!annotation(LibraryDirectory="modelica://ModelicaLibraryName/Resources/Library")!,
   used to specify a location for library files. The preceding one is the
   default and need not be specified; but another location could be
-  specified by using an URI name for the library directory, see \autoref{external-resources}.
+  specified by using an URI name for the library directory, see \cref{external-resources}.
   Different versions of one object library can be provided
   (e.g.\ for Windows and for Linux) by providing a
   \emph{platform} directory below the \lstinline!LibraryDirectory!. If no
@@ -2517,7 +2517,7 @@ is not allowed to access memory that was allocated with
 
 \begin{nonnormative}
 Memory that is not passed to the Modelica simulation environment, such as memory that is freed before leaving the function, or in an \lstinline!ExternalObject!,
-see~\autoref{external-objects}, should be allocated with the standard C-mechanisms, like \lstinline[language=C]!calloc!.
+see~\cref{external-objects}, should be allocated with the standard C-mechanisms, like \lstinline[language=C]!calloc!.
 \end{nonnormative}
 
 \begin{nonnormative}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1,8 +1,8 @@
-\chapter{Functions}\doublelabel{functions}
+\chapter{Functions}\label{functions}
 
 This chapter describes the Modelica function construct.
 
-\section{Function Declaration}\doublelabel{function-declaration}
+\section{Function Declaration}\label{function-declaration}
 
 A Modelica function is a specialized class (\cref{function-as-a-specialized-class}) using the
 keyword \lstinline!function!. The body of a Modelica function is an algorithm
@@ -51,7 +51,7 @@ end !\emph{functionname}!;
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{Ordering of Formal Parameters}\doublelabel{ordering-of-formal-parameters}
+\subsection{Ordering of Formal Parameters}\label{ordering-of-formal-parameters}
 
 The relative ordering between input formal parameter declarations is
 significant since that determines the matching between actual arguments
@@ -80,7 +80,7 @@ end !\emph{\textless{}functionname\textgreater{}}!;
 \end{lstlisting}
 \end{example}
 
-\subsection{Function return-statements}\doublelabel{function-return-statements}
+\subsection{Function return-statements}\label{function-return-statements}
 
 The return-statement terminates the current function call, see \cref{function-call}.
 It can only be used in an algorithm section of a function. It has
@@ -109,7 +109,7 @@ end findValue;
 \end{lstlisting}
 \end{example}
 
-\subsection{Inheritance of Functions}\doublelabel{inheritance-of-functions}
+\subsection{Inheritance of Functions}\label{inheritance-of-functions}
 
 It is allowed for a function to inherit and/or modify another function
 following the usual rules for inheritance of classes (\cref{inheritance-modification-and-redeclaration}).
@@ -118,7 +118,7 @@ following the usual rules for inheritance of classes (\cref{inheritance-modifica
 For example, it is possible to modify and extend a function class to add default values for input variables.
 \end{nonnormative}
 
-\section{Function as a Specialized Class}\doublelabel{function-as-a-specialized-class}
+\section{Function as a Specialized Class}\label{function-as-a-specialized-class}
 
 The function concept in Modelica is a specialized class (\cref{specialized-classes}).
 
@@ -231,7 +231,7 @@ Modelica \lstinline!class!:
   function partial derivative.
 \end{itemize}
 
-\section{Pure Modelica Functions}\doublelabel{pure-modelica-functions}
+\section{Pure Modelica Functions}\label{pure-modelica-functions}
 
 Modelica functions are normally \emph{pure} which makes it easy for
 humans to reason about the code since they behave as mathematical
@@ -404,12 +404,12 @@ algorithm
 \end{lstlisting}
 \end{example}
 
-\section{Function Call}\doublelabel{function-call}
+\section{Function Call}\label{function-call}
 
 Function classes and record constructors (\cref{record-constructor-functions}) and enumeration type
 conversions (\cref{type-conversion-of-integer-to-enumeration-values}) can be called as described in this section.
 
-\subsection{Positional or Named Input Arguments of Functions}\doublelabel{positional-or-named-input-arguments-of-functions}
+\subsection{Positional or Named Input Arguments of Functions}\label{positional-or-named-input-arguments-of-functions}
 
 A function call has optional positional arguments followed by zero, one
 or more named arguments, such as
@@ -486,7 +486,7 @@ RealToString(2.0, 6, precision=6); // error: slot is used twice
 \end{lstlisting}
 \end{example}
 
-\subsection{Functional Input Arguments to Functions}\doublelabel{functional-input-arguments-to-functions}
+\subsection{Functional Input Arguments to Functions}\label{functional-input-arguments-to-functions}
 
 A functional input argument to a function is an argument of function
 type. The declared type of such an input formal parameter in a function
@@ -561,7 +561,7 @@ end quadrature2;
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Function Partial Application}\doublelabel{function-partial-application}
+\subsubsection{Function Partial Application}\label{function-partial-application}
 
 A function partial application is similar to a function call with
 certain formal parameters bound to expressions, the specific rules are
@@ -675,7 +675,7 @@ end surfaceQuadrature;
 \end{lstlisting}
 \end{example}
 
-\subsection{Output Formal Parameters of Functions}\doublelabel{output-formal-parameters-of-functions}
+\subsection{Output Formal Parameters of Functions}\label{output-formal-parameters-of-functions}
 
 A function may have more than one output component, corresponding to
 multiple return values. The only way to use more than the first return
@@ -749,8 +749,8 @@ The following are illegal:
 \end{example}
 
 \subsection{Initialization and Binding Equations of Components in Functions}
-\doublelabel{initialization-and-binding-equations-of-components-in-functions}
-\doublelabel{initialization-and-declaration-assignments-of-components-in-functions}
+\label{initialization-and-binding-equations-of-components-in-functions}
+\label{initialization-and-declaration-assignments-of-components-in-functions}
 
 Components in a function can be divided into three groups:
 \begin{itemize}
@@ -795,7 +795,7 @@ The properties of components in functions described in this
 section are also briefly described in \cref{function-as-a-specialized-class}.
 \end{nonnormative}
 
-\subsection{Flexible Array Sizes and Resizing of Arrays in Functions}\doublelabel{flexible-array-sizes-and-resizing-of-arrays-in-functions}
+\subsection{Flexible Array Sizes and Resizing of Arrays in Functions}\label{flexible-array-sizes-and-resizing-of-arrays-in-functions}
 
 \begin{nonnormative}
 Flexible setting of array dimension sizes of arrays in
@@ -847,7 +847,7 @@ end collectPositive;
 \end{lstlisting}
 \end{example}
 
-\subsection{Scalar Functions Applied to Array Arguments}\doublelabel{scalar-functions-applied-to-array-arguments}
+\subsection{Scalar Functions Applied to Array Arguments}\label{scalar-functions-applied-to-array-arguments}
 
 Functions with one scalar return value can be applied to arrays
 element-wise, e.g.\ if \lstinline!A! is a vector of reals, then \lstinline!sin(A)! is a vector
@@ -927,7 +927,7 @@ write \lstinline!1 + [1,2,3]!, because the rules for the built-in
 operators are more restrictive.
 \end{example}
 
-\subsection{Empty Function Calls}\doublelabel{empty-function-calls}
+\subsection{Empty Function Calls}\label{empty-function-calls}
 
 An \emph{empty} function call is a call that does not return any results.
 
@@ -948,7 +948,7 @@ algorithm
 \end{lstlisting}
 \end{example}
 
-\section{Built-in Functions}\doublelabel{built-in-functions}
+\section{Built-in Functions}\label{built-in-functions}
 
 There are basically four groups of built-in functions in Modelica:
 \begin{itemize}
@@ -967,7 +967,7 @@ There are basically four groups of built-in functions in Modelica:
   user-defined function having the same name.
 \end{itemize}
 
-\section{Record Constructor Functions}\doublelabel{record-constructor-functions}
+\section{Record Constructor Functions}\label{record-constructor-functions}
 
 Whenever a record is defined, a record constructor function with the
 same name and in the same scope as the record class is implicitly
@@ -1135,7 +1135,7 @@ appearing with prefixes, but it is not very meaningful, because it is
 simpler to just use a direct modifier.
 \end{nonnormative}
 
-\subsection{Casting to Record}\doublelabel{casting-to-record}
+\subsection{Casting to Record}\label{casting-to-record}
 
 A constructor of a record \lstinline!R! can be used to cast an instance m of a
 \lstinline!model!, \lstinline!block!, \lstinline!connector! class \lstinline!M! to a value of type \lstinline!R!, provided that for
@@ -1227,14 +1227,14 @@ end ModelExpanded;
 \end{lstlisting}
 \end{example}
 
-\section{Declaring Derivatives of Functions}\doublelabel{declaring-derivatives-of-functions}
+\section{Declaring Derivatives of Functions}\label{declaring-derivatives-of-functions}
 
 Derivatives of functions can be declared explicitly using the \lstinline!derivative!
 annotation, see \cref{using-the-derivative-annotation}, whereas a function can be defined as a
 partial derivative of another function using the \lstinline!der!-operator in a short
 function definition, see \cref{partial-derivatives-of-functions}.
 
-\subsection{Using the Derivative Annotation}\doublelabel{using-the-derivative-annotation}
+\subsection{Using the Derivative Annotation}\label{using-the-derivative-annotation}
 
 A function declaration can have an annotation \lstinline!derivative! specifying the
 derivative function or preferably, for a function written in Modelica,
@@ -1552,7 +1552,7 @@ This is useful if \lstinline!g! represents the major computational
 effort of \lstinline!fg!.
 \end{nonnormative}
 
-\subsection{Partial Derivatives of Functions}\doublelabel{partial-derivatives-of-functions}
+\subsection{Partial Derivatives of Functions}\label{partial-derivatives-of-functions}
 
 A class defined as:
 \begin{lstlisting}[language=grammar]
@@ -1592,7 +1592,7 @@ end specificEnthalpy;
 \end{lstlisting}
 \end{example}
 
-\section{Declaring Inverses of Functions}\doublelabel{declaring-inverses-of-functions}
+\section{Declaring Inverses of Functions}\label{declaring-inverses-of-functions}
 
 Every function with one output formal parameter may have one or more
 \lstinline!inverse! annotations to define inverses of this function:
@@ -1682,7 +1682,7 @@ algorithm
 end sine;
 \end{lstlisting}
 \end{example}
-\section{External Function Interface}\doublelabel{external-function-interface}
+\section{External Function Interface}\label{external-function-interface}
 
 Here, the word function is used to refer to an arbitrary external
 routine, whether or not the routine has a return value or returns its
@@ -1790,7 +1790,7 @@ In that case the input argument pointers shall be const pointers (indicating tha
 and non-const pointers are deprecated.
 The optional external-function-call is still used for determining the name of the function, and order of arguments, as described below.
 
-\subsection{Argument type Mapping}\doublelabel{argument-type-mapping}
+\subsection{Argument type Mapping}\label{argument-type-mapping}
 
 The arguments of the external function are declared in the same order as
 in the Modelica declaration, unless specified otherwise in an explicit
@@ -1798,7 +1798,7 @@ external function call. Protected variables (i.e.\ temporaries) are
 passed in the same way as outputs, whereas constants and size-expression
 are passed as inputs.
 
-\subsubsection{Simple Types}\doublelabel{simple-types}
+\subsubsection{Simple Types}\label{simple-types}
 
 Arguments of \emph{simple} types are by default mapped as follows for C:
 \begin{longtable}[]{|l|l|l|}
@@ -1856,7 +1856,7 @@ Return values are mapped to enumeration types analogously: integer value
 Returning a value which does not map to an existing enumeration literal
 for the specified enumeration type is an error.
 
-\subsubsection{Arrays}\doublelabel{arrays-1}
+\subsubsection{Arrays}\label{arrays-1}
 
 Unless an explicit function call is present in the external declaration,
 an array is passed by its address followed by n arguments of type
@@ -2005,7 +2005,7 @@ double fie(double *, size\_t, size\_t);
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Records}\doublelabel{records}
+\subsubsection{Records}\label{records}
 
 Mapping of record types is only supported for C. A Modelica record class
 that contains simple types, other record elements, is mapped as follows:
@@ -2041,7 +2041,7 @@ struct R {
 \end{lstlisting}
 \end{example}
 
-\subsection{Return Type Mapping}\doublelabel{return-type-mapping}
+\subsection{Return Type Mapping}\label{return-type-mapping}
 
 If there is a single output parameter and no explicit call of the
 external function, or if there is an explicit external call in the form
@@ -2077,7 +2077,7 @@ The element type \lstinline!T! of an array can be any simple type as defined in
 \cref{simple-types} or, for C, a record type is returned as a value of the
 record type defined in \cref{records}.
 
-\subsection{Aliasing}\doublelabel{aliasing}
+\subsection{Aliasing}\label{aliasing}
 
 Any potential aliasing in the external function is the responsibility of
 the tool and not the user. An external function is not allowed to
@@ -2151,7 +2151,7 @@ myfoo_(&a,&temp1,&b);
 The use of the function \lstinline!foo! in Modelica is uninfluenced by these considerations.
 \end{example}
 
-\subsection{Annotations for External Libraries and Include Files}\doublelabel{annotations-for-external-libraries-and-include-files}
+\subsection{Annotations for External Libraries and Include Files}\label{annotations-for-external-libraries-and-include-files}
 
 The following annotations are useful in the context of calling external
 functions from Modelica, and they should occur on the external clause
@@ -2330,9 +2330,9 @@ annotation are mapped to a linkage directive in a compiler-dependent way
 thereby selecting the object library suited for the respective computer
 platform.
 
-\subsection{Examples}\doublelabel{examples1}
+\subsection{Examples}\label{examples1}
 
-\subsubsection{Input Parameters, Function Value}\doublelabel{input-parameters-function-value}
+\subsubsection{Input Parameters, Function Value}\label{input-parameters-function-value}
 
 \begin{example}
 Here all parameters to the external function are input
@@ -2361,7 +2361,7 @@ z = foo(2.4, 3);
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Arbitrary Placement of Output Parameters, No External Function Value}\doublelabel{arbitrary-placement-of-output-parameters-no-external-function-value}
+\subsubsection{Arbitrary Placement of Output Parameters, No External Function Value}\label{arbitrary-placement-of-output-parameters-no-external-function-value}
 
 \begin{example}
 In the following example, the external function call is given
@@ -2390,7 +2390,7 @@ myfoo(2.4, \&z1, 3, \&i2);
 \end{lstlisting}
 \end{example}
 
-\subsubsection{External Function with Both Function Value and Output Variable}\doublelabel{external-function-with-both-function-value-and-output-variable}
+\subsubsection{External Function with Both Function Value and Output Variable}\label{external-function-with-both-function-value-and-output-variable}
 
 \begin{example}
 The following external function returns two results: one
@@ -2419,13 +2419,13 @@ z1 = myfoo(2.4, 3, \&i2);
 \end{lstlisting}
 \end{example}
 
-\subsection{Utility Functions}\doublelabel{utility-functions}
+\subsection{Utility Functions}\label{utility-functions}
 
 The following utility functions can be called in external Modelica
 functions written in C. These functions are defined in file
 \lstinline!ModelicaUtilities.h!:
 
-\subsubsection{Utility Functions for Reporting Errors}\doublelabel{utility-functions-for-reporting-errors}
+\subsubsection{Utility Functions for Reporting Errors}\label{utility-functions-for-reporting-errors}
 The following functions produce a message in different ways. The
 Message-functions only produce the message, but the Warning- and
 Error-functions combine this with error handling as follows.
@@ -2459,7 +2459,7 @@ ModelicaVFormat\{Message,Warning,Error\}\newline
 same format control as the C-function \lstinline!vprintf!.}}\\ \hline
 \end{longtable}
 
-\subsubsection{Utility Functions for Allocating Strings}\doublelabel{utility-functions-for-allocating-strings}
+\subsubsection{Utility Functions for Allocating Strings}\label{utility-functions-for-allocating-strings}
 And then the string handling functions:
 \begin{longtable}[]{|p{7cm}|p{8.2cm}|}
 \hline \endhead
@@ -2525,7 +2525,7 @@ The reason why one may not use, for instance, \lstinline[language=C]!malloc! for
 its own allocation scheme, e.g., a special stack for local variables of a function.
 \end{nonnormative}
 
-\subsection{External Objects}\doublelabel{external-objects}
+\subsection{External Objects}\label{external-objects}
 
 External functions may need to store their internal memory between function calls.
 Within Modelica this memory is defined as instance of the

--- a/chapters/glossary.tex
+++ b/chapters/glossary.tex
@@ -1,4 +1,4 @@
-\chapter{Glossary}\doublelabel{glossary}
+\chapter{Glossary}\label{glossary}
 \glossaryitem{algorithm section}: part of a class definition consisting of the
 keyword \lstinline!algorithm! followed by a sequence of statements. Like an
 equation, an algorithm section relates variables, i.e.\ constrains the

--- a/chapters/glossary.tex
+++ b/chapters/glossary.tex
@@ -8,7 +8,7 @@ outputs: An algorithm section specifies how to compute output variables
 as a function of given input variables. A Modelica processor may
 actually invert an algorithm section, i.e.\ compute inputs from given
 outputs, e.g.\ by search (generate and test), or by deriving an inverse
-algorithm symbolically. (See \autoref{statements-and-algorithm-sections}.)
+algorithm symbolically. (See \cref{statements-and-algorithm-sections}.)
 
 \glossaryitem{array} or array variable: a component whose components are array
 elements. For an array, the ordering of its components matters: The kth
@@ -17,19 +17,19 @@ element in the sequence of components of an array x is the array element
   type. An array element may again be an array, i.e.\ arrays can be nested.
 An array element is hence referenced using n indices in general, where n
 is the number of dimensions of the array. Special cases are matrix (n=2)
-and vector (n=1). Integer indices start with 1, not zero. (See \autoref{arrays}.)
+and vector (n=1). Integer indices start with 1, not zero. (See \cref{arrays}.)
 
 \glossaryitem{array constructor}: an array can be built using the
 array-function -- with the shorthand \{a, b, \ldots{}\}, and can also
-include an iterator to build an array of expressions. (See \autoref{vector-matrix-and-array-constructors}.)
+include an iterator to build an array of expressions. (See \cref{vector-matrix-and-array-constructors}.)
 
 \glossaryitem{array element}: a component contained in an array. An array
 element has no identifier. Instead they are referenced by array access
 expressions called indices that use enumeration values or positive
-integer index values. (See \autoref{arrays}.)
+integer index values. (See \cref{arrays}.)
 
 \glossaryitem{assignment}: a statement of the form \lstinline!x := expr!. The expression
-\lstinline!expr! must not have higher variability than~x. (See \autoref{simple-assignment-statements}.)
+\lstinline!expr! must not have higher variability than~x. (See \cref{simple-assignment-statements}.)
 
 \glossaryitem{attribute}: a component contained in a scalar component, such as
 \lstinline!min!, \lstinline!max!, and \lstinline!unit!. All attributes are predefined and attribute values
@@ -38,35 +38,35 @@ Attributes cannot be accessed using dot notation, and are not
 constrained by equations and algorithm sections. E.g.\ in \lstinline!Real x(unit="kg") = y;! only the values of \lstinline!x! and
 \lstinline!y! are declared to be equal,
 but not their unit attributes, nor any other attribute of \lstinline!x! and \lstinline!y!. (See
-\autoref{predefined-types-and-classes}.)
+\cref{predefined-types-and-classes}.)
 
 \glossaryitem{base class}: class A is called a base class of B, if class B
 extends class A. This relation is specified by an extends clause in B or
 in one of B's base classes. A class inherits all elements from its base
 classes, and may modify all non-final elements inherited from base
-classes. (See \autoref{inheritance-extends-clause}.)
+classes. (See \cref{inheritance-extends-clause}.)
 
 \glossaryitem{binding equation}: Either a declaration equation or an element
 modification for the value of the variable. In a non-function a component with a binding
-equation has its value bound to some expression. (See \autoref{equation-categories}.)
+equation has its value bound to some expression. (See \cref{equation-categories}.)
 In a function an input component uses the value of the binding equation as default value,
 a non-input component starts with that value.
-(See \autoref{initialization-and-binding-equations-of-components-in-functions}.)
+(See \cref{initialization-and-binding-equations-of-components-in-functions}.)
 
 \glossaryitem{class}: a description that generates an object called instance.
 The description consists of a class definition, a modification
 environment that modifies the class definition, an optional list of
 dimension expressions if the class is an array class, and a lexically
-enclosing class for all classes. (See \autoref{class-declarations}.)
+enclosing class for all classes. (See \cref{class-declarations}.)
 
 \glossaryitem{class type} or \glossaryitem{inheritance interface}: property of a
 class, consisting of a number of attributes and a set of public or
 protected elements consisting of element name, element type, and element
-attributes. (See \autoref{inheritance-interface-or-class-type}.)
+attributes. (See \cref{inheritance-interface-or-class-type}.)
 
 \glossaryitem{component} or \glossaryitem{variable}: an instance (object) generated
 by a component declaration. Special kinds of components are scalar,
-array, and attribute. (See \autoref{component-declarations}.)
+array, and attribute. (See \cref{component-declarations}.)
 
 \glossaryitem{component declaration}: an element of a class definition that
 generates a component. A component declaration specifies (1) a component
@@ -74,7 +74,7 @@ name, i.e., an identifier, (2) the class to be flattened in order to
 generate the component, and (3) an optional Boolean parameter
 expression. Generation of the component is suppressed if this parameter
 expression evaluates to false. A component declaration may be overridden
-by an element-redeclaration. (See \autoref{component-declarations}.)
+by an element-redeclaration. (See \cref{component-declarations}.)
 
 \glossaryitem{component reference}: An expression containing a sequence of
 identifiers and indices. A component reference is equivalent to the
@@ -82,7 +82,7 @@ referenced object, which must be a component. A component reference is
 resolved (evaluated) in the scope of a class (or expression for the case
 of a local iterator variable). A scope defines a set of visible
   components and classes. Example reference: \lstinline!Ele.Resistor.u[21].r! (See
-\autoref{component-declarations} and \autoref{slice-operation}.)
+\cref{component-declarations} and \cref{slice-operation}.)
 
 \glossaryitem{declaration assignment}: Deprecated name for binding equation in function.
 
@@ -90,10 +90,10 @@ of a local iterator variable). A scope defines a set of visible
 defined by a component declaration. The expression must not have higher
 variability than the declared component x. Unlike other equations, a
 declaration equation can be overridden (replaced or removed) by an
-element modification. (See \autoref{declaration-equations}.)
+element modification. (See \cref{declaration-equations}.)
 
 \glossaryitem{derived class} or \glossaryitem{subclass} or \glossaryitem{extended class}:
-class B is called derived from A, if B extends A. (See \autoref{inheritance-modification-and-redeclaration}.)
+class B is called derived from A, if B extends A. (See \cref{inheritance-modification-and-redeclaration}.)
 
 \glossaryitem{element}: part of a class definition, one of: class definition,
 component declaration, or extends clause. Component declarations and
@@ -102,15 +102,15 @@ inherited from a base class or local.
 
 \glossaryitem{element modification}: part of a modification, overrides the
 declaration equation in the class used by the instance generated by the
-modified element. Example: \lstinline!vcc(unit="V")=1000!. (See \autoref{modifications}.)
+modified element. Example: \lstinline!vcc(unit="V")=1000!. (See \cref{modifications}.)
 
 \glossaryitem{element-redeclaration}: part of a modification, replaces one of
 the named elements possibly used to build the instance geneated by the
-element that contains the redeclaration. Example: \lstinline!redeclare type Voltage = Real(unit="V")! replaces \lstinline!type Voltage!. (See \autoref{redeclaration}.)
+element that contains the redeclaration. Example: \lstinline!redeclare type Voltage = Real(unit="V")! replaces \lstinline!type Voltage!. (See \cref{redeclaration}.)
 
 \glossaryitem{encapsulated}: a class that does not depend on where it is
 placed in the package-hierarchy, since its lookup is stopped at the
-encapsulated boundary. (See \autoref{simple-name-lookup}).
+encapsulated boundary. (See \cref{simple-name-lookup}).
 
 \glossaryitem{equation}: part of a class definition. A scalar equation relates
 scalar variables, i.e.\ constrains the values that these variables can
@@ -119,45 +119,45 @@ variables are known, the value of the nth variable can be inferred
 (solved for). In contrast to a statement in an algorithm section, an
 equation does not define for which of its variable it is to be solved.
 Special cases are: initial equations, instantaneous equations,
-declaration equations. (See \autoref{equations}.)
+declaration equations. (See \cref{equations}.)
 
 \glossaryitem{event}: something that occurs instantaneously at a specific time
 or when a specific condition occurs. Events are for example defined by
 the condition occurring in a when clause, if clause, or if expression.
-(See \autoref{events-and-synchronization}.)
+(See \cref{events-and-synchronization}.)
 
 \glossaryitem{expression}: a term built from operators, function references,
 components, or component references (referring to components) and
-literals. Each expression has a type and a variability. (See \autoref{operators-and-expressions}.)
+literals. Each expression has a type and a variability. (See \cref{operators-and-expressions}.)
 
 \glossaryitem{extends clause}: an unnamed element of a class definition that
 uses a name and an optional modification to specify a base class of the
-class defined using the class definition. (See \autoref{inheritance-modification-and-redeclaration}.)
+class defined using the class definition. (See \cref{inheritance-modification-and-redeclaration}.)
 
 \glossaryitem{flattening}: the computation that creates a flattened class of a
 given class, where all inheritance, modification, etc.\ has been
 performed and all names resolved, consisting of a flat set of equations,
-algorithm sections, component declarations, and functions. (See \autoref{flattening-process}.)
+algorithm sections, component declarations, and functions. (See \cref{flattening-process}.)
 
-\glossaryitem{function}: a class of the specialized class function. (See \autoref{functions}.)
+\glossaryitem{function}: a class of the specialized class function. (See \cref{functions}.)
 
 \glossaryitem{function subtype} or \glossaryitem{function compatible interface}: A
 is a function subtype of B iff A is a subtype of B and the additional
 arguments of function A that are not in function B are defined in such a
 way (e.g.\ additional arguments need to have default values), that A can
-be called at places where B is called. (See \autoref{function-compatibility-or-function-subtyping-for-functions}.)
+be called at places where B is called. (See \cref{function-compatibility-or-function-subtyping-for-functions}.)
 
 \glossaryitem{identifier} or ident: an atomic (not composed) name. Example:
-\lstinline!Resistor! (See \autoref{identifiers-names-and-keywords}.)
+\lstinline!Resistor! (See \cref{identifiers-names-and-keywords}.)
 
 \glossaryitem{index} or \glossaryitem{subscript}: An expression, typically of
 Integer type or the colon symbol (:), used to reference a component (or
-a range of components) of an array. (See \autoref{array-indexing}.)
+a range of components) of an array. (See \cref{array-indexing}.)
 
 \glossaryitem{inheritance interface} or \glossaryitem{class type}: property of a
 class, consisting of a number of attributes and a set of public or
 protected elements consisting of element name, element type, and element
-attributes. (See \autoref{inheritance-interface-or-class-type}.)
+attributes. (See \cref{inheritance-interface-or-class-type}.)
 
 \glossaryitem{instance}: the object generated by a class. An instance contains
 zero or more components (i.e.\ instances), equations, algorithms, and
@@ -168,69 +168,69 @@ specific type equivalence definitions are given e.g.\ for functions.
 
 \glossaryitem{instantaneous}: An equation or statement is instantaneous if it
 holds only at events, i.e., at single points in time. The equations and
-statements of a when-clause are instantaneous. (See \autoref{when-equations} and
-\autoref{when-statements}.)
+statements of a when-clause are instantaneous. (See \cref{when-equations} and
+\cref{when-statements}.)
 
-\glossaryitem{interface}: see type. (See \autoref{interface-or-type}.)
+\glossaryitem{interface}: see type. (See \cref{interface-or-type}.)
 
 \glossaryitem{literal}: a real, integer, boolean, enumeration, or string
-literal. Used to build expressions. (See \autoref{literal-constants}.)
+literal. Used to build expressions. (See \cref{literal-constants}.)
 
 \glossaryitem{matrix}: an array where the number of dimensions is 2. (See
-\autoref{arrays}.)
+\cref{arrays}.)
 
 \glossaryitem{modification}: part of an element. Modifies the instance
 generated by that element. A modification contains element modifications
-and element redeclarations. (See \autoref{modifications}.)
+and element redeclarations. (See \cref{modifications}.)
 
 \glossaryitem{modification environment}: the modification environment of a
 class defines how to modify the corresponding class definition when
-flattening the class. (See \autoref{modification-environment}.)
+flattening the class. (See \cref{modification-environment}.)
 
 \glossaryitem{name}: Sequence of one or more identifiers. Used to reference a
 class. A class name is resolved in the scope of a class, which defines a
-set of visible classes. Example name: \lstinline!Ele.Resistor!. (See \autoref{names}.)
+set of visible classes. Example name: \lstinline!Ele.Resistor!. (See \cref{names}.)
 
 \glossaryitem{operator record}: A record with user-defined operations;
-defining e.g.\ multiplication and addition see \autoref{overloaded-operators}.
+defining e.g.\ multiplication and addition see \cref{overloaded-operators}.
 
 \glossaryitem{partial}: a class that is incomplete and cannot be instantiated
-in a simulation model; useful e.g.\ as a base-class. (See \autoref{component-declaration-static-semantics}.)
+in a simulation model; useful e.g.\ as a base-class. (See \cref{component-declaration-static-semantics}.)
 
 \glossaryitem{partial flattening}: first find the names of declared local
 classes and components. Modifiers, if present, are merged to the local
 elements and redeclarations are performed. Then base-classes are looked
 up, flattened and inserted into the class. See also flattening, which
 additionally flattens local elements and performs modifications. (See
-\autoref{flattening-process}.)
+\cref{flattening-process}.)
 
-\glossaryitem{plug-compatibility}: see restricted subtyping and \autoref{plug-compatibility-or-restricted-subtyping}.
+\glossaryitem{plug-compatibility}: see restricted subtyping and \cref{plug-compatibility-or-restricted-subtyping}.
 
 \glossaryitem{predefined type}: one of the types \lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!,
 \lstinline!String! and types defined as \lstinline!enumeration! types. The component
 declarations of the predefined types define attributes such as \lstinline!min!, \lstinline!max!,
-and \lstinline!unit!. (See \autoref{predefined-types-and-classes}.)
+and \lstinline!unit!. (See \cref{predefined-types-and-classes}.)
 
 \glossaryitem{prefix}: property of an element of a class definition which can
-be present or not be present, e.g.\ \lstinline!final!, \lstinline!public!, \lstinline!flow!. (See \autoref{prefix-rules}.)
+be present or not be present, e.g.\ \lstinline!final!, \lstinline!public!, \lstinline!flow!. (See \cref{prefix-rules}.)
 
 \glossaryitem{primitive type}: one of the built-in types \lstinline!RealType!,
 \lstinline!BooleanType!, \lstinline!IntegerType!, \lstinline!StringType!, \lstinline!EnumType!. The primitive types are
 used to define attributes and value of predefined types and enumeration
-types. (See \autoref{predefined-types-and-classes}.)
+types. (See \cref{predefined-types-and-classes}.)
 
 \glossaryitem{redeclare}: the modifier that changes a replaceable element.
-(See \autoref{redeclaration})
+(See \cref{redeclaration})
 
 \glossaryitem{replaceable}: an element that can be replaced by a different
-element having a compatible interface. (See \autoref{redeclaration})
+element having a compatible interface. (See \cref{redeclaration})
 
 \glossaryitem{restricted subtyping} or \glossaryitem{plug-compatibility}: a type A
 is a restricted subtype of type B iff A is a subtype of B, and all
 public components present in A but not in B must be default-connectable.
 This is used to avoid introducing, via a redeclaration, an un-connected
 connector in the object/class of type A at a level where a connection is
-not possible. (See \autoref{plug-compatibility-or-restricted-subtyping}.)
+not possible. (See \cref{plug-compatibility-or-restricted-subtyping}.)
 
 \glossaryitem{scalar} or scalar variable: a variable that is not an array.
 
@@ -241,27 +241,27 @@ types
 block, function, type. The class restriction of a class represents an
 assertion regarding the content of the class and restricts its use in
 other classes. For example, a class having the package class restriction
-must only contain classes and constants. (See \autoref{specialized-classes}.)
+must only contain classes and constants. (See \cref{specialized-classes}.)
 
 \glossaryitem{subtype} or \glossaryitem{interface compatible}: relation between
 types. A is a subtype of (interface compatible with) B iff a number of
 properties of A and B are the same and all important elements of B have
 corresponding elements in A with the same names and their types being
 subtypes of the corresponding element types in B. See also restricted
-subtyping and function restricted subtyping. (See \autoref{interface-compatibility-or-subtyping}.)
+subtyping and function restricted subtyping. (See \cref{interface-compatibility-or-subtyping}.)
 
 \glossaryitem{supertype}: relation between types. The inverse of subtype. A is
-a subtype of B means that B is a supertype of A. (See \autoref{interface-compatibility-or-subtyping}.)
+a subtype of B means that B is a supertype of A. (See \cref{interface-compatibility-or-subtyping}.)
 
 \glossaryitem{transitively nonreplaceable}: a class reference is considered
 transitively non-replaceable if there are no replaceable elements in the
 referenced class, or any of its base classes or constraining types
-transitively at any level. (See \autoref{transitively-non-replaceable}.)
+transitively at any level. (See \cref{transitively-non-replaceable}.)
 
 \glossaryitem{type} or interface: property of an instance, expression, consisting of a number of attributes and a set of public
 elements consisting of element name, element type, and element
 attributes. Note: The concept of class type is a property of a class
-definition. (See \autoref{interface-or-type}.)
+definition. (See \cref{interface-or-type}.)
 
 \glossaryitem{variability}: property of an expression: one of
 \begin{itemize}
@@ -277,9 +277,9 @@ in a package) .
 
 Assignments x := expr and binding equations x = expr must satisfy a
 variability constraint: The expression must not have a higher
-variability than component x. (See \autoref{variability-of-expressions}.)
+variability than component x. (See \cref{variability-of-expressions}.)
 
-\glossaryitem{variable}: synonym for component. (See \autoref{component-declarations}.)
+\glossaryitem{variable}: synonym for component. (See \cref{component-declarations}.)
 
 \glossaryitem{vector}: an array where the number of dimensions is 1. (See
-\autoref{arrays}.)
+\cref{arrays}.)

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -23,7 +23,7 @@ extends-clause :
    extends name [ class-modification ] [annotation]
 \end{lstlisting}
 The name of the base class is looked up in the partially flattened
-enclosing class (\autoref{enclosing-classes}) of the extends-clause. The found base
+enclosing class (\cref{enclosing-classes}) of the extends-clause. The found base
 class is flattened with a new environment and the partially flattened
 enclosing class of the extends-clause. The new environment is the result
 of merging
@@ -84,7 +84,7 @@ The declaration elements of the flattened base class shall either:
   Not already exist in the partially flattened enclosing class
   (i.e., have different names).
 \item
-  The new element is a long form of redeclare or uses the \lstinline!class extends A! syntax, see \autoref{redeclaration}.
+  The new element is a long form of redeclare or uses the \lstinline!class extends A! syntax, see \cref{redeclaration}.
 \item
   Be exactly identical to any element of the flattened enclosing class
   with the same name and the same level of protection (public or
@@ -139,7 +139,7 @@ current class (i.e., headings \lstinline!protected! and \lstinline!public! are n
 \subsection{Restrictions on the Kind of Base Class}\doublelabel{restrictions-on-the-kind-of-base-class}
 
 Since specialized classes of different kinds have different properties,
-see \autoref{specialized-classes}, only specialized classes that are \emph{in some sense
+see \cref{specialized-classes}, only specialized classes that are \emph{in some sense
 compatible} to each other can be derived from each other via
 inheritance. The following table shows which kind of specialized class
 can be used in an extends clause of another kind of specialized class
@@ -244,7 +244,7 @@ end ModelB;
 
 The class name used after extends for base-classes and for constraining
 classes must use a class reference considered transitively
-non-replaceable, see definition in \autoref{transitively-non-replaceable}.
+non-replaceable, see definition in \cref{transitively-non-replaceable}.
 For a replaceable component declaration without constraining
 clause the class must use a class reference considered transitively
 non-replaceable.
@@ -276,7 +276,7 @@ A modifier modifies one or more declarations from a class by changing
 some aspect(s) of the declarations. The most common kind of modifier
 just changes the \emph{default value} or the \emph{start value} in a
 binding equation; the value and/or start-value should be compatible with
-the variable according to \autoref{type-compatible-expressions}.
+the variable according to \cref{type-compatible-expressions}.
 
 \begin{example}
 Modifying the default \lstinline!start! value of the \lstinline!altitude! variable:
@@ -289,20 +289,20 @@ A modification (e.g.\ \lstinline!C1 c1(x = 5)!) is considered a modification equ
 if the modified variable (here: \lstinline!c1.x!) is a non-parameter variable.
 
 \begin{nonnormative}
-The modification equation is created, if the modified component (here: \lstinline!c1!) is also created (see \autoref{class-declarations}). In most cases
-a modification equation for a non-parameter variable requires that the variable was declared with a declaration equation, see \autoref{balanced-models};
+The modification equation is created, if the modified component (here: \lstinline!c1!) is also created (see \cref{class-declarations}). In most cases
+a modification equation for a non-parameter variable requires that the variable was declared with a declaration equation, see \cref{balanced-models};
 in those cases the declaration equation is replaced by the modification equation.
 \end{nonnormative}
 
 A more dramatic change is to modify the \emph{type} and/or the
 \emph{prefixes} and possibly the \emph{dimension sizes} of a declared
 element. This kind of modification is called a \emph{redeclaration}
-(\autoref{redeclaration}) and requires the special keyword \lstinline!redeclare! to be used in
+(\cref{redeclaration}) and requires the special keyword \lstinline!redeclare! to be used in
 the modifier in order to reduce the risk for accidental modeling errors.
 In most cases a declaration that can be redeclared must include the
-prefix \lstinline!replaceable! (\autoref{redeclaration}). The modifier value (and class for
+prefix \lstinline!replaceable! (\cref{redeclaration}). The modifier value (and class for
 redeclarations) is found in the context in which the modifier occurs,
-see also \autoref{simple-name-lookup}.
+see also \cref{simple-name-lookup}.
 
 \begin{example}
 Scope for modifiers:
@@ -334,7 +334,7 @@ When present, the description-string of a modifier overrides the existing descri
 
 \subsection{Syntax of Modifications and Redeclarations}\doublelabel{syntax-of-modifications-and-redeclarations}
 
-The syntax is defined in the grammar, \autoref{modification}.
+The syntax is defined in the grammar, \cref{modification}.
 
 \subsection{Modification Environment}\doublelabel{modification-environment}
 
@@ -344,7 +344,7 @@ built by merging class modifications, where outer modifications override
 inner modifications.
 
 \begin{nonnormative}
-This should not be confused with \lstinline!inner outer! prefixes described in \autoref{instance-hierarchy-name-lookup-of-inner-declarations}.
+This should not be confused with \lstinline!inner outer! prefixes described in \cref{instance-hierarchy-name-lookup-of-inner-declarations}.
 \end{nonnormative}
 
 \subsection{Merging of Modifications}\doublelabel{merging-of-modifications}
@@ -623,7 +623,7 @@ The groups that are valid for both classes and components:
 \item
   \lstinline!inner!, \lstinline!outer!
 \item
-  constraining type according to rules in \autoref{constraining-type}.
+  constraining type according to rules in \cref{constraining-type}.
 \end{itemize}
 
 The groups that are only valid for components:
@@ -703,7 +703,7 @@ extends it is not subject to the restriction that \lstinline!B! should be
 transitively non-replaceable (since \lstinline!B! should be replaceable).
 
 The syntax rule for \lstinline!class extends! construct is in the definition of the
-\lstinline!class-specifier! nonterminal (see also class declarations in \autoref{class-declarations}):
+\lstinline!class-specifier! nonterminal (see also class declarations in \cref{class-declarations}):
 \begin{lstlisting}[language=grammar]
 class-definition :
    [ encapsulated ] class-prefixes
@@ -838,7 +838,7 @@ For larger models this is not practical and therefore the only
 practically useful definition is the complicated construction in the
 previous example with \lstinline!redeclare model extends BaseProperties!.
 
-To detect this issue the rule on lookup of composite names (\autoref{composite-name-lookup})
+To detect this issue the rule on lookup of composite names (\cref{composite-name-lookup})
 ensures that \lstinline!PartialMedium.dynamicViscosity! is incorrect in a
 simulation model.
 \end{nonnormative}
@@ -1013,12 +1013,12 @@ replaceable Resistor load3 "The Load" constrainedby TwoPin "The Load!"; //Error
 \end{lstlisting}
 \end{example}
 
-See also the examples in \autoref{annotation-choices-for-suggested-redeclarations-and-modifications}.
+See also the examples in \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
 
 \subsection{Restrictions on Redeclarations}\doublelabel{restrictions-on-redeclarations}
 
 The following additional constraints apply to redeclarations (after
-prefixes are inherited, \autoref{redeclaration}):
+prefixes are inherited, \cref{redeclaration}):
 \begin{itemize}
 \item
   Only classes and components declared as replaceable can be redeclared with a new type, which must have an interface compatible with the constraining
@@ -1036,7 +1036,7 @@ prefixes are inherited, \autoref{redeclaration}):
   public, or a public element to be redeclared as protected.
 \item
   Array dimensions may be redeclared; provided the sub-typing rules in
-  \autoref{interface-compatibility-or-subtyping} are satisfied.
+  \cref{interface-compatibility-or-subtyping} are satisfied.
   \begin{nonnormative}
   This is one example of redeclare of non-replaceable elements.
   \end{nonnormative}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1,4 +1,4 @@
-\chapter{Inheritance, Modification, and Redeclaration}\doublelabel{inheritance-modification-and-redeclaration}
+\chapter{Inheritance, Modification, and Redeclaration}\label{inheritance-modification-and-redeclaration}
 
 One of the major benefits of object-orientation is the ability to
 \emph{extend} the behavior and properties of an existing class. The
@@ -13,7 +13,7 @@ checking, and modification, are performed on the inherited contents when
 appropriate. This chapter describes the inheritance concept in Modelica,
 together with the related concepts modification and redeclaration.
 
-\section{Inheritance---Extends Clause}\doublelabel{inheritance-extends-clause}
+\section{Inheritance---Extends Clause}\label{inheritance-extends-clause}
 
 The extends-clause is used to specify inheritance from a base class into
 an (enclosing) class containing the extends-clause. The syntax of the
@@ -122,12 +122,12 @@ equivalent equations due to inheritance.
 Equations that are mathematically equivalent but not syntactically equivalent are not discarded, hence yield an overdetermined system of equations.
 \end{nonnormative}
 
-\subsection{Multiple Inheritance}\doublelabel{multiple-inheritance}
+\subsection{Multiple Inheritance}\label{multiple-inheritance}
 
 Multiple inheritance is possible since multiple extends-clauses can be
 present in a class.
 
-\subsection{Inheritance of Protected and Public Elements}\doublelabel{inheritance-of-protected-and-public-elements}
+\subsection{Inheritance of Protected and Public Elements}\label{inheritance-of-protected-and-public-elements}
 
 If an extends-clause is used under the \lstinline!protected! heading, all elements
 of the base class become protected elements of the current class. If an
@@ -136,7 +136,7 @@ inherited with their own protection. The eventual headings \lstinline!protected!
 \lstinline!public! from the base class do not affect the consequent elements of the
 current class (i.e., headings \lstinline!protected! and \lstinline!public! are not inherited).
 
-\subsection{Restrictions on the Kind of Base Class}\doublelabel{restrictions-on-the-kind-of-base-class}
+\subsection{Restrictions on the Kind of Base Class}\label{restrictions-on-the-kind-of-base-class}
 
 Since specialized classes of different kinds have different properties,
 see \cref{specialized-classes}, only specialized classes that are \emph{in some sense
@@ -240,7 +240,7 @@ end ModelB;
 \end{lstlisting}
 \end{example}
 
-\subsection{Restrictions on Base Classes and Constraining Types to be Transitively Non-Replaceable}\doublelabel{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}
+\subsection{Restrictions on Base Classes and Constraining Types to be Transitively Non-Replaceable}\label{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}
 
 The class name used after extends for base-classes and for constraining
 classes must use a class reference considered transitively
@@ -259,7 +259,7 @@ The rule for a replaceable component declaration without constraining clause imp
 if explicitly given or implicitly by the declaration.
 \end{nonnormative}
 
-\section{Modifications}\doublelabel{modifications}
+\section{Modifications}\label{modifications}
 
 There are three kinds of constructs in the Modelica language in which
 modifications can occur:
@@ -332,11 +332,11 @@ end D;
 
 When present, the description-string of a modifier overrides the existing description.
 
-\subsection{Syntax of Modifications and Redeclarations}\doublelabel{syntax-of-modifications-and-redeclarations}
+\subsection{Syntax of Modifications and Redeclarations}\label{syntax-of-modifications-and-redeclarations}
 
 The syntax is defined in the grammar, \cref{modification}.
 
-\subsection{Modification Environment}\doublelabel{modification-environment}
+\subsection{Modification Environment}\label{modification-environment}
 
 The modification environment contains arguments which modify elements of
 the class (e.g., parameter changes). The modification environment is
@@ -347,7 +347,7 @@ inner modifications.
 This should not be confused with \lstinline!inner outer! prefixes described in \cref{instance-hierarchy-name-lookup-of-inner-declarations}.
 \end{nonnormative}
 
-\subsection{Merging of Modifications}\doublelabel{merging-of-modifications}
+\subsection{Merging of Modifications}\label{merging-of-modifications}
 
 Merging of modifiers means that outer modifiers override inner
 modifiers. The merging is hierarchical, and a value for an entire
@@ -453,7 +453,7 @@ A flattening of class \lstinline!C4! will give an object with the following vari
 \end{longtable}
 \end{example}
 
-\subsection{Single Modification}\doublelabel{single-modification}
+\subsection{Single Modification}\label{single-modification}
 
 Two arguments of a modification shall not modify the same element,
 attribute, or description-string. When using qualified names the different
@@ -495,7 +495,7 @@ m1(r=R(), r(y(min=2)))
 \end{lstlisting}
 \end{example}
 
-\subsection{Modifiers for Array Elements}\doublelabel{modifiers-for-array-elements}
+\subsection{Modifiers for Array Elements}\label{modifiers-for-array-elements}
 
 The following rules apply to modifiers:
 \begin{itemize}
@@ -553,7 +553,7 @@ This implies \lstinline!b[k].c[i].a[j] = j!, \lstinline!b[k].c[i].d = i!, and \l
 but it is necessary for \lstinline!c.d!.
 \end{example}
 
-\subsection{Final Element Modification Prevention}\doublelabel{final-element-modification-prevention}
+\subsection{Final Element Modification Prevention}\label{final-element-modification-prevention}
 
 An element defined as final by the \lstinline!final! prefix in an element
 modification or declaration cannot be modified by a modification or by a
@@ -589,7 +589,7 @@ end Test;
 \end{lstlisting}
 \end{example}
 
-\section{Redeclaration}\doublelabel{redeclaration}
+\section{Redeclaration}\label{redeclaration}
 
 A redeclare construct in a modifier replaces the declaration of a local
 class or component with another declaration. A redeclare construct as an
@@ -679,7 +679,7 @@ M m(redeclare Modelica.Units.SI.Length x[2,4]); // Valid redeclare of the type
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{The class extends Redeclaration Mechanism}\doublelabel{the-class-extends-redeclaration-mechanism}
+\subsection{The class extends Redeclaration Mechanism}\label{the-class-extends-redeclaration-mechanism}
 
 A class declaration of the type \lstinline!redeclare class extends B($\ldots$)! ,
 where \lstinline!class! as usual can be replaced by any other specialized class,
@@ -843,7 +843,7 @@ ensures that \lstinline!PartialMedium.dynamicViscosity! is incorrect in a
 simulation model.
 \end{nonnormative}
 
-\subsection{Constraining Type}\doublelabel{constraining-type}
+\subsection{Constraining Type}\label{constraining-type}
 
 In a replaceable declaration the optional \lstinline!constraining-clause! defines a
 constraining type. Any modifications following the constraining type
@@ -991,7 +991,7 @@ then \lstinline!T1! must also be a scalar type; and if \lstinline!T2! is defined
   (e.g.\ \lstinline!type T2 = Real[3]!) then \lstinline!T1! must also be vector type.
 \end{example}
 
-\subsubsection{Constraining-clause annotations}\doublelabel{constraining-clause-annotations}
+\subsubsection{Constraining-clause annotations}\label{constraining-clause-annotations}
 
 Description and annotations on the constraining-clause are applied to
 the entire declaration, and it is an error if they also appear on the
@@ -1015,7 +1015,7 @@ replaceable Resistor load3 "The Load" constrainedby TwoPin "The Load!"; //Error
 
 See also the examples in \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
 
-\subsection{Restrictions on Redeclarations}\doublelabel{restrictions-on-redeclarations}
+\subsection{Restrictions on Redeclarations}\label{restrictions-on-redeclarations}
 
 The following additional constraints apply to redeclarations (after
 prefixes are inherited, \cref{redeclaration}):
@@ -1042,7 +1042,7 @@ prefixes are inherited, \cref{redeclaration}):
   \end{nonnormative}
 \end{itemize}
 
-\subsection{Annotation Choices for Suggested Redeclarations and Modifications}\doublelabel{annotation-choices-for-suggested-redeclarations-and-modifications}
+\subsection{Annotation Choices for Suggested Redeclarations and Modifications}\label{annotation-choices-for-suggested-redeclarations-and-modifications}
 
 A declaration can have an annotation \lstinline!choices! containing modifiers on
 \lstinline!choice!, where each of them indicates a suitable redeclaration or

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -2,14 +2,14 @@
 
 A class or component, e.g.\ denoted \lstinline!A!, can in some cases be used at a
 location designed for another class or component, e.g.\ denoted \lstinline!B!. In
-Modelica this is the case for replaceable classes (see \autoref{redeclaration}) and
-for \lstinline!inner!/\lstinline!outer! elements (see \autoref{instance-hierarchy-name-lookup-of-inner-declarations}).
+Modelica this is the case for replaceable classes (see \cref{redeclaration}) and
+for \lstinline!inner!/\lstinline!outer! elements (see \cref{instance-hierarchy-name-lookup-of-inner-declarations}).
 Replaceable classes are the
 primary mechanism to create very flexible models. In this chapter, the
 precise rules are defined when \lstinline!A! can be used at a location designed for
 \lstinline!B!. The restrictions are defined in terms of compatibility rules
-(\autoref{interface-compatibility-or-subtyping} and \autoref{plug-compatibility-or-restricted-subtyping}) between ''interfaces'' (\autoref{the-concepts-of-type-interface-and-subtype}); this can
-also be viewed as sub-typing (\autoref{the-concepts-of-type-interface-and-subtype}).
+(\cref{interface-compatibility-or-subtyping} and \cref{plug-compatibility-or-restricted-subtyping}) between ''interfaces'' (\cref{the-concepts-of-type-interface-and-subtype}); this can
+also be viewed as sub-typing (\cref{the-concepts-of-type-interface-and-subtype}).
 
 In this chapter, two kinds of terminology is used for identical concepts
 to get better understanding (e.g.\ by both engineers and computer
@@ -81,14 +81,14 @@ values corresponding to type \lstinline!A!.
 The type \lstinline!Integer! is not a subtype of \lstinline!Real! in Modelica even though the
 set of primitive integer values is a subset of the primitive real values
 since there are some attributes of \lstinline!Real! that are not part of \lstinline!Integer!
-(\autoref{predefined-types-and-classes}).
+(\cref{predefined-types-and-classes}).
 
-The concept of \emph{interface} as defined in \autoref{interface-or-type} and used in
+The concept of \emph{interface} as defined in \cref{interface-or-type} and used in
 this document is equivalent to the notion of type based on sets in the
 following sense:
 
 An element is characterized by its interface defined by some attributes
-(\autoref{interface-or-type}). The \emph{type} of the element is the set of values
+(\cref{interface-or-type}). The \emph{type} of the element is the set of values
 having the same interface, i.e.\ the same attributes.
 
 A \emph{subtype} \lstinline!A1! in relation to another type \lstinline!A!, means that the
@@ -137,7 +137,7 @@ flattened element itself:
   Whether it is replaceable or not.
 \item
   Whether the class itself or the class of the component is transitively
-  non-replaceable (\autoref{transitively-non-replaceable}), and if not, the reference to the
+  non-replaceable (\cref{transitively-non-replaceable}), and if not, the reference to the
   replaceable class it refers to.
 \item
   Whether it is a component or a class.
@@ -171,7 +171,7 @@ flattened element itself:
   \end{itemize}
 \item
   Only for an \lstinline!operator record! class and classes derived from \lstinline!ExternalObject!: the full name of the operator record base-class
-  (i.e.\  the one containing the operations), or the derived class.  See \autoref{overloaded-operators} and \autoref{external-objects}.
+  (i.e.\  the one containing the operations), or the derived class.  See \cref{overloaded-operators} and \cref{external-objects}.
 
   The following item does not apply for an \lstinline!operator record! class or class derived from \lstinline!ExternalObject!, since the type is already
   uniquely defined by the full name.
@@ -190,7 +190,7 @@ flattened element itself:
 \end{itemize}
 
 The corresponding \emph{constraining} interface is constructed based on
-the \emph{constraining} type (\autoref{constraining-type}) of the declaration (if
+the \emph{constraining} type (\cref{constraining-type}) of the declaration (if
 replaceable -- otherwise same as actual type) and with the
 \emph{constraining} interface for the named elements.
 
@@ -227,10 +227,10 @@ only if}) all parts of the name satisfy the following:
 \end{itemize}
 
 \begin{nonnormative}
-According to \autoref{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}, for a hierarchical name all
+According to \cref{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}, for a hierarchical name all
 parts of the name must be transitively non-replaceable, i.e.\ in \lstinline!extends A.B.C! this implies that \lstinline!A.B.C! must be transitively
 non-replaceable, as well as \lstinline!A! and \lstinline!A.B!, with the exception of the \emph{class
-extends redeclaration mechanism} see \autoref{the-class-extends-redeclaration-mechanism}.
+extends redeclaration mechanism} see \cref{the-class-extends-redeclaration-mechanism}.
 \end{nonnormative}
 
 \subsection{Inheritance Interface or Class Type}\doublelabel{inheritance-interface-or-class-type}
@@ -247,7 +247,7 @@ itself:
   Whether it is replaceable or not.
 \item
   Whether the class itself or the class of the component is transitively
-  non-replaceable (\autoref{transitively-non-replaceable}), and if not the reference to
+  non-replaceable (\cref{transitively-non-replaceable}), and if not the reference to
   replaceable class it refers to.
 \item
   For each named element of the class (including both local and
@@ -311,17 +311,17 @@ equivalently that the type of \lstinline!A! is a subtype of the type of \lstinli
 \item
   If \lstinline!A! has an \lstinline!operator record! base-class then \lstinline!B! must also have one and
   it must be the same. If \lstinline!A! does not have an operator record base-class
-  then \lstinline!B! may not have one. See \autoref{overloaded-operators}.
+  then \lstinline!B! may not have one. See \cref{overloaded-operators}.
 \item
   If \lstinline!A! is derived from \lstinline!ExternalObject!, then \lstinline!B! must also be derived from
   \lstinline!ExternalObject! and have the same full name. If \lstinline!A! is not derived from
   \lstinline!ExternalObject! then \lstinline!B! may not derived from \lstinline!ExternalObject!. See
-  \autoref{external-objects}.
+  \cref{external-objects}.
 \item
   If \lstinline!B! is not replaceable then \lstinline!A! may not be replaceable.
 \item
   If \lstinline!B! is transitively non-replaceable then \lstinline!A! must be transitively
-  non-replaceable (\autoref{transitively-non-replaceable}). For all elements of the inheritance
+  non-replaceable (\cref{transitively-non-replaceable}). For all elements of the inheritance
   interface of \lstinline!B! there must exist a compatible element with the same
   name and visibility in the inheritance interface of \lstinline!A!. The interface
   of \lstinline!A! may not contain any other elements.
@@ -405,8 +405,8 @@ Intuitively, that the type \lstinline!A! is a subtype of the type of \lstinline!
 \end{nonnormative}
 
 Plug-compatibility is a further restriction of compatibility (subtyping)
-defined in \autoref{plug-compatibility-or-restricted-subtyping}, and further restricted for functions, see
-\autoref{function-compatibility-or-function-subtyping-for-functions}. For a replaceable declaration or modifier the default class
+defined in \cref{plug-compatibility-or-restricted-subtyping}, and further restricted for functions, see
+\cref{function-compatibility-or-function-subtyping-for-functions}. For a replaceable declaration or modifier the default class
 must be compatible with the constraining class.
 
 For a modifier the following must apply:
@@ -415,7 +415,7 @@ For a modifier the following must apply:
   The modified element should exist in the element being modified.
 \item
   The modifier should be compatible with the element being modified, and
-  in most cases also plug-compatible, \autoref{plug-compatibility-or-restricted-subtyping}.
+  in most cases also plug-compatible, \cref{plug-compatibility-or-restricted-subtyping}.
 \end{itemize}
 
 \begin{nonnormative}
@@ -430,7 +430,7 @@ similar entities.
 \section{Plug-Compatibility or Restricted Subtyping}\doublelabel{plug-compatibility-or-restricted-subtyping}
 
 \begin{nonnormative}
-If a sub-component is redeclared, see \autoref{redeclaration}, it is
+If a sub-component is redeclared, see \cref{redeclaration}, it is
 impossible to connect to any new connector. A connector with input
 prefix must be connected to, and since one cannot connect across
 hierarchies, one should not be allowed to introduce such a connector at
@@ -549,7 +549,7 @@ but also for replaceable classes.
 \begin{nonnormative}
 Functions may be called with either named or positional
 arguments, and thus both the name and order is significant. If a
-function is redeclared, see \autoref{redeclaration}, any new arguments must
+function is redeclared, see \cref{redeclaration}, any new arguments must
 have defaults (and be at the end) in order to preserve the meaning of
 existing calls.
 \end{nonnormative}
@@ -657,14 +657,14 @@ compatible subexpressions \lstinline!A! and \lstinline!B! is defined as follows:
   expression of a simple type.
 \item
   If \lstinline!A! is a \lstinline!Real! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression
-  and the type compatible expression is \lstinline!Real!, compare \autoref{standard-type-coercion}.
+  and the type compatible expression is \lstinline!Real!, compare \cref{standard-type-coercion}.
 \item
   If \lstinline!A! is an \lstinline!Integer! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer!
   expression. For exponentiation and division the type compatible
-  expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \autoref{exponentiation-of-scalars-of-numeric-elements}
-  and \autoref{division-of-scalars-or-numeric-arrays-by-numeric-scalars}, in
+  expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{exponentiation-of-scalars-of-numeric-elements}
+  and \cref{division-of-scalars-or-numeric-arrays-by-numeric-scalars}, in
   other cases the type compatible expression is \lstinline!Real! or \lstinline!Integer! (same as
-  \lstinline!B!), compare \autoref{standard-type-coercion}.
+  \lstinline!B!), compare \cref{standard-type-coercion}.
 \item
   If \lstinline!A! is a \lstinline!Boolean! expression then \lstinline!B! must be a \lstinline!Boolean! expression and
   the type compatible expression is \lstinline!Boolean!.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -1,4 +1,4 @@
-\chapter{Interface or Type Relationships}\doublelabel{interface-or-type-relationships}
+\chapter{Interface or Type Relationships}\label{interface-or-type-relationships}
 
 A class or component, e.g.\ denoted \lstinline!A!, can in some cases be used at a
 location designed for another class or component, e.g.\ denoted \lstinline!B!. In
@@ -60,7 +60,7 @@ E.g.\ an additional argument must have a default value.
 \end{nonnormative*}
 \end{definition}
 
-\section{The Concepts of Type, Interface and Subtype}\doublelabel{the-concepts-of-type-interface-and-subtype}
+\section{The Concepts of Type, Interface and Subtype}\label{the-concepts-of-type-interface-and-subtype}
 
 A \emph{type} can conceptually be viewed as a \emph{set of values}. When
 we say that the variable \lstinline!x! has the type \lstinline!Real!, we mean that the value of
@@ -125,7 +125,7 @@ that all contain \lstinline!x!, \lstinline!b!, and \lstinline!y!.}
 \end{figure}
 \end{example}
 
-\section{Interface or Type}\doublelabel{interface-or-type}
+\section{Interface or Type}\label{interface-or-type}
 
 Based on a flattened class or component we can construct an interface
 for that flattened class or component. The interface or type
@@ -205,7 +205,7 @@ The public interface does not contain all of the information about the class or 
 for internal type-checking we need e.g.\ import-elements.  However, the information is sufficient for checking compatibility and for using the class to flatten components.
 \end{nonnormative}
 
-\subsection{Transitively non-Replaceable}\doublelabel{transitively-non-replaceable}
+\subsection{Transitively non-Replaceable}\label{transitively-non-replaceable}
 
 \begin{nonnormative}
 In several cases it is important that no new elements can be
@@ -233,7 +233,7 @@ non-replaceable, as well as \lstinline!A! and \lstinline!A.B!, with the exceptio
 extends redeclaration mechanism} see \cref{the-class-extends-redeclaration-mechanism}.
 \end{nonnormative}
 
-\subsection{Inheritance Interface or Class Type}\doublelabel{inheritance-interface-or-class-type}
+\subsection{Inheritance Interface or Class Type}\label{inheritance-interface-or-class-type}
 
 For inheritance the interface also must include protected elements; this
 is the only change compared to above.
@@ -299,7 +299,7 @@ itself:
   \end{itemize}
 \end{itemize}
 
-\section{Interface Compatibility or Subtyping}\doublelabel{interface-compatibility-or-subtyping}
+\section{Interface Compatibility or Subtyping}\label{interface-compatibility-or-subtyping}
 
 An interface of a class or component \lstinline!A! is compatible with an interface
 of a class or component \lstinline!B! (or the constraining interface of \lstinline!B!), or
@@ -427,7 +427,7 @@ and compatible with original constraining class) and references refer to
 similar entities.
 \end{nonnormative}
 
-\section{Plug-Compatibility or Restricted Subtyping}\doublelabel{plug-compatibility-or-restricted-subtyping}
+\section{Plug-Compatibility or Restricted Subtyping}\label{plug-compatibility-or-restricted-subtyping}
 
 \begin{nonnormative}
 If a sub-component is redeclared, see \cref{redeclaration}, it is
@@ -544,7 +544,7 @@ plug-compatibility is required not only for replaceable sub-components,
 but also for replaceable classes.
 \end{nonnormative}
 
-\section{Function-Compatibility or Function-Subtyping for Functions}\doublelabel{function-compatibility-or-function-subtyping-for-functions}
+\section{Function-Compatibility or Function-Subtyping for Functions}\label{function-compatibility-or-function-subtyping-for-functions}
 
 \begin{nonnormative}
 Functions may be called with either named or positional
@@ -628,7 +628,7 @@ inside \lstinline!PlanetSimulation! is function-compatible with
 \lstinline!GravityInterface!.
 \end{example}
 
-\section{Type Compatible Expressions}\doublelabel{type-compatible-expressions}
+\section{Type Compatible Expressions}\label{type-compatible-expressions}
 
 Certain expressions consist of an operator applied to two or more type
 compatible sub-expressions (\lstinline!A! and \lstinline!B!), including binary operators, e.g.

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -1,11 +1,11 @@
-\chapter{Introduction}\doublelabel{introduction1}
-\section{Overview of Modelica}\doublelabel{overview-of-modelica}
+\chapter{Introduction}\label{introduction1}
+\section{Overview of Modelica}\label{overview-of-modelica}
 Modelica is a language for modeling of physical systems, designed to
 support effective library development and model exchange. It is a modern
 language built on acausal modeling with mathematical equations and
 object-oriented constructs to facilitate reuse of modeling knowledge.
 
-\section{Scope of the Specification}\doublelabel{scope-of-the-specification}
+\section{Scope of the Specification}\label{scope-of-the-specification}
 
 The semantics of the Modelica language is specified by means of a set of
 rules for translating any class described in the Modelica language to a
@@ -89,7 +89,7 @@ A Modelica class may also contain annotations, i.e.\ formal comments,
 which specify graphical representations of the class (icon and diagram),
 documentation text for the class, and version information.
 
-\section{Some Definitions}\doublelabel{some-definitions}
+\section{Some Definitions}\label{some-definitions}
 
 The semantic specification should be read together with the Modelica grammar.  Non-normative text, i.e., examples and comments, are enclosed in {[}\ldots{]} and set in italics.  Additional terms
 are explained in the glossary in \cref{glossary}.  Some important terms are defined below.
@@ -108,7 +108,7 @@ and components, and generation of connection equations from connect-equations (b
 together with the corresponding variable declarations and function definitions from the model).
 \end{definition}
 
-\section{Notation and Grammar}\doublelabel{notation-and-grammar}
+\section{Notation and Grammar}\label{notation-and-grammar}
 
 The meta symbols (of the extended BNF-grammar) are defined in~\cref{lexical-conventions}.
 

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -92,7 +92,7 @@ documentation text for the class, and version information.
 \section{Some Definitions}\doublelabel{some-definitions}
 
 The semantic specification should be read together with the Modelica grammar.  Non-normative text, i.e., examples and comments, are enclosed in {[}\ldots{]} and set in italics.  Additional terms
-are explained in the glossary in \autoref{glossary}.  Some important terms are defined below.
+are explained in the glossary in \cref{glossary}.  Some important terms are defined below.
 
 \begin{definition}[Component]
 An element defined by the production \lstinline!component-clause! in the Modelica grammar (basically a variable or an instance of a class)
@@ -110,7 +110,7 @@ together with the corresponding variable declarations and function definitions f
 
 \section{Notation and Grammar}\doublelabel{notation-and-grammar}
 
-The meta symbols (of the extended BNF-grammar) are defined in~\autoref{lexical-conventions}.
+The meta symbols (of the extended BNF-grammar) are defined in~\cref{lexical-conventions}.
 
 Boldface denotes keywords of the Modelica language. Keywords are
 reserved words and may not be used as identifiers, with the exception of
@@ -118,4 +118,4 @@ reserved words and may not be used as identifiers, with the exception of
 keyword for declaration functions, but it is also possible to call the
 functions \lstinline!initial! and \lstinline!der!.
 
-See \autoref{modelica-concrete-syntax} for a full lexical specification and grammar.
+See \cref{modelica-concrete-syntax} for a full lexical specification and grammar.

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -1,4 +1,4 @@
-\chapter{Lexical Structure}\doublelabel{lexical-structure}
+\chapter{Lexical Structure}\label{lexical-structure}
 
 This chapter describes several of the basic building blocks of Modelica
 such as characters and lexical units including identifiers and literals.
@@ -13,13 +13,13 @@ comments are detected by the lexical analyzer before being thrown away.
 The information presented here is derived from the more formal
 specification in \cref{modelica-concrete-syntax}.
 
-\section{Character Set}\doublelabel{character-set}
+\section{Character Set}\label{character-set}
 
 The character set of the Modelica language is Unicode, but restricted to
 the Unicode characters corresponding to 7-bit ASCII characters in
 several places; for details see \cref{lexical-conventions}.
 
-\section{Comments}\doublelabel{comments}
+\section{Comments}\label{comments}
 
 There are two kinds of comments in Modelica which are not lexical units
 in the language and therefore are treated as whitespace by a Modelica
@@ -61,7 +61,7 @@ model TempResistor "Temperature dependent resistor"
 end TempResistor;
 \end{lstlisting}
 
-\section{Identifiers, Names, and Keywords}\doublelabel{identifiers-names-and-keywords}
+\section{Identifiers, Names, and Keywords}\label{identifiers-names-and-keywords}
 
 \emph{Identifiers} are sequences of letters, digits, and other
 characters such as underscore, which are used for \emph{naming} various
@@ -69,7 +69,7 @@ items in the language. Certain combinations of letters are
 \emph{keywords} represented as \emph{reserved} words in the Modelica
 grammar and are therefore not available as identifiers.
 
-\subsection{Identifiers}\doublelabel{identifiers}
+\subsection{Identifiers}\label{identifiers}
 
 Modelica \emph{identifiers}, used for naming classes, variables,
 constants, and other items, are of two forms. The first form always
@@ -96,7 +96,7 @@ Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" 
 S-ESCAPE = "\'" | "\"" | "\?" | "\\" | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 \end{lstlisting}
 
-\subsection{Names}\doublelabel{names}
+\subsection{Names}\label{names}
 
 A \emph{name} is an identifier with a certain interpretation or meaning.
 For example, a name may denote an \lstinline!Integer! variable, a \lstinline!Real! variable, a
@@ -105,7 +105,7 @@ parts of the code, i.e., different scopes. The interpretation of
 identifiers as names is described in more detail in \cref{scoping-name-lookup-and-flattening}. The
 meaning of package names is described in more detail in \cref{packages}.
 
-\subsection{Modelica Keywords}\doublelabel{modelica-keywords}
+\subsection{Modelica Keywords}\label{modelica-keywords}
 
 The following Modelica \emph{keywords} are reserved words and may not be
 used as identifiers, except as listed in \cref{lexical-conventions}:
@@ -124,7 +124,7 @@ used as identifiers, except as listed in \cref{lexical-conventions}:
 \lstinline!der! & \lstinline!external! & \lstinline!input! & \lstinline!public! & \lstinline!within!\\ \hline
 \end{longtable}
 
-\section{Literal Constants}\doublelabel{literal-constants}
+\section{Literal Constants}\label{literal-constants}
 
 Literal constants are unnamed constants that have different forms
 depending on their type. Each of the predefined types in Modelica has a
@@ -132,7 +132,7 @@ way of expressing unnamed constants of the corresponding type, which is
 presented in the ensuing subsections. Additionally, array literals and
 record literals can be expressed.
 
-\subsection{Floating Point Numbers}\doublelabel{floating-point-numbers}
+\subsection{Floating Point Numbers}\label{floating-point-numbers}
 
 A floating point number is expressed as a decimal number in the form of
 a sequence of decimal digits followed by a decimal point, followed by decimal digits,
@@ -156,7 +156,7 @@ The last variant shows that that the leading zero is optional (in that case deci
 Note that \lstinline!13! is not in this list, since it is not a floating point number,
 but can be converted to a floating point number.
 
-\subsection{Integer Literals}\doublelabel{integer-literals}
+\subsection{Integer Literals}\label{integer-literals}
 
 Literals of type \lstinline!Integer! are sequences of decimal digits, e.g.\ as in the integer numbers \lstinline!33!, \lstinline!0!, \lstinline!100!, \lstinline!30030044!.
 The range of supported \lstinline!Integer! literals shall be at least large enough to represent the largest positive \lstinline!IntegerType! value, see \cref{integer-type}.
@@ -165,11 +165,11 @@ The range of supported \lstinline!Integer! literals shall be at least large enou
 Negative numbers are formed by unary minus followed by an integer literal.
 \end{nonnormative}
 
-\subsection{Boolean Literals}\doublelabel{boolean-literals}
+\subsection{Boolean Literals}\label{boolean-literals}
 
 The two \lstinline!Boolean! literal values are \lstinline!true! and \lstinline!false!.
 
-\subsection{Strings}\doublelabel{strings}
+\subsection{Strings}\label{strings}
 
 String literals appear between double quotes as in \lstinline!"between"!. Any
 character in the Modelica language character set (see \cref{lexical-conventions} for
@@ -237,7 +237,7 @@ level = AssertionLevel.warning);
 \end{lstlisting}
 \end{nonnormative}
 
-\section{Operator Symbols}\doublelabel{operator-symbols}
+\section{Operator Symbols}\label{operator-symbols}
 
 The predefined operator symbols are formally defined on page \pageref{lexical-conventions} and
 summarized in the table of operators in \cref{operator-precedence-and-associativity}.

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -11,13 +11,13 @@ lexical units since they are eventually discarded. On the other hand,
 comments are detected by the lexical analyzer before being thrown away.
 
 The information presented here is derived from the more formal
-specification in \autoref{modelica-concrete-syntax}.
+specification in \cref{modelica-concrete-syntax}.
 
 \section{Character Set}\doublelabel{character-set}
 
 The character set of the Modelica language is Unicode, but restricted to
 the Unicode characters corresponding to 7-bit ASCII characters in
-several places; for details see \autoref{lexical-conventions}.
+several places; for details see \cref{lexical-conventions}.
 
 \section{Comments}\doublelabel{comments}
 
@@ -85,7 +85,7 @@ The single quotes are part of the identifier, i.e., \lstinline!'x'! and \lstinli
 are distinct identifiers. The redundant escapes (\lstinline!'\?'! and \lstinline!'\"'!) are the same as the corresponding non-escaped
 variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica source code.
 A full BNF definition of the Modelica syntax and
-lexical units is available in \autoref{modelica-concrete-syntax}.
+lexical units is available in \cref{modelica-concrete-syntax}.
 
 \begin{lstlisting}[language=grammar,mathescape=false]
 IDENT   = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
@@ -102,13 +102,13 @@ A \emph{name} is an identifier with a certain interpretation or meaning.
 For example, a name may denote an \lstinline!Integer! variable, a \lstinline!Real! variable, a
 function, a type, etc. A name may have different meanings in different
 parts of the code, i.e., different scopes. The interpretation of
-identifiers as names is described in more detail in \autoref{scoping-name-lookup-and-flattening}. The
-meaning of package names is described in more detail in \autoref{packages}.
+identifiers as names is described in more detail in \cref{scoping-name-lookup-and-flattening}. The
+meaning of package names is described in more detail in \cref{packages}.
 
 \subsection{Modelica Keywords}\doublelabel{modelica-keywords}
 
 The following Modelica \emph{keywords} are reserved words and may not be
-used as identifiers, except as listed in \autoref{lexical-conventions}:
+used as identifiers, except as listed in \cref{lexical-conventions}:
 \begin{longtable}[c]{@{}lllll@{}}
 \lstinline!algorithm! & \lstinline!discrete! & \lstinline!false! & \lstinline!loop! & \lstinline!pure!\\ \hline
 \lstinline!and! & \lstinline!each! & \lstinline!final! & \lstinline!model! & \lstinline!record!\\ \hline
@@ -137,7 +137,7 @@ record literals can be expressed.
 A floating point number is expressed as a decimal number in the form of
 a sequence of decimal digits followed by a decimal point, followed by decimal digits,
 followed by an exponent indicated by E or e followed by a sign
-and one or more decimal digits. The various parts can be omitted, see \lstinline!UNSIGNED_REAL! in~\autoref{lexical-conventions} for
+and one or more decimal digits. The various parts can be omitted, see \lstinline!UNSIGNED_REAL! in~\cref{lexical-conventions} for
 details and also the examples below. The minimal recommended range is
 that of IEEE double precision floating point numbers, for which the
 largest representable positive number is 1.7976931348623157E+308 and the
@@ -159,7 +159,7 @@ but can be converted to a floating point number.
 \subsection{Integer Literals}\doublelabel{integer-literals}
 
 Literals of type \lstinline!Integer! are sequences of decimal digits, e.g.\ as in the integer numbers \lstinline!33!, \lstinline!0!, \lstinline!100!, \lstinline!30030044!.
-The range of supported \lstinline!Integer! literals shall be at least large enough to represent the largest positive \lstinline!IntegerType! value, see \autoref{integer-type}.
+The range of supported \lstinline!Integer! literals shall be at least large enough to represent the largest positive \lstinline!IntegerType! value, see \cref{integer-type}.
 
 \begin{nonnormative}
 Negative numbers are formed by unary minus followed by an integer literal.
@@ -172,7 +172,7 @@ The two \lstinline!Boolean! literal values are \lstinline!true! and \lstinline!f
 \subsection{Strings}\doublelabel{strings}
 
 String literals appear between double quotes as in \lstinline!"between"!. Any
-character in the Modelica language character set (see \autoref{lexical-conventions} for
+character in the Modelica language character set (see \cref{lexical-conventions} for
 allowed characters) apart from double quote (\lstinline!"!) and backslash
 (\lstinline!\!), including new-line, can be \emph{directly} included
 in a string without using an escape code. Certain characters in string
@@ -240,4 +240,4 @@ level = AssertionLevel.warning);
 \section{Operator Symbols}\doublelabel{operator-symbols}
 
 The predefined operator symbols are formally defined on page \pageref{lexical-conventions} and
-summarized in the table of operators in \autoref{operator-precedence-and-associativity}.
+summarized in the table of operators in \cref{operator-precedence-and-associativity}.

--- a/chapters/library.tex
+++ b/chapters/library.tex
@@ -1,4 +1,4 @@
-\chapter{The Modelica Standard Library}\doublelabel{the-modelica-standard-library}
+\chapter{The Modelica Standard Library}\label{the-modelica-standard-library}
 
 In order that a modeler can quickly build up system models, it is
 important that libraries of the most commonly used components are

--- a/chapters/literature.tex
+++ b/chapters/literature.tex
@@ -1,4 +1,4 @@
-\chapter{Literature}\doublelabel{literature}
+\chapter{Literature}\label{literature}
 
 Benveniste A., Caspi P., Edwards S.A., Halbwachs N., Le Guernic P., and Simone R. (2003):
 \bibitemtitle{The Synchronous Languages Twelve Years Later}.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -2,7 +2,7 @@
 
 The lexical units are combined to form even larger building blocks such
 as expressions according to the rules given by the expression part of
-the Modelica grammar in \autoref{modelica-concrete-syntax}.
+the Modelica grammar in \cref{modelica-concrete-syntax}.
 
 This chapter describes the evaluation rules for expressions, the concept
 of expression variability, built-in mathematical operators and
@@ -12,7 +12,7 @@ syntax.
 Expressions can contain variables and constants, which have types,
 predefined or user defined. The predefined built-in types of Modelica
 are \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, \lstinline!String!, and enumeration types which are
-presented in more detail in \autoref{predefined-types-and-classes}.
+presented in more detail in \cref{predefined-types-and-classes}.
 
 \begin{nonnormative}
 The abbreviated predefined type information below is given as background information for the rest of the presentation.
@@ -24,15 +24,15 @@ Modelica equations, assignments and declaration equations contain
 expressions.
 
 Expressions can contain basic operations, \lstinline!+!, \lstinline!-!, \lstinline!*!, \lstinline!/!, \lstinline!^!, etc.\ with
-normal precedence as defined in the Table in \autoref{operator-precedence-and-associativity} and the grammar
-in \autoref{modelica-concrete-syntax}. The semantics of the operations is defined for both
-scalar and array arguments in \autoref{scalar-vector-matrix-and-array-operator-functions}.
+normal precedence as defined in the Table in \cref{operator-precedence-and-associativity} and the grammar
+in \cref{modelica-concrete-syntax}. The semantics of the operations is defined for both
+scalar and array arguments in \cref{scalar-vector-matrix-and-array-operator-functions}.
 
 It is also possible to define functions and call them in a normal
 fashion. The function call syntax for both positional and named
-arguments is described in \autoref{positional-or-named-input-arguments-of-functions} and for vectorized calls in
-\autoref{initialization-and-binding-equations-of-components-in-functions}. The built-in array functions are given in \autoref{array-dimension-lower-and-upper-index-bounds}
-and other built-in operators in \autoref{built-in-intrinsic-operators-with-function-syntax}.
+arguments is described in \cref{positional-or-named-input-arguments-of-functions} and for vectorized calls in
+\cref{initialization-and-binding-equations-of-components-in-functions}. The built-in array functions are given in \cref{array-dimension-lower-and-upper-index-bounds}
+and other built-in operators in \cref{built-in-intrinsic-operators-with-function-syntax}.
 
 \section{Operator Precedence and Associativity}\doublelabel{operator-precedence-and-associativity}
 
@@ -42,7 +42,7 @@ operator with lower precedence in the same expression.
 
 The following table presents all the expression operators in order of
 precedence from highest to lowest, as derived from the Modelica grammar
-in \autoref{modelica-concrete-syntax}. All operators are binary except the postfix operators and
+in \cref{modelica-concrete-syntax}. All operators are binary except the postfix operators and
 those shown as unary together with \emph{expr}, the conditional
 operator, the array construction operator \lstinline!{ }! and concatenation
 operator \lstinline![ ]!, and the array range constructor which is either binary
@@ -157,7 +157,7 @@ numerical type:
 \end{longtable}
 
 Some of these operators can also be applied to a combination of a scalar
-type and an array type, see \autoref{scalar-vector-matrix-and-array-operator-functions}.
+type and an array type, see \cref{scalar-vector-matrix-and-array-operator-functions}.
 
 The syntax of these operators is defined by the following rules from the
 Modelica grammar:
@@ -194,8 +194,8 @@ all of which produce the standard boolean values \lstinline!true! or \lstinline!
 \end{longtable}
 
 A single equals sign \lstinline!=! is never used in relational expressions, only in
-equations (\autoref{equations}, \autoref{equality-and-assignment}) and in function calls using named
-parameter passing (\autoref{positional-or-named-input-arguments-of-functions}).
+equations (\cref{equations}, \cref{equality-and-assignment}) and in function calls using named
+parameter passing (\cref{positional-or-named-input-arguments-of-functions}).
 
 The following logical operators are defined:
 \begin{longtable}[]{ll}
@@ -244,13 +244,13 @@ The following holds for relational operators:
   In relations of the form \lstinline!v1 == v2 or v1 <> v2!,
   \lstinline!v1! or \lstinline!v2! shall, unless used in a function, not be a subtype of \lstinline!Real!.
   \begin{nonnormative}
-  The reason for this rule is that relations with \lstinline!Real! arguments are transformed to state events (see Events, \autoref{events-and-synchronization})
+  The reason for this rule is that relations with \lstinline!Real! arguments are transformed to state events (see Events, \cref{events-and-synchronization})
   and this transformation becomes unnecessarily complicated for the \lstinline!==! and \lstinline!<>! relational operators (e.g.\ two crossing functions instead
   of one crossing function needed, epsilon strategy needed even at event instants). Furthermore, testing on equality of Real variables is questionable on machines
   where the number length in registers is different to number length in main memory.
   \end{nonnormative}
 \item
-  Relational operators can generate events, see \autoref{discrete-time-expressions}.
+  Relational operators can generate events, see \cref{discrete-time-expressions}.
 \end{itemize}
 
 \section{Miscellaneous Operators and Variables}\doublelabel{miscellaneous-operators-and-variables}
@@ -270,15 +270,15 @@ operator in Modelica.
 
 \subsection{Array Constructor Operator}\doublelabel{array-constructor-operator}
 
-The array constructor operator \lstinline!{ $\ldots$ }! is described in \autoref{vector-matrix-and-array-constructors}.
+The array constructor operator \lstinline!{ $\ldots$ }! is described in \cref{vector-matrix-and-array-constructors}.
 
 \subsection{Array Concatenation Operator}\doublelabel{array-concatenation-operator}
 
-The array concatenation operator \lstinline![ $\ldots$ ]! is described in \autoref{array-concatenation}.
+The array concatenation operator \lstinline![ $\ldots$ ]! is described in \cref{array-concatenation}.
 
 \subsection{Array Range Operator}\doublelabel{array-range-operator}
 
-The array range constructor operator \lstinline!:! is described in \autoref{vector-construction}.
+The array range constructor operator \lstinline!:! is described in \cref{vector-construction}.
 
 \subsection{If-Expressions}\doublelabel{if-expressions}
 
@@ -291,9 +291,9 @@ is one example of if-expression. First \lstinline!expression1!, which must be
 evaluated and is the value of the if-expression, else \lstinline!expression3! is
 evaluated and is the value of the if-expression. The two expressions,
 \lstinline!expression2! and \lstinline!expression3!, must be type compatible expressions
-(\autoref{type-compatible-expressions}) giving the type of the if-expression. If-expressions with
+(\cref{type-compatible-expressions}) giving the type of the if-expression. If-expressions with
 \lstinline!elseif! are defined by replacing \lstinline!elseif! by \lstinline!else if!. For
-short-circuit evaluation see \autoref{evaluation-order}.
+short-circuit evaluation see \cref{evaluation-order}.
 
 \begin{nonnormative}
 \lstinline!elseif! in expressions has been added to the Modelica language for symmetry with if-clauses.
@@ -357,20 +357,20 @@ not in the Modelica library. The following built-in intrinsic
 operators/functions are available:
 \begin{itemize}
 \item
-  Mathematical functions and conversion functions, see \autoref{numeric-functions-and-conversion-functions}
+  Mathematical functions and conversion functions, see \cref{numeric-functions-and-conversion-functions}
   below.
 \item
   Derivative and special purpose operators with function syntax, see
-  \autoref{derivative-and-special-purpose-operators-with-function-syntax} below.
+  \cref{derivative-and-special-purpose-operators-with-function-syntax} below.
 \item
-  Event-related operators with function syntax, see \autoref{event-related-operators-with-function-syntax} below.
+  Event-related operators with function syntax, see \cref{event-related-operators-with-function-syntax} below.
 \item
-  Array operators/functions, see \autoref{array-dimension-lower-and-upper-index-bounds}.
+  Array operators/functions, see \cref{array-dimension-lower-and-upper-index-bounds}.
 \end{itemize}
 
 Note that when the specification references a function having the name
 of a built-in function it references the built-in function, not a
-user-defined function having the same name, see also \autoref{built-in-functions}. With
+user-defined function having the same name, see also \cref{built-in-functions}. With
 exception of the built-in \lstinline!String! operator, all operators in this section
 can only be called with positional arguments.
 
@@ -378,10 +378,10 @@ can only be called with positional arguments.
 
 The following mathematical operators and functions, also including some
 conversion functions, are predefined in Modelica, and are vectorizable
-according to \autoref{scalar-functions-applied-to-array-arguments}, except for the \lstinline!String! function. The
+according to \cref{scalar-functions-applied-to-array-arguments}, except for the \lstinline!String! function. The
 functions which do not trigger events are described in the table below,
 whereas the event-triggering mathematical functions are described in
-\autoref{event-triggering-mathematical-functions}.
+\cref{event-triggering-mathematical-functions}.
 
 \begin{longtable}{|p{4.5cm}|p{10cm}|} \hline
 \endhead
@@ -395,14 +395,14 @@ expression.\\ \hline
 \lstinline!Integer(e)! & Returns the ordinal number of the expression \lstinline!e! of
 enumeration type that evaluates to the enumeration value \lstinline!E.enumvalue!,
 where \lstinline!Integer(E.e1)=1!, \lstinline!Integer(E.en)=n!, for an enumeration type
-\lstinline!E=enumeration(e1, ..., en)!. See also \autoref{type-conversion-of-enumeration-values-to-string-or-integer}.\\ \hline
+\lstinline!E=enumeration(e1, ..., en)!. See also \cref{type-conversion-of-enumeration-values-to-string-or-integer}.\\ \hline
 \lstinline!EnumTypeName(i)! &
 For any enumeration type \lstinline!EnumTypeName!, returns the enumeration
 value \lstinline!EnumTypeName!.e such that \lstinline!Integer(EnumTypeName.e) = i!. Refer to the definition of
 \lstinline!Integer! above.
 
 It is an error to attempt to convert values of i that do not correspond
-to values of the enumeration type. See also \autoref{type-conversion-of-integer-to-enumeration-values}.
+to values of the enumeration type. See also \cref{type-conversion-of-integer-to-enumeration-values}.
 \\ \hline
 
 \begin{tabular}{@{}p{4.5cm}@{}}
@@ -417,7 +417,7 @@ to values of the enumeration type. See also \autoref{type-conversion-of-integer-
 &
 Convert a scalar non-\lstinline!String! expression to a \lstinline!String! representation. The
 first argument may be a \lstinline!Boolean b!, an \lstinline!Integer i!, a \lstinline!Real r! or an
-\lstinline!Enumeration e! (\autoref{type-conversion-of-enumeration-values-to-string-or-integer}). The other arguments must use named
+\lstinline!Enumeration e! (\cref{type-conversion-of-enumeration-values-to-string-or-integer}). The other arguments must use named
 arguments. The optional \textless{}options\textgreater{} are:
 
 \lstinline!Integer minimumLength=0!: minimum length of the resulting string. If
@@ -461,7 +461,7 @@ lead to input~that agrees with the Modelica-grammar.\\ \hline
 
 The built-in operators in this section trigger events if used outside of
 a when-clause and outside of a clocked discrete-time partition (see
-\autoref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}).
+\cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}).
 These expression for \lstinline!div!, \lstinline!ceil!, \lstinline!floor!, and \lstinline!integer! are
 event generating expression. The event generating expression for
 \lstinline!mod(x,y)! is \lstinline!floor(x/y)!, and for \lstinline!rem(x,y)! it is \lstinline!div(x,y)! --- i.e.\ events
@@ -566,7 +566,7 @@ scalar it needs to be a subtype of Real. The expression and all its
 time-varying subexpressions must be continuous and semi-differentiable.
 If \lstinline!expr! is an array, the operator
 is applied to all elements of the array. For non-scalar arguments the
-function is vectorized according to \autoref{vectorized-calls-of-functions}.
+function is vectorized according to \cref{vectorized-calls-of-functions}.
 \par
 \begin{nonnormative*}
 For Real parameters and constants the result is a zero scalar or array of the same size as the variable.
@@ -584,8 +584,8 @@ Returns: \lstinline!expr(time-delayTime)! for \lstinline!time>time.start + delay
 subtypes of Real. \lstinline!delayMax! needs to be additionally a parameter
 expression. The following relation shall hold: \lstinline!0 <= delayTime <= delayMax!, otherwise an error occurs. If \lstinline!delayMax! is not
 supplied in the argument list, \lstinline!delayTime! needs to be a parameter
-expression. See also \autoref{delay}. For non-scalar arguments the
-function is vectorized according to \autoref{vectorized-calls-of-functions}.\\
+expression. See also \cref{delay}. For non-scalar arguments the
+function is vectorized according to \cref{vectorized-calls-of-functions}.\\
 \hline
 
 % cardinality
@@ -595,7 +595,7 @@ This is a deprecated operator. It should no longer be used, since it will be rem
 \end{nonnormative*}
 
 Returns the number of (inside and outside) occurrences of connector
-instance \lstinline!c! in a connect-equation as an \lstinline!Integer! number. See also \autoref{cardinality-deprecated}.\\
+instance \lstinline!c! in a connect-equation as an \lstinline!Integer! number. See also \cref{cardinality-deprecated}.\\
 \hline
 
 % homotopy
@@ -615,8 +615,8 @@ instance \lstinline!c! in a connect-equation as an \lstinline!Integer! number. S
   The solution must fulfill the equations for homotopy returning \lstinline!actual!.
 \end{enumerate}
 
-See also \autoref{homotopy}. For non-scalar arguments the function is
-vectorized according to \autoref{scalar-functions-applied-to-array-arguments}.\\
+See also \cref{homotopy}. For non-scalar arguments the function is
+vectorized according to \cref{scalar-functions-applied-to-array-arguments}.\\
 \hline
 
 % semiLinear
@@ -627,9 +627,9 @@ vectorized according to \autoref{scalar-functions-applied-to-array-arguments}.\\
 \end{tabular}&
 Returns:
 \lstinline!smooth(0, if x>=0 then positiveSlope*x else negativeSlope*x)!.
-The result is of type \lstinline!Real!. See \autoref{semilinear} (especially in
+The result is of type \lstinline!Real!. See \cref{semilinear} (especially in
 the case when $x = 0$). For non-scalar arguments the function is
-vectorized according to \autoref{vectorized-calls-of-functions}.\\
+vectorized according to \cref{vectorized-calls-of-functions}.\\
 \hline
 
 % inStream
@@ -638,13 +638,13 @@ variables \lstinline!v! defined in stream connectors, and is the value of the st
 variable \lstinline!v! close to the connection point assuming that the flow is from
 the connection point into the component. This value is computed from the
 stream connection equations of the flow variables and of the stream
-variables. The operator is vectorizable. For more details see \autoref{stream-operator-instream-and-connection-equations}.\\
+variables. The operator is vectorizable. For more details see \cref{stream-operator-instream-and-connection-equations}.\\
 \hline
 
 % actualStream
 \lstinline!actualStream(v)! & \lstinline!actualStream(v)! returns the actual value
 of the stream variable \lstinline!v! for any flow direction. The operator is
-vectorizable. For more details, see \autoref{stream-operator-actualstream}.\\
+vectorizable. For more details, see \cref{stream-operator-actualstream}.\\
 \hline
 
 % spatialDistribution
@@ -655,13 +655,13 @@ vectorizable. For more details, see \autoref{stream-operator-actualstream}.\\
 \lstinline!  initialPoints=...,!\\
 \lstinline!  initialValues=...)!
 \end{tabular} &
-\lstinline!spatialDistribution! allows approximation of variable-speed transport of properties, see \autoref{spatialdistribution}.\\
+\lstinline!spatialDistribution! allows approximation of variable-speed transport of properties, see \cref{spatialdistribution}.\\
 \hline
 
 % getInstanceName
 \lstinline!getInstanceName()! & Returns a string with the name of the model/block
 that is simulated, appended with the fully qualified name of the
-instance in which this function is called, see \autoref{getinstancename}.\\
+instance in which this function is called, see \cref{getinstancename}.\\
 \hline
 \end{longtable}
 
@@ -733,7 +733,7 @@ are the boundary conditions at $z(0.0, t)$ and $z(1.0, t)$ (at
 each point in time only one of in0 and in1 is used). Elements in the
 initialPoints array must be sorted in non-descending order. The operator
 can not be vectorized according to the vectorization rules described in
-\autoref{scalar-functions-applied-to-array-arguments}. The operator can be vectorized only with respect to the
+\cref{scalar-functions-applied-to-array-arguments}. The operator can be vectorized only with respect to the
 arguments in0 and in1 (which must have the same size), returning
 vectorized outputs out0 and out1 of the same size; the arguments
 initialPoints and initialValues are vectorized accordingly.
@@ -861,7 +861,7 @@ may not be applied to expandable connectors, elements in expandable
 connectors, or to arrays of connectors (but can be applied to the scalar
 elements of array of connectors). \lstinline!cardinality! should only
 be used in the condition of assert and if-statements -- that do not
-contain connect (and similar operators -- see \autoref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}).
+contain connect (and similar operators -- see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}).
 
 \subsubsection{homotopy}\doublelabel{homotopy}
 
@@ -1006,7 +1006,7 @@ which has the correct value of $x_0$ at $\lambda = 0$ and of 1 at $\lambda= 1$, 
 
 \subsubsection{semiLinear}\doublelabel{semilinear}
 
-(See definition of \lstinline!semiLinear! in \autoref{derivative-and-special-purpose-operators-with-function-syntax}). In some situations,
+(See definition of \lstinline!semiLinear! in \cref{derivative-and-special-purpose-operators-with-function-syntax}). In some situations,
 equations with \lstinline!semiLinear! become underdetermined if the
 first argument (\lstinline!x!) becomes zero, i.e., there are an infinite number of
 solutions. It is recommended that the following rules are used to
@@ -1108,7 +1108,7 @@ The simulation result should not depend on the return value of this function.
 
 The following event-related operators with function syntax are
 supported. The operators \lstinline!noEvent!, \lstinline!pre!, \lstinline!edge!, and \lstinline!change!, are
-vectorizable according to \autoref{scalar-functions-applied-to-array-arguments}
+vectorizable according to \cref{scalar-functions-applied-to-array-arguments}
 
 \begin{longtable}{|p{5cm}|p{8cm}|}
 \hline \endhead
@@ -1131,7 +1131,7 @@ Hereby, \lstinline!terminal()! ensures an event at the end of successful simulat
 \\ \hline
 
 % noEvent
-\lstinline!noEvent(expr)! & Real elementary relations within \lstinline!expr! are taken literally, i.e., no state or time event is triggered. See also \autoref{noevent-and-smooth} and \autoref{events-and-synchronization}.\\ \hline
+\lstinline!noEvent(expr)! & Real elementary relations within \lstinline!expr! are taken literally, i.e., no state or time event is triggered. See also \cref{noevent-and-smooth} and \cref{events-and-synchronization}.\\ \hline
 
 % smooth
 \lstinline!smooth(p, expr)! & If $p>=0$ \lstinline!smooth(p,expr)!
@@ -1142,7 +1142,7 @@ appearing real variables exist and are continuous up to order
 \lstinline!p!. The argument \lstinline!p! should be a scalar integer parameter
 expression. The only allowed types for \lstinline!expr! in \lstinline!smooth! are: real
 expressions, arrays of allowed expressions, and records containing only
-components of allowed expressions. See also \autoref{noevent-and-smooth}.\\ \hline
+components of allowed expressions. See also \cref{noevent-and-smooth}.\\ \hline
 
 % sample
 \lstinline!sample(start, interval)! & Returns \lstinline!true! and triggers time events at time
@@ -1164,10 +1164,10 @@ simultaneously: (a) variable $y$ is either a subtype of a simple type or
 is a record component, (b) $y$ is a discrete-time expression (c) the
 operator is \emph{not} applied in a function class.
 \begin{nonnormative}
-This can be applied to continuous-time variables in when-clauses, see \autoref{discrete-time-expressions} for the definition of discrete-time expression.
+This can be applied to continuous-time variables in when-clauses, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
 \end{nonnormative}
 The first value of \lstinline!pre(y)! is determined in the initialization phase. See
-also \autoref{pre}.\\ \hline
+also \cref{pre}.\\ \hline
 
 % edge
 \lstinline!edge(b)! & Is expanded into \lstinline!(b and not pre(b))! for Boolean variable
@@ -1187,7 +1187,7 @@ It is an error if the variable cannot be selected as a state.
 \lstinline!reinit! can only be applied once for the same variable --- either
 as an individual variable or as part of an array of variables. It can
 only be applied in the body of a when clause in an equation section. See
-also \autoref{reinit}.\\ \hline
+also \cref{reinit}.\\ \hline
 \end{longtable}
 
 A few of these operators are described in more detail in the following.
@@ -1220,7 +1220,7 @@ model equations.
 \subsubsection{noEvent and smooth}\doublelabel{noevent-and-smooth}
 
 \lstinline!noEvent! implies that real elementary relations/functions
-are taken literally instead of generating crossing functions, \autoref{events-and-synchronization}.
+are taken literally instead of generating crossing functions, \cref{events-and-synchronization}.
 \lstinline!smooth! should be used instead of \lstinline!noEvent!, in order to
 avoid events for efficiency reasons. A tool is free to not generate
 events for expressions inside \lstinline!smooth!. However, \lstinline!smooth! does not guarantee
@@ -1246,7 +1246,7 @@ equation
 \section{Variability of Expressions}\doublelabel{variability-of-expressions}
 
 The concept of variability of an expression indicates to what extent the
-expression can vary over time. See also \autoref{component-variability-prefixes-discrete-parameter-constant} regarding the
+expression can vary over time. See also \cref{component-variability-prefixes-discrete-parameter-constant} regarding the
 concept of variability. There are four levels of variability of
 expressions, starting from the least variable:
 \begin{itemize}
@@ -1269,7 +1269,7 @@ restrictions that simplify reasoning and reporting of errors:
   to be at least as variable as \lstinline!expr!.
 \item
   When determining whether an equation can contribute to solving for a variable \lstinline!v! (for instance,
-  when applying the perfect matching rule, see \autoref{synchronous-data-flow-principle-and-single-assignment-rule}),
+  when applying the perfect matching rule, see \cref{synchronous-data-flow-principle-and-single-assignment-rule}),
   the equation can only be considered contributing if the resulting solution would be at most as variable as \lstinline!v!.
 \item
   The right-hand side expression in a binding equation (that is, \lstinline!expr!) of a parameter component and of the base type attributes
@@ -1326,7 +1326,7 @@ Parameter expressions are:
   Some function calls are parameter expressions even if the arguments are not:
   \begin{itemize}
   \item
-    \lstinline!cardinality(c)!, see restrictions for use in \autoref{cardinality-deprecated}.
+    \lstinline!cardinality(c)!, see restrictions for use in \cref{cardinality-deprecated}.
   \item
     \lstinline!end! in \lstinline!A[$\ldots$ end $\ldots$]! if \lstinline!A! is variable declared in a non-function class.
   \item
@@ -1362,7 +1362,7 @@ Discrete-time expressions are:
   generating functions \lstinline!ceil!, \lstinline!floor!, \lstinline!div!, and \lstinline!integer!, if at least one
   argument is non-discrete time expression and subtype of \lstinline!Real!.
   \begin{nonnormative}
-  These will generate events, see \autoref{events-and-synchronization}.  Note that \lstinline!rem! and \lstinline!mod! generate events but are not discrete-time
+  These will generate events, see \cref{events-and-synchronization}.  Note that \lstinline!rem! and \lstinline!mod! generate events but are not discrete-time
   expressions. In other words, relations inside \lstinline!noEvent!, such as \lstinline!noEvent(x>1)!, are not discrete-time expressions.
   \end{nonnormative}
 \item

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1,4 +1,4 @@
-\chapter{Operators and Expressions}\doublelabel{operators-and-expressions}
+\chapter{Operators and Expressions}\label{operators-and-expressions}
 
 The lexical units are combined to form even larger building blocks such
 as expressions according to the rules given by the expression part of
@@ -18,7 +18,7 @@ presented in more detail in \cref{predefined-types-and-classes}.
 The abbreviated predefined type information below is given as background information for the rest of the presentation.
 \end{nonnormative}
 
-\section{Expressions}\doublelabel{expressions}
+\section{Expressions}\label{expressions}
 
 Modelica equations, assignments and declaration equations contain
 expressions.
@@ -34,7 +34,7 @@ arguments is described in \cref{positional-or-named-input-arguments-of-functions
 \cref{initialization-and-binding-equations-of-components-in-functions}. The built-in array functions are given in \cref{array-dimension-lower-and-upper-index-bounds}
 and other built-in operators in \cref{built-in-intrinsic-operators-with-function-syntax}.
 
-\section{Operator Precedence and Associativity}\doublelabel{operator-precedence-and-associativity}
+\section{Operator Precedence and Associativity}\label{operator-precedence-and-associativity}
 
 Operator precedence determines the order of evaluation of operators in
 an expression. An operator with higher precedence is evaluated before an
@@ -114,7 +114,7 @@ a:b:c:d:e:f:g // Not legal, and scalar arguments gives no legal interpretation.
 \end{lstlisting}
 \end{nonnormative}
 
-\section{Evaluation Order}\doublelabel{evaluation-order}
+\section{Evaluation Order}\label{evaluation-order}
 
 A tool is free to solve equations, reorder expressions and to not evaluate expressions if their values do not influence the result (e.g.\ short-circuit
 evaluation of Boolean expressions).  If-statements and if-expressions guarantee that their clauses are only evaluated if the appropriate condition is true,
@@ -124,7 +124,7 @@ If a numeric operation overflows the result is undefined. For literals
 it is recommended to automatically convert the number to another type
 with greater precision.
 
-\subsection{Example: Guarding Expressions Against Incorrect Evaluation}\doublelabel{example-guarding-expressions-against-incorrect-evaluation}
+\subsection{Example: Guarding Expressions Against Incorrect Evaluation}\label{example-guarding-expressions-against-incorrect-evaluation}
 
 \begin{example}
 If one wants to guard an expression against incorrect evaluation, it should be guarded by an \lstinline!if!:
@@ -144,7 +144,7 @@ der(h)=if noEvent(h>0) then -c*sqrt(h) else 0; // Correct
 \end{lstlisting}
 \end{example}
 
-\section{Arithmetic Operators}\doublelabel{arithmetic-operators}
+\section{Arithmetic Operators}\label{arithmetic-operators}
 
 Modelica supports five binary arithmetic operators that operate on any
 numerical type:
@@ -178,7 +178,7 @@ factor :
    primary [ "^" primary ]
 \end{lstlisting}
 
-\section{Equality, Relational, and Logical Operators}\doublelabel{equality-relational-and-logical-operators}
+\section{Equality, Relational, and Logical Operators}\label{equality-relational-and-logical-operators}
 
 Modelica supports the standard set of relational and logical operators,
 all of which produce the standard boolean values \lstinline!true! or \lstinline!false!.
@@ -253,13 +253,13 @@ The following holds for relational operators:
   Relational operators can generate events, see \cref{discrete-time-expressions}.
 \end{itemize}
 
-\section{Miscellaneous Operators and Variables}\doublelabel{miscellaneous-operators-and-variables}
+\section{Miscellaneous Operators and Variables}\label{miscellaneous-operators-and-variables}
 
 Modelica also contains a few built-in operators which are not standard
 arithmetic, relational, or logical operators. These are described below,
 including \lstinline!time!, which is a built-in variable, not an operator.
 
-\subsection{String Concatenation}\doublelabel{string-concatenation}
+\subsection{String Concatenation}\label{string-concatenation}
 
 Concatenation of strings (see the Modelica grammar) is denoted by the \lstinline!+!
 operator in Modelica.
@@ -268,19 +268,19 @@ operator in Modelica.
 \lstinline!"a" + "b"! becomes \lstinline!"ab"!.
 \end{example}
 
-\subsection{Array Constructor Operator}\doublelabel{array-constructor-operator}
+\subsection{Array Constructor Operator}\label{array-constructor-operator}
 
 The array constructor operator \lstinline!{ $\ldots$ }! is described in \cref{vector-matrix-and-array-constructors}.
 
-\subsection{Array Concatenation Operator}\doublelabel{array-concatenation-operator}
+\subsection{Array Concatenation Operator}\label{array-concatenation-operator}
 
 The array concatenation operator \lstinline![ $\ldots$ ]! is described in \cref{array-concatenation}.
 
-\subsection{Array Range Operator}\doublelabel{array-range-operator}
+\subsection{Array Range Operator}\label{array-range-operator}
 
 The array range constructor operator \lstinline!:! is described in \cref{vector-construction}.
 
-\subsection{If-Expressions}\doublelabel{if-expressions}
+\subsection{If-Expressions}\label{if-expressions}
 
 An expression
 \begin{lstlisting}[language=modelica]
@@ -307,7 +307,7 @@ Integer sign_of_i2=if i<0 then -1 else if i==0 then 0 else 1;
 \end{lstlisting}
 \end{example}
 
-\subsection{Member Access Operator}\doublelabel{member-access-operator}
+\subsection{Member Access Operator}\label{member-access-operator}
 
 It is possible to access members of a class instance using dot notation,
 i.e., the \lstinline!.! operator.
@@ -319,7 +319,7 @@ which are members of a class can of course also be accessed using dot
 notation on the name of the class, not on instances of the class.
 \end{example}
 
-\subsection{Built-in Variable time}\doublelabel{built-in-variable-time}
+\subsection{Built-in Variable time}\label{built-in-variable-time}
 
 All declared variables are functions of the independent variable \lstinline!time!.
 The variable \lstinline!time! is a built-in variable available in all models and
@@ -343,7 +343,7 @@ end SineSource;
 \end{lstlisting}
 \end{example}
 
-\section{Built-in Intrinsic Operators with Function Syntax}\doublelabel{built-in-intrinsic-operators-with-function-syntax}
+\section{Built-in Intrinsic Operators with Function Syntax}\label{built-in-intrinsic-operators-with-function-syntax}
 
 Certain built-in operators of Modelica have the same syntax as a
 function call. However, they do not behave as a mathematical function,
@@ -374,7 +374,7 @@ user-defined function having the same name, see also \cref{built-in-functions}. 
 exception of the built-in \lstinline!String! operator, all operators in this section
 can only be called with positional arguments.
 
-\subsection{Numeric Functions and Conversion Functions}\doublelabel{numeric-functions-and-conversion-functions}
+\subsection{Numeric Functions and Conversion Functions}\label{numeric-functions-and-conversion-functions}
 
 The following mathematical operators and functions, also including some
 conversion functions, are predefined in Modelica, and are vectorizable
@@ -457,7 +457,7 @@ The x,X-formats (hexa-decimal)~and c (character) for Integers does not
 lead to input~that agrees with the Modelica-grammar.\\ \hline
 \end{longtable}
 
-\subsubsection{Event Triggering Mathematical Functions}\doublelabel{event-triggering-mathematical-functions}
+\subsubsection{Event Triggering Mathematical Functions}\label{event-triggering-mathematical-functions}
 
 The built-in operators in this section trigger events if used outside of
 a when-clause and outside of a clocked discrete-time partition (see
@@ -524,7 +524,7 @@ Note, outside of a when-clause state events are triggered when the return value 
 \\ \hline
 \end{longtable}
 
-\subsubsection{Built-in Mathematical Functions and External Built-in Functions}\doublelabel{built-in-mathematical-functions-and-external-built-in-functions}
+\subsubsection{Built-in Mathematical Functions and External Built-in Functions}\label{built-in-mathematical-functions-and-external-built-in-functions}
 
 The following built-in mathematical functions are available in Modelica
 and can be called directly without any package prefix added to the
@@ -548,7 +548,7 @@ the \lstinline!Modelica.Math! library.
 \lstinline!log10(x)! & base 10 logarithm ($x > 0$)\\ \hline
 \end{longtable}
 
-\subsection{Derivative and Special Purpose Operators with Function Syntax}\doublelabel{derivative-and-special-purpose-operators-with-function-syntax}
+\subsection{Derivative and Special Purpose Operators with Function Syntax}\label{derivative-and-special-purpose-operators-with-function-syntax}
 
 The following derivative operator and special purpose operators with
 function syntax are predefined. The special purpose operators with
@@ -667,7 +667,7 @@ instance in which this function is called, see \cref{getinstancename}.\\
 
 A few of these operators are described in more detail in the following.
 
-\subsubsection{delay}\doublelabel{delay}
+\subsubsection{delay}\label{delay}
 
 \begin{nonnormative}
 \lstinline!delay! allows a numerical sound
@@ -692,7 +692,7 @@ minimum delay time in order to avoid extrapolation in the delay
 buffer.
 \end{nonnormative}
 
-\subsubsection{spatialDistribution}\doublelabel{spatialdistribution}
+\subsubsection{spatialDistribution}\label{spatialdistribution}
 
 \begin{nonnormative}
 Many applications involve the modelling of variable-speed
@@ -825,7 +825,7 @@ for pipelines where more than one quantity is transported with velocity
 v in the example above.
 \end{nonnormative}
 
-\subsubsection{cardinality (deprecated)}\doublelabel{cardinality-deprecated}
+\subsubsection{cardinality (deprecated)}\label{cardinality-deprecated}
 
 \begin{nonnormative}
 \lstinline!cardinality! is deprecated for the following reasons and will be removed in a future release:
@@ -863,7 +863,7 @@ elements of array of connectors). \lstinline!cardinality! should only
 be used in the condition of assert and if-statements -- that do not
 contain connect (and similar operators -- see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}).
 
-\subsubsection{homotopy}\doublelabel{homotopy}
+\subsubsection{homotopy}\label{homotopy}
 
 \begin{nonnormative}
 During the initialization phase of a dynamic simulation
@@ -1004,7 +1004,7 @@ which has the correct value of $x_0$ at $\lambda = 0$ and of 1 at $\lambda= 1$, 
 \end{example}
 
 
-\subsubsection{semiLinear}\doublelabel{semilinear}
+\subsubsection{semiLinear}\label{semilinear}
 
 (See definition of \lstinline!semiLinear! in \cref{derivative-and-special-purpose-operators-with-function-syntax}). In some situations,
 equations with \lstinline!semiLinear! become underdetermined if the
@@ -1069,7 +1069,7 @@ mass flow rate \lstinline!m_flow! and the upstream specific enthalpy
 depending on the flow direction.
 \end{nonnormative}
 
-\subsubsection{getInstanceName}\doublelabel{getinstancename}
+\subsubsection{getInstanceName}\label{getinstancename}
 
 Returns a string with the name of the model/block that is simulated,
 appended with the fully qualified name of the instance in which this
@@ -1104,7 +1104,7 @@ return value is not specified.
 The simulation result should not depend on the return value of this function.
 \end{nonnormative}
 
-\subsection{Event-Related Operators with Function Syntax}\doublelabel{event-related-operators-with-function-syntax}
+\subsection{Event-Related Operators with Function Syntax}\label{event-related-operators-with-function-syntax}
 
 The following event-related operators with function syntax are
 supported. The operators \lstinline!noEvent!, \lstinline!pre!, \lstinline!edge!, and \lstinline!change!, are
@@ -1192,7 +1192,7 @@ also \cref{reinit}.\\ \hline
 
 A few of these operators are described in more detail in the following.
 
-\subsubsection{pre}\doublelabel{pre}
+\subsubsection{pre}\label{pre}
 
 A new event is triggered if there is at least for one variable \lstinline!v! such that \lstinline!pre(v)<> v! after the active model equations are
 evaluated at an event instant. In this case the model is at once
@@ -1217,7 +1217,7 @@ e.g., by applying the fix point iteration scheme to a subset of the
 model equations.
 \end{nonnormative}
 
-\subsubsection{noEvent and smooth}\doublelabel{noevent-and-smooth}
+\subsubsection{noEvent and smooth}\label{noevent-and-smooth}
 
 \lstinline!noEvent! implies that real elementary relations/functions
 are taken literally instead of generating crossing functions, \cref{events-and-synchronization}.
@@ -1243,7 +1243,7 @@ equation
 \end{lstlisting}
 \end{example}
 
-\section{Variability of Expressions}\doublelabel{variability-of-expressions}
+\section{Variability of Expressions}\label{variability-of-expressions}
 
 The concept of variability of an expression indicates to what extent the
 expression can vary over time. See also \cref{component-variability-prefixes-discrete-parameter-constant} regarding the
@@ -1279,7 +1279,7 @@ restrictions that simplify reasoning and reporting of errors:
   discrete-time expression.
 \end{itemize}
 
-\subsection{Constant Expressions}\doublelabel{constant-expressions}
+\subsection{Constant Expressions}\label{constant-expressions}
 
 Constant expressions are:
 \begin{itemize}
@@ -1308,7 +1308,7 @@ constant is declared final or modified with a final modifier. A constant
 without an associated declaration equation can be given one by using a
 modifier.
 
-\subsection{Parameter Expressions}\doublelabel{parameter-expressions}
+\subsection{Parameter Expressions}\label{parameter-expressions}
 
 Parameter expressions are:
 \begin{itemize}
@@ -1338,7 +1338,7 @@ Parameter expressions are:
   \end{itemize}
 \end{itemize}
 
-\subsection{Discrete-Time Expressions}\doublelabel{discrete-time-expressions}
+\subsection{Discrete-Time Expressions}\label{discrete-time-expressions}
 
 Discrete-time expressions are:
 \begin{itemize}
@@ -1424,7 +1424,7 @@ end Test;
 \end{lstlisting}
 \end{example}
 
-\subsection{Continuous-Time Expressions}\doublelabel{continuous-time-expressions}
+\subsection{Continuous-Time Expressions}\label{continuous-time-expressions}
 
 All expressions are continuous-time expressions including constant,
 parameter and discrete expressions. The term \emph{non-discrete-time

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -3,7 +3,7 @@
 A Modelica \lstinline!operator record! can define the behavior for
 operations such as constructing, adding, multiplying etc. This is done
 using the specialized class \lstinline!operator! (a restricted class
-similar to \lstinline!package!, see \autoref{specialized-classes}) comprised of functions
+similar to \lstinline!package!, see \cref{specialized-classes}) comprised of functions
 implementing different variants of the operation for the record class in
 which the respective \lstinline!operator! definition resides.
 
@@ -21,15 +21,15 @@ The \lstinline!operator! keyword is followed by the name of the operation:
 % (Note: It's pure coincide that this issue occured for this case.)
 \begin{longtable}[c]{@{}|ll|@{}}
 \hline\endhead
-\multicolumn{2}{|l|}{Overloaded constructors, see \autoref{overloaded-constructors}:}\\
+\multicolumn{2}{|l|}{Overloaded constructors, see \cref{overloaded-constructors}:}\\
 & \lstinline!'constructor'!, \lstinline!'0'!\\
-\multicolumn{2}{|l|}{Overloaded string conversions, see \autoref{overloaded-string-conversions}:}\\
+\multicolumn{2}{|l|}{Overloaded string conversions, see \cref{overloaded-string-conversions}:}\\
 & \lstinline!'String'! \\
-\multicolumn{2}{|l|}{Overloaded binary operations, see \autoref{overloaded-binary-operations}:}\\
+\multicolumn{2}{|l|}{Overloaded binary operations, see \cref{overloaded-binary-operations}:}\\
 & \lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,\\
 & \lstinline!'=='!, \lstinline!'<='!', \lstinline!'>'!, \lstinline!'<'!,
 \lstinline!'>='!, \lstinline!'<='!, \lstinline!'and'!, \lstinline!'or'!\\
-\multicolumn{2}{|l|}{Overloaded unary operations, see \autoref{overloaded-unary-operations}:}\\
+\multicolumn{2}{|l|}{Overloaded unary operations, see \cref{overloaded-unary-operations}:}\\
 & \lstinline!'-'! (negation), \lstinline!'not'!\\
 \hline
 \end{longtable}
@@ -53,10 +53,10 @@ operator record.
 
 If an operator record was derived by a short class definition, the
 overloaded operators of this operator record are the operators that are
-defined in its base class, for subtyping see \autoref{interface-or-type-relationships}.
+defined in its base class, for subtyping see \cref{interface-or-type-relationships}.
 
 The precedence and associativity of the overloaded operators is
-identical to the one defined in Table 3.1 in \autoref{operator-precedence-and-associativity}.
+identical to the one defined in Table 3.1 in \cref{operator-precedence-and-associativity}.
 
 \begin{nonnormative}
 Note, the operator overloading as defined in this section is
@@ -266,19 +266,19 @@ Complex c = a*b; // interpreted as:
 \end{nonnormative}
 \item
   Otherwise, if \lstinline!a! or \lstinline!b! is an array expression, then the expression is
-  conceptually evaluated according to the rules of \autoref{scalar-vector-matrix-and-array-operator-functions} with the
-  following exceptions concerning \autoref{matrix-and-vector-multiplication-of-numeric-arrays}:
+  conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions} with the
+  following exceptions concerning \cref{matrix-and-vector-multiplication-of-numeric-arrays}:
   \begin{enumerate}
   \def\labelenumii{(\alph{enumii})}
   \item
     vector*vector should be left undefined.
     \begin{nonnormative}
-    The scalar product of \autoref{tab:product} does not generalize to the expected linear and conjugate linear scalar product of complex numbers.
+    The scalar product of \cref{tab:product} does not generalize to the expected linear and conjugate linear scalar product of complex numbers.
     \end{nonnormative}
   \item
     vector*matrix should be left undefined.
     \begin{nonnormative}
-    The corresponding definition of \autoref{tab:product} does not generalize to complex numbers in the expected way.
+    The corresponding definition of \cref{tab:product} does not generalize to complex numbers in the expected way.
     \end{nonnormative}
   \item
     If the inner dimension for matrix*vector or matrix*matrix is zero,
@@ -329,7 +329,7 @@ Let $\theop$ denote a unary operator and consider an expression
   error, if there are multiple valid matches.
 \item
   Otherwise, if \lstinline!a! is an array expression, then the expression
-  is conceptually evaluated according to the rules of \autoref{scalar-vector-matrix-and-array-operator-functions}.
+  is conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions}.
 \item
   Otherwise the expression is erroneous.
 \end{enumerate}
@@ -371,7 +371,7 @@ operator record Complex "Record defining a Complex number"
     end fromReal;
   end 'constructor';
 
-  encapsulated operator function '+' // short hand notation, see !\autoref{specialized-classes}!
+  encapsulated operator function '+' // short hand notation, see !\cref{specialized-classes}!
     import Complex;
     input Complex c1;
     input Complex c2;

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -1,4 +1,4 @@
-\chapter{Overloaded Operators}\doublelabel{overloaded-operators}
+\chapter{Overloaded Operators}\label{overloaded-operators}
 
 A Modelica \lstinline!operator record! can define the behavior for
 operations such as constructing, adding, multiplying etc. This is done
@@ -63,7 +63,7 @@ Note, the operator overloading as defined in this section is
 only a short hand notation for function calls.
 \end{nonnormative}
 
-\section{Matching Function}\doublelabel{matching-function}
+\section{Matching Function}\label{matching-function}
 
 All functions defined inside the \lstinline!operator! class must return one
 output (based on the restriction above), and may include functions with
@@ -110,7 +110,7 @@ defines a valid call, but does not explicitly define the set of
 domains.
 \end{nonnormative}
 
-\section{Overloaded Constructors}\doublelabel{overloaded-constructors}
+\section{Overloaded Constructors}\label{overloaded-constructors}
 
 Let C denote an operator record class and consider an expression
 C($A_1$, $a_{2}$,\ldots{}, $a_{k}$,
@@ -178,7 +178,7 @@ should return the identity element of addition, and is used for
 generating flow-equations for connect-equations and zero elements for
 matrix-multiplication.
 
-\section{Overloaded String Conversions}\doublelabel{overloaded-string-conversions}
+\section{Overloaded String Conversions}\label{overloaded-string-conversions}
 
 Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!,
 $k \ge 1$ where $A_1$ is an element of class \lstinline!A!.
@@ -214,7 +214,7 @@ Restrictions:
   \end{nonnormative}
 \end{itemize}
 
-\section{Overloaded Binary Operations}\doublelabel{overloaded-binary-operations}
+\section{Overloaded Binary Operations}\label{overloaded-binary-operations}
 
 % Can't use \mathit{op} in the \lstinline math due to issue reported here:
 %   https://github.com/brucemiller/LaTeXML/issues/1274 (marked as fixed as of commit 80d7940)
@@ -312,7 +312,7 @@ Restrictions:
   (potential) call that lead to multiple matches in (2) above.
 \end{itemize}
 
-\section{Overloaded Unary Operations}\doublelabel{overloaded-unary-operations}
+\section{Overloaded Unary Operations}\label{overloaded-unary-operations}
 
 Let $\theop$ denote a unary operator and consider an expression
 \lstinline!$\theop$ a! where \lstinline!a! is an instance or array of instances of class
@@ -351,7 +351,7 @@ Restrictions:
   (negation) and binary (subtraction) operator.
 \end{itemize}
 
-\section{Example of Overloading for Complex Numbers}\doublelabel{example-of-overloading-for-complex-numbers}
+\section{Example of Overloading for Complex Numbers}\label{example-of-overloading-for-complex-numbers}
 
 \begin{example}
 The rules in the previous subsections are demonstrated at hand

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -2,7 +2,7 @@
 
 \section{Package as Specialized Class}\doublelabel{package-as-specialized-class}
 
-The package concept is a specialized class (\autoref{specialized-classes}), using the
+The package concept is a specialized class (\cref{specialized-classes}), using the
 keyword \lstinline!package!.
 
 \section{Motivation and Usage of Packages}\doublelabel{motivation-and-usage-of-packages}
@@ -87,7 +87,7 @@ to multiple single definition imports with corresponding $\mathit{packagename}$ 
 
 \subsubsection{Lookup of Imported Names}\doublelabel{lookup-of-imported-names}
 
-This section only defines how the imported name is looked up in the import clause. For lookup in general --- including how import clauses are used --- see \autoref{static-name-lookup}.
+This section only defines how the imported name is looked up in the import clause. For lookup in general --- including how import clauses are used --- see \cref{static-name-lookup}.
 
 Lookup of the name of an imported package or class deviates from the normal lexical lookup.  For example, consider \lstinline!A.B.C! in the clauses \lstinline!import A.B.C;!, \lstinline!import D = A.B.C;!, or \lstinline!import A.B.C.*;!.
 Here, lookup starts with the lexical lookup of the first part of the name (\lstinline!A!) at the top-level.
@@ -141,7 +141,7 @@ The following rules apply to import-clauses:
 
 Packages/classes may be represented in the hierarchical structure of the
 operating system (the file system). For classes with version
-information see also \autoref{mapping-of-versions-to-file-system}. The nature of such an external
+information see also \cref{mapping-of-versions-to-file-system}. The nature of such an external
 entity falls into one of the following two groups:
 \begin{itemize}
 \item
@@ -234,7 +234,7 @@ package Rotational // Modelica.Mechanics.Rotational
 
 In order to reference external resources from documentation (such as
 links and images in html-text) and/or to reference images in the Bitmap
-annotation (see \autoref{bitmap}). URIs should be used, for example
+annotation (see \cref{bitmap}). URIs should be used, for example
 \filename{file:///} and the URI scheme \filename{modelica://} which can be used to retrieve
 resources associated with a package. According to the URI specification scheme names are
 case-insensitive, but the lower-case form should be used, that is \filename{Modelica://} is allowed but \filename{modelica://} is the
@@ -302,7 +302,7 @@ it is a string with path names separated by a `\filename{:}'.
 In addition a tool may define an internal list of libraries, since it is
 in general not advisable for a program installation to modify global
 environment variables. The version information for a library (as defined
-in \autoref{annotations-for-version-handling}) may also be used during this search to search for a
+in \cref{annotations-for-version-handling}) may also be used during this search to search for a
 specific version of the library (e.g.\ if Modelica library version 2.2 is
 needed and the first directory in \lstinline!MODELICAPATH! contain Modelica library
 version 2.1, whereas the second directory contains Modelica version 2.2,
@@ -321,7 +321,7 @@ scope, the search continues in the package hierarchies stored in these
 directories.
 
 \begin{example}
-\autoref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}, with three
+\cref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}, with three
 directories containing the roots of the package hierarchies \lstinline!Modelica!, \lstinline!MyLib!, and \lstinline!ComplexNumbers!.  The first two are represented as
 the subdirectories \filename{C:\textbackslash{}library\textbackslash{}Modelica} and \filename{C:\textbackslash{}lib1\textbackslash{}MyLib}, whereas the third is stored
 as the file \filename{C:\textbackslash{}lib2\textbackslash{}ComplexNumbers.mo}.
@@ -335,7 +335,7 @@ Roots of package hierarchies, e.g., \lstinline!Modelica!, \lstinline!MyLib!, and
 \includegraphics[width=6in,height=2in]{modelicapath}
 \end{figure}
 
-Assume that we want to access the package \lstinline!MyLib.Pack2! in \autoref{fig:roots} above, e.g.\ through an \lstinline!import!-clause \lstinline!import MyLib.Pack2;!.
+Assume that we want to access the package \lstinline!MyLib.Pack2! in \cref{fig:roots} above, e.g.\ through an \lstinline!import!-clause \lstinline!import MyLib.Pack2;!.
 During lookup we first try to find a package \lstinline!MyLib! corresponding to the first part of the import name.  It is not found in the top-level scope since it has not
 previously been loaded into the environment.
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -1,11 +1,11 @@
-\chapter{Packages}\doublelabel{packages}
+\chapter{Packages}\label{packages}
 
-\section{Package as Specialized Class}\doublelabel{package-as-specialized-class}
+\section{Package as Specialized Class}\label{package-as-specialized-class}
 
 The package concept is a specialized class (\cref{specialized-classes}), using the
 keyword \lstinline!package!.
 
-\section{Motivation and Usage of Packages}\doublelabel{motivation-and-usage-of-packages}
+\section{Motivation and Usage of Packages}\label{motivation-and-usage-of-packages}
 
 \begin{nonnormative}
 Packages in Modelica may contain definitions of constants and
@@ -42,7 +42,7 @@ useful for a number of reasons:
 \end{itemize}
 \end{nonnormative}
 
-\subsection{Importing Definitions from a Package}\doublelabel{importing-definitions-from-a-package}
+\subsection{Importing Definitions from a Package}\label{importing-definitions-from-a-package}
 
 The import-clause makes public classes and other public definitions
 declared in some package available for use by shorter names in a class
@@ -85,7 +85,7 @@ An \lstinline!import!-clause can occur in one of the following syntactic forms:
 Here $\mathit{packagename}$ is the fully qualified name of the imported package including possible dot notation and $\mathit{definitionname}$ is the name of an element in a package.  The multiple definition import is equivalent
 to multiple single definition imports with corresponding $\mathit{packagename}$ and definition names.
 
-\subsubsection{Lookup of Imported Names}\doublelabel{lookup-of-imported-names}
+\subsubsection{Lookup of Imported Names}\label{lookup-of-imported-names}
 
 This section only defines how the imported name is looked up in the import clause. For lookup in general --- including how import clauses are used --- see \cref{static-name-lookup}.
 
@@ -114,7 +114,7 @@ import Co = Modelica.Math.ComplexNumbers;  // Accessed by Co.Add
 \end{lstlisting}
 \end{nonnormative}
 
-\subsubsection{Summary of Rules for Import Clauses}\doublelabel{summary-of-rules-for-import-clauses}
+\subsubsection{Summary of Rules for Import Clauses}\label{summary-of-rules-for-import-clauses}
 
 The following rules apply to import-clauses:
 \begin{itemize}
@@ -137,7 +137,7 @@ The following rules apply to import-clauses:
   Multiple qualified import-clauses may not have the same import name.
 \end{itemize}
 
-\subsection{Mapping Package/Class Structures to a Hierarchical File System}\doublelabel{mapping-package-class-structures-to-a-hierarchical-file-system}
+\subsection{Mapping Package/Class Structures to a Hierarchical File System}\label{mapping-package-class-structures-to-a-hierarchical-file-system}
 
 Packages/classes may be represented in the hierarchical structure of the
 operating system (the file system). For classes with version
@@ -162,7 +162,7 @@ white-space in the grammar.
 Tools may also store classes in data-base systems, but that is not standardized.
 \end{nonnormative}
 
-\subsubsection{Mapping a Package/Class Hierarchy into a Directory Hierarchy (Structured Entity)}\doublelabel{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}
+\subsubsection{Mapping a Package/Class Hierarchy into a Directory Hierarchy (Structured Entity)}\label{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}
 
 A directory shall contain a node, the file \filename{package.mo}. The node shall contain a stored-definition that defines a class \lstinline!A! with a name
 matching the name of the structured entity.
@@ -195,7 +195,7 @@ constants that are stored in \filename{package.mo} are also present in
 \filename{package.mo} (this ensures that the relative order between classes and
 constants stored in different ways is preserved).
 
-\subsubsection{Mapping a Package/Class Hierarchy into a Single File (Nonstructured Entity)}\doublelabel{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}
+\subsubsection{Mapping a Package/Class Hierarchy into a Single File (Nonstructured Entity)}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}
 
 When mapping a package or class-hierarchy to a file (e.g.\ the file \filename{A.mo}), that file shall only define a single class \lstinline!A! with a
 name matching the name of the nonstructured entity. In a file hierarchy the files shall have the extension \filename{.mo}.
@@ -204,7 +204,7 @@ A \filename{.mo} file defining more than one class cannot be part of the mapping
 to file-structure and it is an error if it is loaded from the
 \lstinline!MODELICAPATH!.
 
-\subsubsection{The within Clause}\doublelabel{the-within-clause}
+\subsubsection{The within Clause}\label{the-within-clause}
 
 A within-clause has the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -230,7 +230,7 @@ package Rotational // Modelica.Mechanics.Rotational
 \end{lstlisting}
 \end{example}
 
-\subsection{External resources}\doublelabel{external-resources}
+\subsection{External resources}\label{external-resources}
 
 In order to reference external resources from documentation (such as
 links and images in html-text) and/or to reference images in the Bitmap
@@ -285,7 +285,7 @@ Consider a top-level package \lstinline!Modelica! and a class
 resource than \filename{modelica://Modelica/C.jpg}.
 \end{example}
 
-\subsection{The Modelica Library Path -- MODELICAPATH}\doublelabel{the-modelica-library-path-modelicapath}
+\subsection{The Modelica Library Path -- MODELICAPATH}\label{the-modelica-library-path-modelicapath}
 
 The top-level scope implicitly contains a number of classes stored
 externally. If a top-level name is not found at global scope, a Modelica
@@ -314,7 +314,7 @@ The first part of the path \lstinline!A.B.C! (i.e., \lstinline!A!) is located by
 fails without searching for \lstinline!A! in any of the remaining roots in \lstinline!MODELICAPATH!.
 \end{nonnormative}
 
-\subsubsection{Example of Searching MODELICAPATH}\doublelabel{example-of-searching-modelicapath}
+\subsubsection{Example of Searching MODELICAPATH}\label{example-of-searching-modelicapath}
 
 If during lookup a top-level name is not found in the unnamed top-level
 scope, the search continues in the package hierarchies stored in these

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -321,7 +321,7 @@ scope, the search continues in the package hierarchies stored in these
 directories.
 
 \begin{example}
-\cref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}, with three
+\Cref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}, with three
 directories containing the roots of the package hierarchies \lstinline!Modelica!, \lstinline!MyLib!, and \lstinline!ComplexNumbers!.  The first two are represented as
 the subdirectories \filename{C:\textbackslash{}library\textbackslash{}Modelica} and \filename{C:\textbackslash{}lib1\textbackslash{}MyLib}, whereas the third is stored
 as the file \filename{C:\textbackslash{}lib2\textbackslash{}ComplexNumbers.mo}.

--- a/chapters/preface.tex
+++ b/chapters/preface.tex
@@ -41,4 +41,4 @@ particular language element.
 
 The Modelica language has been developed since 1996. This document
 describes version 3.4 of the Modelica language. A complete summary is
-available in \autoref{modelica-3-4}.
+available in \cref{modelica-3-4}.

--- a/chapters/preface.tex
+++ b/chapters/preface.tex
@@ -1,4 +1,4 @@
-\chapter*{Preface}\doublelabel{preface}
+\chapter*{Preface}\label{preface}
 % https://tex.stackexchange.com/questions/45672/adding-numberless-chapters-to-the-table-of-contents
 \addcontentsline{toc}{chapter}{\protect\numberline{}Preface}
 Modelica is a freely available, object-oriented language for modeling of

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -16,298 +16,298 @@ extensions added in 3.4:
 \begin{itemize}
 \item
   Automatic conversions between different versions (MCP-0014),
-  \autoref{version-handling}. Ticket
+  \cref{version-handling}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1622}{\#1622}.
 \item
-  Flattening is clearly specified (MCP-0019), \autoref{simple-name-lookup} and \autoref{flattening-process}.
+  Flattening is clearly specified (MCP-0019), \cref{simple-name-lookup} and \cref{flattening-process}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1829}{\#1829}.
 \item
   Convert from Integer to Enumeration (MCP-0022), primarily
-  \autoref{type-conversion-of-integer-to-enumeration-values}. Ticket
+  \cref{type-conversion-of-integer-to-enumeration-values}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1842}{\#1842}.
 \item
-  Explicitly casting a Model to Record (MCP-0023), \autoref{casting-to-record}.
+  Explicitly casting a Model to Record (MCP-0023), \cref{casting-to-record}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1953}{\#1953}.
 \item
   Initialization of Clocked Continuous States (MCP-0024),
-  \autoref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition},
-  \autoref{initialization-of-clocked-partitions} and \autoref{other-operators}. Ticket
+  \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition},
+  \cref{initialization-of-clocked-partitions} and \cref{other-operators}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2007}{\#2007}.
 \item
   An added option to Ellipse Annotation to draw only an arc (MCP-0026),
-  \autoref{ellipse}. Ticket
+  \cref{ellipse}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2045}{\#2045}.
 \item
   Allowing mixed Real and non-Real Record Derivatives (MCP-0028),
-  \autoref{using-the-derivative-annotation}. Ticket
+  \cref{using-the-derivative-annotation}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2134}{\#2134}.
 \end{itemize}
 
 The definition of pure functions was refined, in particular to restore
-backwards compatibility with Modelica 3.2, \autoref{pure-modelica-functions}. Ticket
+backwards compatibility with Modelica 3.2, \cref{pure-modelica-functions}. Ticket
 \href{https://github.com/modelica/ModelicaSpecification/issues/1937}{\#1937}.
 
 The following minor improvements were made (starting from 3.3 Revision 1):
 \begin{itemize}
 \item
-  Clarified simulation model, \autoref{scope-of-the-specification}. Ticket
+  Clarified simulation model, \cref{scope-of-the-specification}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/730}{\#730}.
 \item
-  Clarified structural analysis, \autoref{scope-of-the-specification}. Ticket
+  Clarified structural analysis, \cref{scope-of-the-specification}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/588}{\#588}.
 \item
-  Clarified meta-symbols, \autoref{notation-and-grammar} and 2.3.1. Ticket
+  Clarified meta-symbols, \cref{notation-and-grammar} and 2.3.1. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1616}{\#1616}.
 \item
-  Typo, \autoref{identifiers}. Ticket
+  Typo, \cref{identifiers}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1702}{\#1702}.
 \item
-  Clarified newline, \autoref{strings}. Ticket
+  Clarified newline, \cref{strings}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1479}{\#1479}.
 \item
   Allow `\lstinline!"!' and define it to be equal to `\lstinline!\"!' (and
-  similarly for `\lstinline!\?!'), \autoref{identifiers}. Ticket
+  similarly for `\lstinline!\?!'), \cref{identifiers}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1176}{\#1176}.
 \item
-  Clarified that built-in functions in the specification, \autoref{built-in-intrinsic-operators-with-function-syntax}
+  Clarified that built-in functions in the specification, \cref{built-in-intrinsic-operators-with-function-syntax}
   and 12.5. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1608}{\#1608}.
 \item
   Clarified named arguments for builtin operators, in particular
-  spatialDistribution, \autoref{derivative-and-special-purpose-operators-with-function-syntax} and \autoref{positional-or-named-input-arguments-of-functions}. Ticket
+  spatialDistribution, \cref{derivative-and-special-purpose-operators-with-function-syntax} and \cref{positional-or-named-input-arguments-of-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2002}{\#2002}.
 \item
-  Clarified that semiLinear is continuous, \autoref{derivative-and-special-purpose-operators-with-function-syntax}. Ticket
+  Clarified that semiLinear is continuous, \cref{derivative-and-special-purpose-operators-with-function-syntax}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/112}{\#112}.
 \item
-  Corrected spelling, \autoref{derivative-and-special-purpose-operators-with-function-syntax}. Ticket
+  Corrected spelling, \cref{derivative-and-special-purpose-operators-with-function-syntax}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1828}{\#1828}.
 \item
-  Corrected typo in code and reformulated description, \autoref{spatialdistribution}.
+  Corrected typo in code and reformulated description, \cref{spatialdistribution}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1588}{\#1588},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1729}{\#1729}, and
   \href{https://github.com/modelica/ModelicaSpecification/issues/2166}{\#2166}.
 \item
-  Corrected typo for events, \autoref{noevent-and-smooth}. Ticket
+  Corrected typo for events, \cref{noevent-and-smooth}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1657}{\#1657}.
 \item
-  Clarified sample operator, \autoref{event-related-operators-with-function-syntax}. Ticket
+  Clarified sample operator, \cref{event-related-operators-with-function-syntax}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/677}{\#677}.
 \item
-  Additional functions give parameter expression, \autoref{parameter-expressions}. Ticket
+  Additional functions give parameter expression, \cref{parameter-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1082}{\#1082}.
 \item
-  Clarified ExternalObject, \autoref{prefix-rules}. Ticket
+  Clarified ExternalObject, \cref{prefix-rules}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1546}{\#1546}.
 \item
-  Simplified rules type prefixes for structured components, \autoref{prefix-rules}. Ticket
+  Simplified rules type prefixes for structured components, \cref{prefix-rules}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1686}{\#1686}.
 \item
-  Clarified that unexpanded bindings shall be unexpanded, \autoref{acyclic-bindings-of-constants-and-parameters}.
+  Clarified that unexpanded bindings shall be unexpanded, \cref{acyclic-bindings-of-constants-and-parameters}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2153}{\#2153}.
 \item
-  Clarified conditional components, \autoref{conditional-component-declaration}. Ticket
+  Clarified conditional components, \cref{conditional-component-declaration}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2057}{\#2057}.
 \item
-  Improved example to avoid using class, \autoref{local-class-definitions-nested-classes}. Ticket
+  Improved example to avoid using class, \cref{local-class-definitions-nested-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/553}{\#553}.
 \item
-  Clarify inheritance from predefines types, \autoref{specialized-classes}. Ticket
+  Clarify inheritance from predefines types, \cref{specialized-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1250}{\#1250}.
 \item
-  Allow connector inheriting from operator record, \autoref{specialized-classes}. Ticket
+  Allow connector inheriting from operator record, \cref{specialized-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1714}{\#1714}.
 \item
-  Clarify restrictions on record components, \autoref{specialized-classes}. Ticket
+  Clarify restrictions on record components, \cref{specialized-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1615}{\#1615}.
 \item
-  Clarify that only functions may have external clause, \autoref{specialized-classes} and
-  \autoref{function-as-a-specialized-class}. Ticket
+  Clarify that only functions may have external clause, \cref{specialized-classes} and
+  \cref{function-as-a-specialized-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2014}{\#2014}.
 \item
-  Clarified equation count for operator record, \autoref{balanced-models}. Ticket
+  Clarified equation count for operator record, \cref{balanced-models}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/866}{\#866}.
 \item
-  Clarified restriction on attributes, \autoref{predefined-types-and-classes}. Ticket
+  Clarified restriction on attributes, \cref{predefined-types-and-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1426}{\#1426}.
 \item
-  Clarified how reserved the different built-in types are, \autoref{predefined-types-and-classes}.
+  Clarified how reserved the different built-in types are, \cref{predefined-types-and-classes}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1538}{\#1538}.
 \item
-  Removed restriction on nominal and explained purpose, \autoref{real-type}.
+  Removed restriction on nominal and explained purpose, \cref{real-type}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1445}{\#1445}.
 \item
-  Added unbounded to Real, \autoref{real-type} and \autoref{attributes-start-fixed-nominal-and-unbounded}. Ticket
+  Added unbounded to Real, \cref{real-type} and \cref{attributes-start-fixed-nominal-and-unbounded}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/926}{\#926}.
 \item
-  Added fixed-attribute for String, \autoref{string-type}. Ticket
+  Added fixed-attribute for String, \cref{string-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1797}{\#1797}.
 \item
-  Clarified and corrected example in \autoref{enumeration-types}. Ticket
+  Clarified and corrected example in \cref{enumeration-types}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1849}{\#1849} and
   \href{https://github.com/modelica/ModelicaSpecification/issues/2150}{\#2150}.
 \item
-  Clarified nominal attribute, \autoref{attributes-start-fixed-nominal-and-unbounded}
-  and \autoref{stream-operator-instream-and-connection-equations}. Ticket
+  Clarified nominal attribute, \cref{attributes-start-fixed-nominal-and-unbounded}
+  and \cref{stream-operator-instream-and-connection-equations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1877}{\#1877}.
 \item
-  Added that Connections is builtin package, \autoref{connections}. Ticket
+  Added that Connections is builtin package, \cref{connections}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1883}{\#1883}.
 \item
-  Clarified lookup-order regarding import, \autoref{simple-name-lookup}. Ticket
+  Clarified lookup-order regarding import, \cref{simple-name-lookup}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1573}{\#1573}.
 \item
-  Extend calling functions through component to array case, \autoref{composite-name-lookup} and \autoref{expressions}. Ticket
+  Extend calling functions through component to array case, \cref{composite-name-lookup} and \cref{expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1613}{\#1613}.
 \item
-  Clarified existing use of automatic inner declarations, \autoref{instance-hierarchy-name-lookup-of-inner-declarations}
-  and \autoref{annotations-for-the-graphical-user-interface}. Ticket
+  Clarified existing use of automatic inner declarations, \cref{instance-hierarchy-name-lookup-of-inner-declarations}
+  and \cref{annotations-for-the-graphical-user-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1551}{\#1551} and
   \href{https://github.com/modelica/ModelicaSpecification/issues/1749}{\#1749}.
 \item
-  Removed restriction on array size for modifiers, \autoref{interface-compatibility-or-subtyping}. Ticket
+  Removed restriction on array size for modifiers, \cref{interface-compatibility-or-subtyping}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1432}{\#1432}.
 \item
-  Clarified that 2/3 and 2\^{}(-3) are Real, \autoref{type-compatible-expressions}. Ticket
+  Clarified that 2/3 and 2\^{}(-3) are Real, \cref{type-compatible-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1647}{\#1647}.
 \item
-  Clarified that external declaration is inherited, \autoref{inheritance-extends-clause}. Ticket
+  Clarified that external declaration is inherited, \cref{inheritance-extends-clause}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/789}{\#789}.
 \item
-  Further clarified order for multiple inheritance, \autoref{instantiation} and
-  \autoref{inheritance-extends-clause}. Ticket
+  Further clarified order for multiple inheritance, \cref{instantiation} and
+  \cref{inheritance-extends-clause}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2015}{\#2015}.
 \item
-  Clarified inheritance restrictions, \autoref{restrictions-on-the-kind-of-base-class}. Ticket
+  Clarified inheritance restrictions, \cref{restrictions-on-the-kind-of-base-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1451}{\#1451}.
 \item
-  Restricted merging of modifiers, \autoref{merging-of-modifications}. Ticket
+  Restricted merging of modifiers, \cref{merging-of-modifications}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/791}{\#791}.
 \item
-  Clarified each especially for nested arrays, \autoref{single-modification} and \autoref{modifiers-for-array-elements}.
+  Clarified each especially for nested arrays, \cref{single-modification} and \cref{modifiers-for-array-elements}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1596}{\#1596}.
 \item
-  Clarified replaceable with array sizes on types, \autoref{redeclaration}. Ticket
+  Clarified replaceable with array sizes on types, \cref{redeclaration}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1251}{\#1251}.
 \item
-  Corrected and moved example, \autoref{redeclaration} and \autoref{constraining-type}. Ticket
+  Corrected and moved example, \cref{redeclaration} and \cref{constraining-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1034}{\#1034}.
 \item
-  Clarified \lstinline!redeclare class extends B!, \autoref{the-class-extends-redeclaration-mechanism}. Ticket
+  Clarified \lstinline!redeclare class extends B!, \cref{the-class-extends-redeclaration-mechanism}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/462}{\#462} and
   \href{https://github.com/modelica/ModelicaSpecification/issues/709}{\#709}.
 \item
-  Corrected example, \autoref{constraining-type}. Ticket
+  Corrected example, \cref{constraining-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1725}{\#1725}.
 \item
-  Clarified description and annotation on constraining-clause, \autoref{constraining-clause-annotations}. Ticket
+  Clarified description and annotation on constraining-clause, \cref{constraining-clause-annotations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/512}{\#512}.
 \item
-  Corrected typo, \autoref{annotation-choices-for-suggested-redeclarations-and-modifications}. Ticket
+  Corrected typo, \cref{annotation-choices-for-suggested-redeclarations-and-modifications}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1770}{\#1770}.
 \item
-  Clarified for-equation with types, \autoref{for-equations-repetitive-equation-structures}. Ticket
+  Clarified for-equation with types, \cref{for-equations-repetitive-equation-structures}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/915}{\#915}.
 \item
-  Clarified event generation, \autoref{events-and-synchronization}. Ticket
+  Clarified event generation, \cref{events-and-synchronization}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2114}{\#2114}.
 \item
-  Further clarified initial() for when-clauses, \autoref{initialization-initial-equation-and-initial-algorithm} -- and
+  Further clarified initial() for when-clauses, \cref{initialization-initial-equation-and-initial-algorithm} -- and
   indicated that this appendix is not normative. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1852}{\#1852}.
 \item
-  Clarified using start-attribute for parameters, \autoref{initialization-initial-equation-and-initial-algorithm}. Ticket
+  Clarified using start-attribute for parameters, \cref{initialization-initial-equation-and-initial-algorithm}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2136}{\#2136}.
 \item
-  Clarified that states for first order ODE, \autoref{the-number-of-equations-needed-for-initialization}. Ticket
+  Clarified that states for first order ODE, \cref{the-number-of-equations-needed-for-initialization}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/937}{\#937}.
 \item
   Clarified adding input/output prefix for expandable connector
-  variables, \autoref{expandable-connectors}. Ticket
+  variables, \cref{expandable-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/829}{\#829}.
 \item
-  Clarified creating elements in expandable connectors, \autoref{expandable-connectors}.
+  Clarified creating elements in expandable connectors, \cref{expandable-connectors}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/428}{\#428}.
 \item
-  Corrected expandable connector example, \autoref{expandable-connectors}. Ticket
+  Corrected expandable connector example, \cref{expandable-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1763}{\#1763}.
 \item
-  Clarified that stream-variables do not generate equations, \autoref{generation-of-connection-equations}. Ticket
+  Clarified that stream-variables do not generate equations, \cref{generation-of-connection-equations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1584}{\#1584}.
 \item
-  Restrict that stream only connects to stream, \autoref{restrictions-of-connections-and-connectors}. Ticket
+  Restrict that stream only connects to stream, \cref{restrictions-of-connections-and-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/796}{\#796}.
 \item
-  Clarified section heading, \autoref{balancing-restriction-and-size-of-connectors}. Ticket
+  Clarified section heading, \cref{balancing-restriction-and-size-of-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/727}{\#727}.
 \item
-  Clarified vector arguments for operators in \autoref{overconstrained-equation-operators-for-connection-graphs}. Ticket
+  Clarified vector arguments for operators in \cref{overconstrained-equation-operators-for-connection-graphs}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1590}{\#1590}.
 \item
-  Corrected example, \autoref{an-overdetermined-connector-for-power-systems}. Ticket
+  Corrected example, \cref{an-overdetermined-connector-for-power-systems}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2143}{\#2143}.
 \item
-  Clarified return type for reduction expressions, \autoref{reduction-functions-and-operators}.
+  Clarified return type for reduction expressions, \cref{reduction-functions-and-operators}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/981}{\#981}.
 \item
-  Extended reduction expression sum to operator records, \autoref{reduction-functions-and-operators}.
+  Extended reduction expression sum to operator records, \cref{reduction-functions-and-operators}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1897}{\#1897}.
 \item
-  Clarified table in \autoref{reduction-expressions}. Ticket
+  Clarified table in \cref{reduction-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1722}{\#1722}.
 \item
-  Match parenthesis, \autoref{array-constructor-with-several-iterators}. Ticket
+  Match parenthesis, \cref{array-constructor-with-several-iterators}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1558}{\#1558}.
 \item
-  Recommend better alternative for generating vector, \autoref{vector-construction}.
+  Recommend better alternative for generating vector, \cref{vector-construction}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1837}{\#1837}.
 \item
-  Defined unary operators, \autoref{array-element-wise-addition-subtraction-and-string-concatenation}. Ticket
+  Defined unary operators, \cref{array-element-wise-addition-subtraction-and-string-concatenation}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2027}{\#2027}.
 \item
-  Allow missing trailing indices, sections \autoref{array-indexing} and \autoref{slice-operation}. Ticket
+  Allow missing trailing indices, sections \cref{array-indexing} and \cref{slice-operation}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1603}{\#1603}.
 \item
   Clarified that element-wise division gives real result,
-  \autoref{array-element-wise-division}. Ticket
+  \cref{array-element-wise-division}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1119}{\#1119}.
 \item
-  Removed misleading comment, \autoref{execution-of-an-algorithm-in-a-model}. Ticket
+  Removed misleading comment, \cref{execution-of-an-algorithm-in-a-model}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/938}{\#938}.
 \item
   Clarified how assignment works for multi-returning functions,
-  \autoref{assignments-from-called-functions-with-multiple-results}. Ticket
+  \cref{assignments-from-called-functions-with-multiple-results}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1921}{\#1921}.
 \item
   Clarified no equations and initial algorithms in functions,
-  \autoref{function-as-a-specialized-class}. Ticket
+  \cref{function-as-a-specialized-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2160}{\#2160}.
 \item
   Clarified assigning to record variables with bindings in functions,
-  \autoref{function-as-a-specialized-class}. Ticket
+  \cref{function-as-a-specialized-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2016}{\#2016}.
 \item
-  Clarified initialization of variables in functions, \autoref{initialization-and-declaration-assignments-of-components-in-functions}.
+  Clarified initialization of variables in functions, \cref{initialization-and-declaration-assignments-of-components-in-functions}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1708}{\#1708}.
 \item
   Standarize current practice of using = instead of := for bindings in
-  functions, \autoref{function-as-a-specialized-class}. Ticket
+  functions, \cref{function-as-a-specialized-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1595}{\#1595}.
 \item
-  Clarified function partial evaluation, \autoref{function-partial-application}. Ticket
+  Clarified function partial evaluation, \cref{function-partial-application}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/647}{\#647}.
 \item
   Clarified initialization of record components in functions,
-  \autoref{initialization-and-declaration-assignments-of-components-in-functions}. Ticket
+  \cref{initialization-and-declaration-assignments-of-components-in-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1230}{\#1230}.
 \item
-  Clarified flexible array sizes, \autoref{flexible-array-sizes-and-resizing-of-arrays-in-functions}. Ticket
+  Clarified flexible array sizes, \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2158}{\#2158}.
 \item
-  Clarified name of output for record constructor in \autoref{record-constructor-functions}.
+  Clarified name of output for record constructor in \cref{record-constructor-functions}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/366}{\#366}.
 \item
-  Clarified derivatives for functions in several ways, \autoref{using-the-derivative-annotation}.
+  Clarified derivatives for functions in several ways, \cref{using-the-derivative-annotation}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/985}{\#985},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1543}{\#1543},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1544}{\#1544},
@@ -319,139 +319,139 @@ The following minor improvements were made (starting from 3.3 Revision 1):
   \href{https://github.com/modelica/ModelicaSpecification/issues/1987}{\#1987}.
 \item
   Clarified that using C89 and added possibility for C89, C99, and C11 ,
-  \autoref{external-function-interface}. Ticket
+  \cref{external-function-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1088}{\#1088}.
 \item
-  Clarified input/output to external functions, \autoref{external-function-interface}. Ticket
+  Clarified input/output to external functions, \cref{external-function-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/775}{\#775}.
 \item
   Clarified handling of Boolean variables for external C,
-  \autoref{simple-types}. Ticket
+  \cref{simple-types}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1846}{\#1846}.
 \item
-  Added that Strings can be sent to FORTRAN~77, \autoref{simple-types}. Ticket
+  Added that Strings can be sent to FORTRAN~77, \cref{simple-types}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1971}{\#1971}.
 \item
-  Allow multiple include directories, \autoref{annotations-for-external-libraries-and-include-files}. Ticket
+  Allow multiple include directories, \cref{annotations-for-external-libraries-and-include-files}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2103}{\#2103}.
 \item
   Allow specific libraries for different compiler versions,
-  \autoref{annotations-for-external-libraries-and-include-files}. Ticket
+  \cref{annotations-for-external-libraries-and-include-files}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1316}{\#1316}.
 \item
-  Added external warning functions, \autoref{utility-functions}. Ticker
+  Added external warning functions, \cref{utility-functions}. Ticker
   \href{https://github.com/modelica/ModelicaSpecification/issues/1967}{\#1967}.
 \item
-  Clarified that pointers are only valid during each call, \autoref{external-objects}. Ticket
+  Clarified that pointers are only valid during each call, \cref{external-objects}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1611}{\#1611}.
 \item
-  Clarified constructor and destructor, \autoref{external-objects}. Ticket
+  Clarified constructor and destructor, \cref{external-objects}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1907}{\#1907}.
 \item
-  Clarified 'structured entity' to be 'directory', \autoref{mapping-package-class-structures-to-a-hierarchical-file-system}.
+  Clarified 'structured entity' to be 'directory', \cref{mapping-package-class-structures-to-a-hierarchical-file-system}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/922}{\#922}.
 \item
-  Clarified handling of incorrect package.order, \autoref{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}.
+  Clarified handling of incorrect package.order, \cref{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1858}{\#1858}.
 \item
-  Restricted use of files with multiple classes, \autoref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}.
+  Restricted use of files with multiple classes, \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1854}{\#1854}.
 \item
-  Clarified storing resources in a file-system, \autoref{external-resources}. Ticket
+  Clarified storing resources in a file-system, \cref{external-resources}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/685}{\#685},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1623}{\#1623}.
 \item
-  Used correct font, \autoref{external-resources}. Ticket
+  Used correct font, \cref{external-resources}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2061}{\#2061}.
 \item
-  Clarified that inStream optimizations are allowed, \autoref{stream-operator-instream-and-connection-equations}.
+  Clarified that inStream optimizations are allowed, \cref{stream-operator-instream-and-connection-equations}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1766}{\#1766}.
 \item
-  Corrected actualStream example in \autoref{stream-operator-actualstream}. Ticket
+  Corrected actualStream example in \cref{stream-operator-actualstream}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1652}{\#1652}.
 \item
-  Corrected non-periodic rational clocks, \autoref{clock-constructors}. Ticket
+  Corrected non-periodic rational clocks, \cref{clock-constructors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2022}{\#2022}.
 \item
   Clarified initialization of clocked discretized continuous-time
-  partitions, \autoref{solver-methods}. Ticket
+  partitions, \cref{solver-methods}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1528}{\#1528}.
 \item
-  Defined rendering order, \autoref{annotations-for-graphical-objects}. Ticket
+  Defined rendering order, \cref{annotations-for-graphical-objects}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1750}{\#1750}.
 \item
-  Clarified rotation direction, \autoref{common-definitions}. Ticket
+  Clarified rotation direction, \cref{common-definitions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1830}{\#1830}.
 \item
-  Clarified coordinate system definition, \autoref{coordinate-systems}. Ticket
+  Clarified coordinate system definition, \cref{coordinate-systems}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1831}{\#1831}.
 \item
   Defined coordinate system inheritance to be less suprising,
-  \autoref{coordinate-systems} and \autoref{extends-clause}. Ticket
+  \cref{coordinate-systems} and \cref{extends-clause}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1978}{\#1978}.
 \item
-  Clarified lineThickness and borderPattern, \autoref{graphical-primitives} \autoref{graphical-properties}.
+  Clarified lineThickness and borderPattern, \cref{graphical-primitives} \cref{graphical-properties}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1896}{\#1896}.
 \item
-  Corrected formatting, \autoref{graphical-properties}. Ticket
+  Corrected formatting, \cref{graphical-properties}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1825}{\#1825}.
 \item
-  Made the different Text-annotations more similar, \autoref{connections}.
+  Made the different Text-annotations more similar, \cref{connections}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1621}{\#1621}.
 \item
-  Clarified LinePatterns in \autoref{graphical-primitives}. Ticket
+  Clarified LinePatterns in \cref{graphical-primitives}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1483}{\#1483}.
 \item
   Corrected flipping of components and bitmaps, and clarified various
-  aspects of bitmaps, \autoref{component-instance} and \autoref{bitmap}. Ticket
+  aspects of bitmaps, \cref{component-instance} and \cref{bitmap}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1923}{\#1923}.
 \item
-  Clarified arrows, \autoref{line}. Ticket
+  Clarified arrows, \cref{line}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1894}{\#1894}.
 \item
-  Clarified existing use of zero-width texts, \autoref{text}. Ticket
+  Clarified existing use of zero-width texts, \cref{text}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1636}{\#1636}.
 \item
-  Added specific fontnames, \autoref{text}. Ticket
+  Added specific fontnames, \cref{text}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1986}{\#1986}.
 \item
-  Added alternative for macro-expansion, \autoref{text}. Ticket
+  Added alternative for macro-expansion, \cref{text}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2148}{\#2148}.
 \item
-  Corrected example in \autoref{mouse-input}. Ticket
+  Corrected example in \cref{mouse-input}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2111}{\#2111}.
 \item
-  Placed annotation last in classes, in particular \autoref{annotations-for-the-graphical-user-interface}. Ticket
+  Placed annotation last in classes, in particular \cref{annotations-for-the-graphical-user-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1009}{\#1009}.
 \item
-  Cleaned up code and formatting in \autoref{annotations-for-the-graphical-user-interface}. Ticket
+  Cleaned up code and formatting in \cref{annotations-for-the-graphical-user-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2041}{\#2041},
   \href{https://github.com/modelica/ModelicaSpecification/issues/2042}{\#2042}, and
   \href{https://github.com/modelica/ModelicaSpecification/issues/2125}{\#2125}.
 \item
-  Added missing nano-prefix, \autoref{the-syntax-of-unit-expressions}. Ticket
+  Added missing nano-prefix, \cref{the-syntax-of-unit-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1261}{\#1261}.
 \item
-  Replaced the outdated contents of \autoref{the-modelica-standard-library} by a hyperlink. Ticket
+  Replaced the outdated contents of \cref{the-modelica-standard-library} by a hyperlink. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2130}{\#2130}.
 \item
-  Added ModelicaServices to \autoref{the-modelica-standard-library}. Ticket
+  Added ModelicaServices to \cref{the-modelica-standard-library}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/2132}{\#2132}.
 \item
-  Restrict grammar to avoid modifiers with leading dot, \autoref{grammar}.
+  Restrict grammar to avoid modifiers with leading dot, \cref{grammar}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1027}{\#1027}.
 \item
-  Restrict grammar for base-prefix, \autoref{class-definition}. Ticket
+  Restrict grammar for base-prefix, \cref{class-definition}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/917}{\#917}.
 \item
-  Restrict grammar for arrays, \autoref{expressions}. Ticket
+  Restrict grammar for arrays, \cref{expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/809}{\#809}.
 \item
   Restrict grammar for function arguments (replacing semantic
-  restriction), \autoref{expressions}. Ticket
+  restriction), \cref{expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1634}{\#1634}.
 \item
-  Corrected typo in \autoref{rationale-for-the-formulation-of-the-instream-operator}. Ticket
+  Corrected typo in \cref{rationale-for-the-formulation-of-the-instream-operator}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1317}{\#1317}.
 \end{itemize}
 
@@ -471,194 +471,194 @@ addition the following improvements were made:
 \begin{itemize}
 \item
   Clarified that String-operator cannot use positional arguments,
-  \autoref{numeric-functions-and-conversion-functions}. Ticket
+  \cref{numeric-functions-and-conversion-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1468}{\#1468}.
 \item
-  Corrected size of enumeration, \autoref{numeric-functions-and-conversion-functions} and \autoref{type-conversion-of-enumeration-values-to-string-or-integer}. Ticket
+  Corrected size of enumeration, \cref{numeric-functions-and-conversion-functions} and \cref{type-conversion-of-enumeration-values-to-string-or-integer}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1369}{\#1369}.
 \item
-  Clarified spatialDistribution, \autoref{built-in-mathematical-functions-and-external-built-in-functions}. Ticket
+  Clarified spatialDistribution, \cref{built-in-mathematical-functions-and-external-built-in-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1510}{\#1510}.
 \item
-  Restricted cardinality to give a clear definition, \autoref{cardinality-deprecated}.
+  Restricted cardinality to give a clear definition, \cref{cardinality-deprecated}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1409}{\#1409}.
 \item
-  Clarified which constants need a value, \autoref{constant-expressions}. Ticket
+  Clarified which constants need a value, \cref{constant-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1220}{\#1220}.
 \item
-  Clarified type prefixes rules, \autoref{prefix-rules}. Tickets
+  Clarified type prefixes rules, \cref{prefix-rules}. Tickets
   \href{https://github.com/modelica/ModelicaSpecification/issues/1196}{\#1196},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1221}{\#1221},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1301}{\#1301}.
 \item
   Added exception for cyclic parameter bindings (already used in MSL),
-  \autoref{acyclic-bindings-of-constants-and-parameters}. Ticket
+  \cref{acyclic-bindings-of-constants-and-parameters}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1320}{\#1320}.
 \item
-  Added example for use of conditional components, \autoref{conditional-component-declaration}. Ticket
+  Added example for use of conditional components, \cref{conditional-component-declaration}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1227}{\#1227}.
 \item
-  Corrected annotation-grammar, \autoref{class-declarations}. Ticket
+  Corrected annotation-grammar, \cref{class-declarations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1378}{\#1378}.
 \item
-  Corrected duplicated class-definition grammar, \autoref{class-declarations}. Ticket
+  Corrected duplicated class-definition grammar, \cref{class-declarations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1388}{\#1388}.
 \item
-  Clarified short class definition, \autoref{short-class-definitions}. Ticket
+  Clarified short class definition, \cref{short-class-definitions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/527}{\#527}.
 \item
-  Removed unusable variant for operator and operator function, \autoref{specialized-classes}. Ticket
+  Removed unusable variant for operator and operator function, \cref{specialized-classes}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1459}{\#1459},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1497}{\#1497}.
 \item
-  Added definition of AssertionLevel, \autoref{assertionlevel}. Ticket
+  Added definition of AssertionLevel, \cref{assertionlevel}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/962}{\#962}.
 \item
-  Corrected typos at end of loops in examples,\autoref{enumeration-types} and
-  \autoref{implicit-iteration-ranges-of-for-equations}. Ticket
+  Corrected typos at end of loops in examples,\cref{enumeration-types} and
+  \cref{implicit-iteration-ranges-of-for-equations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/902}{\#902}
 \item
-  Clarified temporary flattening, \autoref{composite-name-lookup}. Ticket
+  Clarified temporary flattening, \cref{composite-name-lookup}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1327}{\#1327}.
 \item
-  Added definition of modification equations, \autoref{modifications}. Ticket
+  Added definition of modification equations, \cref{modifications}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/959}{\#959}.
 \item
-  Clarified modifiers for array elements, \autoref{modifiers-for-array-elements}. Ticket
+  Clarified modifiers for array elements, \cref{modifiers-for-array-elements}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1324}{\#1324}.
 \item
-  Corrected example for final element modification, \autoref{final-element-modification-prevention}
+  Corrected example for final element modification, \cref{final-element-modification-prevention}
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1326}{\#1326}.
 \item
-  Corrected duplicated class-definition grammar, \autoref{the-class-extends-redeclaration-mechanism}. Ticket
+  Corrected duplicated class-definition grammar, \cref{the-class-extends-redeclaration-mechanism}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1388}{\#1388}.
 \item
-  Clarified modifiers on constraining type, \autoref{constraining-type}. Ticket
+  Clarified modifiers on constraining type, \cref{constraining-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1033}{\#1033}.
 \item
   Clarified when redeclare can be used with the same type and rules for
-  redeclaring array types, \autoref{restrictions-on-redeclarations}. Tickets
+  redeclaring array types, \cref{restrictions-on-redeclarations}. Tickets
   \href{https://github.com/modelica/ModelicaSpecification/issues/1252}{\#1252},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1281}{\#1281}.
 \item
-  Clarified default for annotation choicesAllMatching, \autoref{annotation-choices-for-suggested-redeclarations-and-modifications}.
+  Clarified default for annotation choicesAllMatching, \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1391}{\#1391}.
 \item
   Forbid when-statements in initial equation/algorithm (they would in
-  most cases not be active; leading to confusion), \autoref{restrictions-on-equations-within-when-equations} and
-  \autoref{restrictions-on-when-statements}. Ticket
+  most cases not be active; leading to confusion), \cref{restrictions-on-equations-within-when-equations} and
+  \cref{restrictions-on-when-statements}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1288}{\#1288}.
 \item
-  Clarified reinit during initialization, \autoref{reinit} \autoref{initialization-initial-equation-and-initial-algorithm}. Ticket
+  Clarified reinit during initialization, \cref{reinit} \cref{initialization-initial-equation-and-initial-algorithm}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1372}{\#1372}.
 \item
-  Clarified using start-values as guess-values; \autoref{initialization-initial-equation-and-initial-algorithm}. Tickets
+  Clarified using start-values as guess-values; \cref{initialization-initial-equation-and-initial-algorithm}. Tickets
   \href{https://github.com/modelica/ModelicaSpecification/issues/1133}{\#1133},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1246}{\#1246}.
 \item
-  Clarified allowed use of variables in expandable connectors; \autoref{expandable-connectors}. Ticket
+  Clarified allowed use of variables in expandable connectors; \cref{expandable-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1279}{\#1279}.
 \item
-  Clarified causality for expandable connectors; \autoref{expandable-connectors}. Ticket
+  Clarified causality for expandable connectors; \cref{expandable-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1305}{\#1305}.
 \item
-  Clarified expandable connectors in general; \autoref{expandable-connectors}. Ticket
+  Clarified expandable connectors in general; \cref{expandable-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1330}{\#1330}.
 \item
-  Clarified connection matching, \autoref{restrictions-of-connections-and-connectors}. Ticket
+  Clarified connection matching, \cref{restrictions-of-connections-and-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/884}{\#884}.
 \item
   Added quantity checks for connectors (MSL already relies on this
-  check); \autoref{restrictions-of-connections-and-connectors}. Ticket
+  check); \cref{restrictions-of-connections-and-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1284}{\#1284}.
 \item
-  Clarified arrays with non-Integer dimensions, \autoref{array-declarations}. Ticket
+  Clarified arrays with non-Integer dimensions, \cref{array-declarations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1501}{\#1501}.
 \item
-  Clarified that ndims is allow for a scalar, \autoref{array-dimension-and-size-functions}. Ticket
+  Clarified that ndims is allow for a scalar, \cref{array-dimension-and-size-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1303}{\#1303}.
 \item
-  Clarified number of arguments for zeros, ones, fill, \autoref{specialized-array-constructor-functions}.
+  Clarified number of arguments for zeros, ones, fill, \cref{specialized-array-constructor-functions}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1351}{\#1351}.
 \item
-  Clarified min/max, \autoref{reduction-functions-and-operators}. Ticket
+  Clarified min/max, \cref{reduction-functions-and-operators}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1036}{\#1036}.
 \item
   Clarified array expressions using iterations allow non-simple types,
-  \autoref{array-constructor-with-iterators}. Ticket
+  \cref{array-constructor-with-iterators}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1521}{\#1521}.
 \item
-  Clarified arrays with non-Integer dimensions, \autoref{indexing-with-boolean-or-enumeration-values}. Ticket
+  Clarified arrays with non-Integer dimensions, \cref{indexing-with-boolean-or-enumeration-values}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1463}{\#1463}.
 \item
-  Clarified calling function as specialized class, \autoref{function-as-a-specialized-class}. Ticket
+  Clarified calling function as specialized class, \cref{function-as-a-specialized-class}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1362}{\#1362}.
 \item
   Clarified default values in functions depending on other inputs,
-  \autoref{positional-or-named-input-arguments-of-functions}. Ticket
+  \cref{positional-or-named-input-arguments-of-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1346}{\#1346}.
 \item
-  Corrected syntax error in example, \autoref{function-partial-application}. Ticket
+  Corrected syntax error in example, \cref{function-partial-application}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1338}{\#1338}.
 \item
-  Clarified annotations on external functions, \autoref{external-function-interface}. Ticket
+  Clarified annotations on external functions, \cref{external-function-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/660}{\#660}.
 \item
   Add possibility for sending arrays in records to external functions,
-  \autoref{external-function-interface}. Ticket
+  \cref{external-function-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/351}{\#351}.
 \item
-  Corrected spelling to FORTRAN~77, \autoref{aliasing}. Ticket
+  Corrected spelling to FORTRAN~77, \cref{aliasing}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1278}{\#1278}.
 \item
-  Clarified default directories, \autoref{annotations-for-external-libraries-and-include-files}. Ticket
+  Clarified default directories, \cref{annotations-for-external-libraries-and-include-files}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1456}{\#1456}.
 \item
-  Clarified constructing/destructing external objects, \autoref{external-objects}.
+  Clarified constructing/destructing external objects, \cref{external-objects}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1518}{\#1518}.
 \item
-  Clarified encapsulation requirement for operator record, \autoref{overloaded-operators}.
+  Clarified encapsulation requirement for operator record, \cref{overloaded-operators}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1254}{\#1254}.
 \item
   Clarified operator record: arrays, priority, and zero result,
-  \autoref{overloaded-binary-operations}. Tickets
+  \cref{overloaded-binary-operations}. Tickets
   \href{https://github.com/modelica/ModelicaSpecification/issues/1469}{\#1469},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1476}{\#1476},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1481}{\#1481}.
 \item
-  Added element wise operations for operator record, \autoref{overloaded-binary-operations}.
+  Added element wise operations for operator record, \cref{overloaded-binary-operations}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1455}{\#1455}.
 \item
-  Improved formulation, \autoref{clock-constructors}. Ticket
+  Improved formulation, \cref{clock-constructors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1362}{\#1362}.
 \item
-  Clarified why noClock exists; \autoref{sub-clock-conversion-operators}. Ticket
+  Clarified why noClock exists; \cref{sub-clock-conversion-operators}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1094}{\#1094}.
 \item
   Added initial conditions to solver methods for clocked discretized
-  continuous-time partitions; \autoref{solver-methods}. Ticket
+  continuous-time partitions; \cref{solver-methods}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1379}{\#1379}.
 \item
   Added requirement that priorities must be unique for statechart
   transitions (the restriction was present in original description and
-  is necessary to ensure deterministic behavior), \autoref{state-machine-semantics}. Ticket
+  is necessary to ensure deterministic behavior), \cref{state-machine-semantics}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/853}{\#853}.
 \item
-  Corrected syntax in Line definition, \autoref{line}. Ticket
+  Corrected syntax in Line definition, \cref{line}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1464}{\#1464}.
 \item
-  Corrected connectorSizing description, \autoref{annotations-for-the-graphical-user-interface}. Ticket
+  Corrected connectorSizing description, \cref{annotations-for-the-graphical-user-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1441}{\#1441}.
 \item
-  Corrected license example, \autoref{licensing}. Ticket
+  Corrected license example, \cref{licensing}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1127}{\#1127}.
 \item
   Clarified names of productions in grammar and changed to use hyphen,
-  \autoref{lexical-conventions}. Tickets
+  \cref{lexical-conventions}. Tickets
   \href{https://github.com/modelica/ModelicaSpecification/issues/713}{\#713} and
   \href{https://github.com/modelica/ModelicaSpecification/issues/1033}{\#1033}.
 \item
-  Modified grammar use consistent style for import-list, \autoref{class-definition}.
+  Modified grammar use consistent style for import-list, \cref{class-definition}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1374}{\#1374}.
 \end{itemize}
 
@@ -693,62 +693,62 @@ The following \emph{backward compatible extensions} have been introduced with Mo
 \begin{itemize}
 \item
   Language elements for describing synchronous behavior suited for
-  implementation of control systems, \autoref{synchronous-language-elements}.
+  implementation of control systems, \cref{synchronous-language-elements}.
 \item
-  Language elements to define synchronous state machines, \autoref{state-machines}.
+  Language elements to define synchronous state machines, \cref{state-machines}.
 \item
   The spatialDistribution function for special one-dimensional flow
-  problems, \autoref{spatialdistribution}.
+  problems, \cref{spatialdistribution}.
 \item
-  The getInstanceName function for diagnostic messages, \autoref{getinstancename}.
+  The getInstanceName function for diagnostic messages, \cref{getinstancename}.
 \item
-  Possible to call a function through an instance name, \autoref{composite-name-lookup}.
+  Possible to call a function through an instance name, \cref{composite-name-lookup}.
 \item
   Can use the start-value for a parameter to give a non-zero default
-  that should be changed, \autoref{initialization-initial-equation-and-initial-algorithm}.
+  that should be changed, \cref{initialization-initial-equation-and-initial-algorithm}.
 \item
   A recommened procedure for priority between initial values have been
-  added, \autoref{recommended-selection-of-start-values}.
+  added, \cref{recommended-selection-of-start-values}.
 \item
-  Functions can be defined without algorithm-section, \autoref{function-as-a-specialized-class}.
+  Functions can be defined without algorithm-section, \cref{function-as-a-specialized-class}.
 \item
   Functions can be marked as pure or impure with specified semantics,
-  \autoref{pure-modelica-functions}.
+  \cref{pure-modelica-functions}.
 \item
-  The rules for ExternalObject have been clarified, \autoref{external-objects} and
-  \autoref{interface-or-type-relationships}.
+  The rules for ExternalObject have been clarified, \cref{external-objects} and
+  \cref{interface-or-type-relationships}.
 \item
-  Multiple definition import, \autoref{importing-definitions-from-a-package}.
+  Multiple definition import, \cref{importing-definitions-from-a-package}.
 \item
   Additional annotations allowing:
   \begin{itemize}
   \item
-    Functions to generate events, \autoref{annotations-for-code-generation}.
+    Functions to generate events, \cref{annotations-for-code-generation}.
   \item
     Experiments to specify a time-resolution of simulation result,
-    \autoref{annotations-for-simulation-experiments}.
+    \cref{annotations-for-simulation-experiments}.
   \item
-    Single instance of class, \autoref{annotation-for-single-use-of-class}.
+    Single instance of class, \cref{annotation-for-single-use-of-class}.
   \item
-    Text in the diagram layer can use a macro syntax, \autoref{text}.
+    Text in the diagram layer can use a macro syntax, \cref{text}.
   \item
-    Color selection dialog for parameters, \autoref{annotations-for-the-graphical-user-interface}.
+    Color selection dialog for parameters, \cref{annotations-for-the-graphical-user-interface}.
   \item
     Conversion to specify a set of versions to convert with one script,
-    \autoref{version-handling}.
+    \cref{version-handling}.
   \item
     Licensed libraries to define the set of allowed operations
-    (including binary/source export), \autoref{licensing}.
+    (including binary/source export), \cref{licensing}.
   \end{itemize}
 \end{itemize}
 
 The following changes in Modelica 3.3 are \emph{not} backwards compatible:
 \begin{itemize}
 \item
-  \autonameref{synchronous-language-elements} from
+  \Crefnameref{synchronous-language-elements} from
   Modelica 3.2 has been removed (a more powerful functionality is
-  instead provided with the new \autoref{synchronous-language-elements} and \autoref{state-machines}). Since, no
-  released tools has yet supported the previous \autoref{synchronous-language-elements}, this not
+  instead provided with the new \cref{synchronous-language-elements} and \cref{state-machines}). Since, no
+  released tools has yet supported the previous \cref{synchronous-language-elements}, this not
   backwards compatible change is uncritical.
 \item
   The new \lstinline!spatialDistribution! and \lstinline!getInstanceName! functions could cause
@@ -758,22 +758,22 @@ The following changes in Modelica 3.3 are \emph{not} backwards compatible:
 \begin{itemize}
 \item
   Conditional physical connectors must be connected if enabled,
-  \autoref{conditional-component-declaration}
-  and \autoref{restrictions-of-connections-and-connectors}. In almost all cases they have to be connected
+  \cref{conditional-component-declaration}
+  and \cref{restrictions-of-connections-and-connectors}. In almost all cases they have to be connected
   to generate correct result, and it is not possible to check that they
   are connected in the models
 \end{itemize}
 
 \subsection{Contributors to Modelica 3.3}\doublelabel{contributors-to-modelica-3-3}
 
-The language elements for describing synchronous behavior, \autoref{synchronous-language-elements},
+The language elements for describing synchronous behavior, \cref{synchronous-language-elements},
 was mainly developed by Hilding Elmqvist, Martin Otter, and Sven Erik
 Mattsson. Hilding Elmqvist wrote a detailed tutorial. Sven Erik Mattsson
 developed a test implementation of the language elements and the needed
 new algorithms. Based on the prototype, tests and feedback have been
 provided by Martin Otter and Bernhard Thiele.
 
-The language elements to define synchronous state machines, \autoref{state-machines},
+The language elements to define synchronous state machines, \cref{state-machines},
 was mainly developed by Hilding Elmqvist with contributions from
 Francois Dupont, Sven Erik Mattsson and Fabien Gaucher. Hilding Elmqvist
 wrote a tutorial. Sven Erik Mattsson and Carl-Fredrik Abelson developed
@@ -852,8 +852,8 @@ meetings and contributed to the Modelica 3.3 specification:
 
 \subsection{Acknowledgments}\doublelabel{acknowledgments1}
 
-For the design of the synchronous language elements (\autoref{synchronous-language-elements}) and
-synchronous state machines (\autoref{state-machines}), and for the understanding of
+For the design of the synchronous language elements (\cref{synchronous-language-elements}) and
+synchronous state machines (\cref{state-machines}), and for the understanding of
 fine details of synchronous languages, especially from Lucid Synchrone,
 very helpful discussions with
 
@@ -879,7 +879,7 @@ Revision 2. This required the following improvements compared to 3.2
 Revision 1:
 \begin{itemize}
 \item
-  Possible to call a function through an instance name, \autoref{composite-name-lookup}\\
+  Possible to call a function through an instance name, \cref{composite-name-lookup}\\
   (used in MSL 3.2 to compute the gravity acceleration in
   Modelica.Mechanics.MultiBody.World; this feature was also introduced
   in Modelica Language version 3.3 in May 2012).
@@ -887,36 +887,36 @@ Revision 1:
   New built-in operator Connections.rooted(A.R) to inquire whether an
   overdetermined type or record instance A.R in a call to
   Connections.branch(A.R,B.R) is closer to the root of the spanning tree
-  than B.R, \autoref{overconstrained-equation-operators-for-connection-graphs} (used in MSL 3.2 to avoid algebraic loops in
+  than B.R, \cref{overconstrained-equation-operators-for-connection-graphs} (used in MSL 3.2 to avoid algebraic loops in
   several components such as in
   Modelica.Mechanics.MultiBody.Joints.Revolute).
 \item
   Several new annotations where vendor-specific variants were used in
-  MSL 3.2; \autoref{annotation-choices-for-suggested-redeclarations-and-modifications},
-  \autoref{annotations-for-documentation}, \autoref{annotations-for-code-generation},
-  \autoref{annotations-for-simulation-experiments}, \autoref{connections}, and \autoref{annotations-for-the-graphical-user-interface}.
+  MSL 3.2; \cref{annotation-choices-for-suggested-redeclarations-and-modifications},
+  \cref{annotations-for-documentation}, \cref{annotations-for-code-generation},
+  \cref{annotations-for-simulation-experiments}, \cref{connections}, and \cref{annotations-for-the-graphical-user-interface}.
 \item
   Specified that Evaluate can also occur in types, since this is used in
-  MSL and important for performance; \autoref{annotations-for-code-generation}. Ticket
+  MSL and important for performance; \cref{annotations-for-code-generation}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/925}{\#925}.
 \item
-  Macros in graphical text items, \autoref{text}. Ticket
+  Macros in graphical text items, \cref{text}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/659}{\#659}. (This
   feature was also introduced in Modelica Language version 3.3.)
 \item
   Initial equations are discrete -- used in MSL for initialization of
-  pre-variables, \autoref{discrete-time-expressions}. Ticket
+  pre-variables, \cref{discrete-time-expressions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/853}{\#853}.
 \item
-  Updated noDerivative to be consistent with MSL, \autoref{using-the-derivative-annotation}. This
+  Updated noDerivative to be consistent with MSL, \cref{using-the-derivative-annotation}. This
   is an incompatibility -- but the other variant was not used. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1035}{\#1035}.
 \item
   Clarified handling of component with missingInnerMessage;
-  \autoref{annotations-for-the-graphical-user-interface}. Ticket
+  \cref{annotations-for-the-graphical-user-interface}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/891}{\#891}.
 \item
-  Clarified definition of protected; \autoref{access-control-public-and-protected-elements}. Ticket
+  Clarified definition of protected; \cref{access-control-public-and-protected-elements}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/975}{\#975},
   \href{https://github.com/modelica/ModelicaSpecification/issues/1123}{\#1123}.
 \end{itemize}
@@ -925,74 +925,74 @@ In addition several issues with the specification text were corrected:
 \begin{itemize}
 \item
   Clarified an unclear sequence regarding functions as input arguments
-  in \autoref{prefix-rules}. Ticket
+  in \cref{prefix-rules}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1182}{\#1182}.
 \item
-  Clarified allowed binding equations for redeclarations, \autoref{balanced-models}.
+  Clarified allowed binding equations for redeclarations, \cref{balanced-models}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1111}{\#1111}.
 \item
-  Unspecified enumerations now have defined semantics, \autoref{unspecified-enumeration}.
+  Unspecified enumerations now have defined semantics, \cref{unspecified-enumeration}.
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/834}{\#834}.
 \item
-  Transitively non-Replaceable, \autoref{transitively-non-replaceable}. Ticket
+  Transitively non-Replaceable, \cref{transitively-non-replaceable}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/854}{\#854}.
 \item
   Modification text improved to not refer to inherited class,
-  \autoref{modifications}. Ticket
+  \cref{modifications}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1042}{\#1042}.
 \item
-  Precedence for modifiers on constraining-clause clarified, \autoref{constraining-type}. Ticket
+  Precedence for modifiers on constraining-clause clarified, \cref{constraining-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1128}{\#1128}.
 \item
-  Clarified arrays for constraining type, \autoref{constraining-type}. Ticket
+  Clarified arrays for constraining type, \cref{constraining-type}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1148}{\#1148}.
 \item
   Avoid all forms of connections depending on connections,
-  \autoref{connect-equations}. Ticket
+  \cref{connect-equations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/828}{\#828}.
 \item
-  Clarified equation count for if-equations, \autoref{if-equations}. Ticket
+  Clarified equation count for if-equations, \cref{if-equations}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/888}{\#888}.
 \item
-  Complete definition of reinit, \autoref{reinit}. Ticket
+  Complete definition of reinit, \cref{reinit}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/578}{\#578}. This
   forbids reinit in algorithms -- but it was previously not
   well-defined.
 \item
   Clarified initializaton of pre(vc) for a non-discrete (that is
-  continuous-time) Real variable vc, \autoref{initialization-initial-equation-and-initial-algorithm}. Ticket
+  continuous-time) Real variable vc, \cref{initialization-initial-equation-and-initial-algorithm}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1195}{\#1195}.
 \item
   Only one way of handling arrays of connectors is now defined,
-  \autoref{connectors-and-connections}. Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/757}{\#757}.
+  \cref{connectors-and-connections}. Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/757}{\#757}.
 \item
-  Example now use correct sine-source, \autoref{connect-equations-and-connectors}. Ticket
+  Example now use correct sine-source, \cref{connect-equations-and-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/750}{\#750}.
 \item
-  Restricted parameters in connectors, \autoref{restrictions-of-connections-and-connectors}. Ticket
+  Restricted parameters in connectors, \cref{restrictions-of-connections-and-connectors}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/768}{\#768}.
 \item
-  Clarified type restrictions for some operators, \autoref{reduction-functions-and-operators},
-  \autoref{matrix-and-vector-algebra-functions}. Ticket
+  Clarified type restrictions for some operators, \cref{reduction-functions-and-operators},
+  \cref{matrix-and-vector-algebra-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/622}{\#622}.
 \item
   Clarified that if at least one array element is used on the left hand
   side of the assignment operator in an algorithm section, then the
-  complete array is initialized in this section, \autoref{execution-of-an-algorithm-in-a-model}. Ticket
+  complete array is initialized in this section, \cref{execution-of-an-algorithm-in-a-model}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1190}{\#1190}.
 \item
   Record constructor corrected to not refer to keywords that should not
-  occur, \autoref{record-constructor-functions}. Ticket
+  occur, \cref{record-constructor-functions}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/907}{\#907}.
 \item
-  External storage of classes, \autoref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity},
-  \autoref{the-within-clause} and \autoref{mapping-of-versions-to-file-system}.
+  External storage of classes, \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity},
+  \cref{the-within-clause} and \cref{mapping-of-versions-to-file-system}.
   Tickets \href{https://github.com/modelica/ModelicaSpecification/issues/1019}{\#1019},
   \href{https://github.com/modelica/ModelicaSpecification/issues/892}{\#892},
   \href{https://github.com/modelica/ModelicaSpecification/issues/887}{\#887}.
 \item
   Added example and explanation for inheritance restriction on operator
-  record; \autoref{example-of-overloading-for-complex-numbers}. Ticket
+  record; \cref{example-of-overloading-for-complex-numbers}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1065}{\#1065}.
 \item
   Chapter \emph{Mapping of Models to Execution Environments} was removed;
@@ -1000,11 +1000,11 @@ In addition several issues with the specification text were corrected:
   released an implementation of this feature. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1015}{\#1015}.
 \item
-  Corrected license-example in \autoref{licensing}. Ticket
+  Corrected license-example in \cref{licensing}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1127}{\#1127}.
 \item
   Grammar was internally restructured for short-class-definition,
-  \autoref{class-declarations}, \autoref{class-definition}. Ticket
+  \cref{class-declarations}, \cref{class-definition}. Ticket
   \href{https://github.com/modelica/ModelicaSpecification/issues/1140}{\#1140}.
 \end{itemize}
 
@@ -1051,96 +1051,96 @@ particular:
 \item
   Corrected typos and improved formatting.
 \item
-  \autoref{comments} Comments:\\
+  \cref{comments} Comments:\\
   There are 2 and not 3 kinds of comments and comments are treated as
   white space character.\\
   Added definition of white space character.
 \item
-  \autoref{identifiers} Identifiers:\\
+  \cref{identifiers} Identifiers:\\
   The single quotes are part of the identifier, e.g., 'x'.
 \item
-  \autoref{built-in-variable-time} Built-in Variable time:\\
+  \cref{built-in-variable-time} Built-in Variable time:\\
   Variable \lstinline!time! is only available in models and blocks and not in the
   other classes.
 \item
-  \autoref{built-in-mathematical-functions-and-external-built-in-functions} Built-in Mathematical Functions\\
+  \cref{built-in-mathematical-functions-and-external-built-in-functions} Built-in Mathematical Functions\\
   Definition of \lstinline!atan2! corrected.
 \item
-  \autoref{derivative-and-special-purpose-operators-with-function-syntax} Special Purpose Operators\\
+  \cref{derivative-and-special-purpose-operators-with-function-syntax} Special Purpose Operators\\
   Included definition of inStream and actualStream operators from
-  \autoref{stream-connectors}.
+  \cref{stream-connectors}.
 \item
-  \autoref{event-related-operators-with-function-syntax} Event-Related Operators\\
+  \cref{event-related-operators-with-function-syntax} Event-Related Operators\\
   Clarified, that the first argument of \lstinline!smooth! is a scalar.\\
   Improved the definition of \lstinline!reinit!.
 \item
-  \autoref{discrete-time-expressions} Discrete-Time Expressions\\
+  \cref{discrete-time-expressions} Discrete-Time Expressions\\
   Improved definition of ordered relations
   (\textgreater{},\textless{},\textgreater{}=,\textless{}=).
 \item
-  \autoref{conditional-component-declaration} Conditional Component Declaration\\
+  \cref{conditional-component-declaration} Conditional Component Declaration\\
   Clarified redeclaration of a component.
 \item
-  \autoref{specialized-classes} Specialized Classes\\
+  \cref{specialized-classes} Specialized Classes\\
   Clarified that \lstinline!stream! cannot be used in a record.\\
   Clarified restrictions on elements in a \lstinline!connector!.\\
   Errors in example of operator record Complex corrected.
 \item
-  \autoref{enumeration-types} Enumeration Types\\
+  \cref{enumeration-types} Enumeration Types\\
   Error in example corrected.
 \item
-  \autoref{simultaneous-inner-outer-declarations} Simulataneous Inner/Outer Declarations\\
+  \cref{simultaneous-inner-outer-declarations} Simulataneous Inner/Outer Declarations\\
   Clarified inner/outer declarations.
 \item
-  \autoref{inheritance-extends-clause} Inheritance\\
+  \cref{inheritance-extends-clause} Inheritance\\
   Clarified that the elements of a flattened base class are added at the
   place of the extends clause.\\
   Equations of the flattened base class that are syntactically
   equivalent to equations in the flattened enclosing class are
   deprecated.
 \item
-  \autoref{modifications} Modifications\\
+  \cref{modifications} Modifications\\
   Element modifiers are no longer part of language, reference grammar
   instead of duplicating it.
 \item
-  \autoref{redeclaration} Redeclaration\\
-  Improved redeclarations definition and moved an example from \autoref{the-class-extends-redeclaration-mechanism} at
+  \cref{redeclaration} Redeclaration\\
+  Improved redeclarations definition and moved an example from \cref{the-class-extends-redeclaration-mechanism} at
   the right place.
 \item
-  \autoref{reinit} reinit\\
+  \cref{reinit} reinit\\
   Improved reinit definition.
 \item
-  \autoref{initialization-initial-equation-and-initial-algorithm} Initialization\\
+  \cref{initialization-initial-equation-and-initial-algorithm} Initialization\\
   Clarified that only when-clauses with restricted form of initial() as
   condition will be active during initialization.
 \item
-  \autoref{reduction-expressions} Reduction Expressions\\
+  \cref{reduction-expressions} Reduction Expressions\\
   Improved definition
 \item
-  \autoref{types-as-iteration-ranges} Types as iteration ranges\\
+  \cref{types-as-iteration-ranges} Types as iteration ranges\\
   Newly introduced section to improve the definition of iteration ranges
 \item
-  \autoref{function-as-a-specialized-class} Function\\
+  \cref{function-as-a-specialized-class} Function\\
   Added missing restrictions that model, block, inner, outer cannot be
   used in a function.
 \item
-  \autoref{positional-or-named-input-arguments-of-functions} Positional or Named Input Arguments of Functions\\
+  \cref{positional-or-named-input-arguments-of-functions} Positional or Named Input Arguments of Functions\\
   Corrected formal syntax of a function call
 \item
-  \autoref{initialization-and-declaration-assignments-of-components-in-functions} Initialization and Declaration Assignments of
+  \cref{initialization-and-declaration-assignments-of-components-in-functions} Initialization and Declaration Assignments of
   Components in Functions\\
   Added the restriction of acylic bindings.
 \item
-  \autoref{records} Records\\
+  \cref{records} Records\\
   Mapping of arrays in records to C-structs is removed.
 \item
-  \autoref{bitmap} Bitmap\\
+  \cref{bitmap} Bitmap\\
   Defined flipping more precisely.
 \item
-  \autoref{lexical-conventions} Lexical conventions\\
+  \cref{lexical-conventions} Lexical conventions\\
   More precisely defined whitespace and comments.
 \item
-  \autoref{grammar} Grammar\\
+  \cref{grammar} Grammar\\
   Improved/corrected grammar definition
 \end{itemize}
 
@@ -1178,11 +1178,11 @@ The following \emph{backward compatible extensions} have been introduced with Mo
 \begin{itemize}
 \item
   Homotopy function for making it easier to solve initialization
-  problems (see \autoref{derivative-and-special-purpose-operators-with-function-syntax}).
+  problems (see \cref{derivative-and-special-purpose-operators-with-function-syntax}).
 \item
-  Functions as formal inputs to functions (see new \autoref{functional-input-arguments-to-functions}).
+  Functions as formal inputs to functions (see new \cref{functional-input-arguments-to-functions}).
 \item
-  Overloaded operators have been refined (see \autoref{overloaded-operators}):
+  Overloaded operators have been refined (see \cref{overloaded-operators}):
   \begin{itemize}
   \item
     A new specialized class \lstinline!operator record! is introduced -- with
@@ -1205,20 +1205,20 @@ The following \emph{backward compatible extensions} have been introduced with Mo
 \item
   Unicode support in description strings, strings in annotations and in
   comments in order to improve Modelica, e.g., for Arabian, Asian or
-  Indian users (see grammar changes in \autoref{lexical-conventions}). Modelica files are
+  Indian users (see grammar changes in \cref{lexical-conventions}). Modelica files are
   UTF-8 encoded, and can start with the UTF-8 encoded byte order mark
   (0xef 0xbb 0xbf) to indicate that it may contain UTF-8 characters;
-  this is treated as white-space in the grammar (see \autoref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
+  this is treated as white-space in the grammar (see \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
 \item
   Constants can once again be modified unless declared final -- as this
   is already used in packages.\\
-  (see \autoref{constant-expressions}).
+  (see \cref{constant-expressions}).
 \item
   Global name lookup has been introduced (e.g.
-  \lstinline!.Modelica.Constants.pi!), see \autoref{global-name-lookup}.
+  \lstinline!.Modelica.Constants.pi!), see \cref{global-name-lookup}.
 \item
   New C-functions \lstinline!ModelicaVFormatMessage! and \lstinline!ModelicaVFormatError!, to
-  simplify message formatting in external functions (see \autoref{utility-functions})
+  simplify message formatting in external functions (see \cref{utility-functions})
 \item
   Additional annotations allowing:
   \begin{itemize}
@@ -1226,17 +1226,17 @@ The following \emph{backward compatible extensions} have been introduced with Mo
     Inclusion of C-header and object library files in packages and
     referencing them with URIs.\\
     (new annotations \lstinline!IncludeDirectory!, \lstinline!LibraryDirectory!, and
-    standardized platform names like \lstinline!win32!; see \autoref{annotations-for-external-libraries-and-include-files}; resolves
+    standardized platform names like \lstinline!win32!; see \cref{annotations-for-external-libraries-and-include-files}; resolves
     ticket \#297).
   \item
     Images in parameter dialogs (new annotation \lstinline!groupImage!; see
-    \autoref{annotations-for-the-graphical-user-interface}).
+    \cref{annotations-for-the-graphical-user-interface}).
   \item
     Start and fixed attributes for variables in parameter dialogs\\
-    (new annotation \lstinline!showStartAttribute!; see \autoref{annotations-for-the-graphical-user-interface}).
+    (new annotation \lstinline!showStartAttribute!; see \cref{annotations-for-the-graphical-user-interface}).
   \item
     Access control for packages to protect intelectual property.\\
-    (new annotations \lstinline!Protection,! and \lstinline!License!; see new \autoref{annotations-for-access-control-to-protect-intellectual-property}).
+    (new annotations \lstinline!Protection,! and \lstinline!License!; see new \cref{annotations-for-access-control-to-protect-intellectual-property}).
   \end{itemize}
 \end{itemize}
 
@@ -1467,15 +1467,15 @@ The following defects have been fixed in the Modelica specification:
   defined, not implemented in many tools, and not used in libraries.
   They were thus removed.
 \item
-  Modelica keywords (\autoref{modelica-keywords}) updated.
+  Modelica keywords (\cref{modelica-keywords}) updated.
 \item
   Clarification: Exponentiation and array range operator are
   non-associative\\
   (x\^{}y\^{}z or a:b:c:d:e:f are not allowed; parentheses are required)
 \item
-  Clarification: Restrictions on combining base classes (\autoref{restriction-on-combining-base-classes-and-other-elements}).
+  Clarification: Restrictions on combining base classes (\cref{restriction-on-combining-base-classes-and-other-elements}).
 \item
-  Clarification: Execution of an algorithm (new \autoref{execution-of-an-algorithm-in-a-model}).
+  Clarification: Execution of an algorithm (new \cref{execution-of-an-algorithm-in-a-model}).
 \item
   The default type for arrays sent to external functions has been
   clarified.
@@ -1676,7 +1676,7 @@ Otter, Hilding Elmqvist, and Sven Erik Mattsson. The original
 inspiration was from Mike Tiller.
 
 This goes together with making the type interface and sub-typing cleaner
-and stricter (the new \autoref{interface-or-type-relationships}). This concept fixes flaws of the
+and stricter (the new \cref{interface-or-type-relationships}). This concept fixes flaws of the
 language that have been pointed out by Sébastien Furic.
 
 The graphical annotations have been redesigned and improved by Daniel
@@ -1797,7 +1797,7 @@ libraries.
 The following main changes in Modelica 3.0 are \emph{not} backwards compatible:
 \begin{itemize}
 \item
-  Restrictions to connectors (see \autoref{restrictions-of-connections-and-connectors}): For each non-partial
+  Restrictions to connectors (see \cref{restrictions-of-connections-and-connectors}): For each non-partial
   connector class the number of flow variables shall be equal to the
   number of variables that are neither parameter, constant, input,
   output, nor flow. For example, the following connector is illegal in
@@ -1821,7 +1821,7 @@ end notValid;
   inputs and variables having a default binding equation.
 \item
   All non-partial model and block classes must be locally balanced (see
-  \autoref{balanced-models}). This means that the local number of unknowns equals the
+  \cref{balanced-models}). This means that the local number of unknowns equals the
   local equation size. Together with other restrictions, this leads to
   the strong property that a simulation model is always globally
   balanced (i.e., the number of unknowns is equal to the number of
@@ -1866,26 +1866,26 @@ The following main changes in Modelica 3.0 are \emph{backwards compatible}:
   A third argument \lstinline!AssertionLevel! to built-in function \lstinline!assert(!...\lstinline!)! in
   order that warnings can optionally be defined.
 \item
-  New annotations \autonameref{vendor-specific-annotations}:\\
+  New annotations \crefnameref{vendor-specific-annotations}:\\
   In this section it is precisely defined how vendor-specific
   annotations should be marked. Any tool shall save files with all
-  standard annotations (defined in \autoref{annotations}) and all vendor-specific
+  standard annotations (defined in \cref{annotations}) and all vendor-specific
   annotations intact. The advantage is that a typo in non-vendor
   annotations can now be detected and marked as an error, whereas in
   previous versions this had to be ignored.
 \item
-  New annotation in \autonameref{annotations-for-documentation}:\\
+  New annotation in \crefnameref{annotations-for-documentation}:\\
   \lstinline!preferredView = info!, \lstinline!diagram! or \lstinline!text!
 \item
-  New annotations \autonameref{annotations-for-code-generation}:\\
+  New annotations \crefnameref{annotations-for-code-generation}:\\
   \lstinline!Evaluate!, \lstinline!HideResult!, \lstinline!Inline!,
 	\lstinline!LateInline!, \lstinline!smoothOrder!
 \item
-  New annotation \autonameref{annotations-for-simulation-experiments}:\\
+  New annotation \crefnameref{annotations-for-simulation-experiments}:\\
   \lstinline!StartTime!, \lstinline!StopTime!, \lstinline!Tolerance! to define important parameters of an
   experiment setup.
 \item
-  New annotations for graphical annotations in \autoref{annotations-for-graphical-objects}:\\
+  New annotations for graphical annotations in \cref{annotations-for-graphical-objects}:\\
   New attribute \lstinline!Smooth = enumeration(None, Bezier)! for graphical objects
   and connection lines (Bezier defines a Bezier spline).\\
   New attribute \lstinline!visible! in \lstinline!record Placement! allows to make a graphical
@@ -1897,7 +1897,7 @@ The following main changes in Modelica 3.0 are \emph{backwards compatible}:
   horizontal alignment of text.
 \item
   New annotations for schematic animation and interactive user input in
-  \autoref{annotations-for-graphical-objects}:\\
+  \cref{annotations-for-graphical-objects}:\\
   \lstinline!DynamicSelect! to modify annotation literals by the actual values of variables.\\
   \lstinline!OnMouseDownSetBoolean!, \lstinline!OnMouseUpSetBoolean!, \lstinline!OnMouseMoveXSetReal!,
   \lstinline!OnMouseMoveYSetReal!, \lstinline!OnMouseDownEditReal!, \lstinline!OnMouseDownEditString! to

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1,15 +1,15 @@
-\chapter{Modelica Revision History}\doublelabel{modelica-revision-history}
+\chapter{Modelica Revision History}\label{modelica-revision-history}
 
 This appendix describes the history of the Modelica Language Design, and
 its contributors. This appendix is just present for historic reasons and
 is not normative. The current version of this document is available from
 \url{https://www.modelica.org/documents}.
 
-\section{Modelica 3.4}\doublelabel{modelica-3-4}
+\section{Modelica 3.4}\label{modelica-3-4}
 Modelica 3.4 was released April 10, 2017. The Modelica 3.4 specification
 was edited by Hans Olsson.
 
-\subsection{Main changes in Modelica 3.4}\doublelabel{main-changes-in-modelica-3-4}
+\subsection{Main changes in Modelica 3.4}\label{main-changes-in-modelica-3-4}
 
 The following Modelica Change Proposals are backward compatible
 extensions added in 3.4:
@@ -455,17 +455,17 @@ The following minor improvements were made (starting from 3.3 Revision 1):
   \href{https://github.com/modelica/ModelicaSpecification/issues/1317}{\#1317}.
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language 3.4}\doublelabel{contributors-to-the-modelica-language-3-4}
+\subsection{Contributors to the Modelica Language 3.4}\label{contributors-to-the-modelica-language-3-4}
 
 The members of the Modelica Association contributed to the Modelica 3.4
 specification.
 
-\section{Modelica 3.3 Revision 1}\doublelabel{modelica-3-3-revision-1}
+\section{Modelica 3.3 Revision 1}\label{modelica-3-3-revision-1}
 
 Modelica 3.3 Revision 1 was released July 11, 2014. The Modelica 3.3
 Revision 1 specification was edited by Hans Olsson.
 
-\subsection{Main changes in Modelica 3.3 Revision 1}\doublelabel{main-changes-in-modelica-3-3-revision-1}
+\subsection{Main changes in Modelica 3.3 Revision 1}\label{main-changes-in-modelica-3-3-revision-1}
 The changes made in Modelica 3.2 Revision 2 are included, and in
 addition the following improvements were made:
 \begin{itemize}
@@ -662,7 +662,7 @@ addition the following improvements were made:
   Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/1374}{\#1374}.
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language, Version 3.3 Revision 1}\doublelabel{contributors-to-the-modelica-language-version-3-3-revision-1}
+\subsection{Contributors to the Modelica Language, Version 3.3 Revision 1}\label{contributors-to-the-modelica-language-version-3-3-revision-1}
 
 The following members of the Modelica Association contributed to the
 Modelica 3.3 Revision 1 and/or Modelica 3.2 Revision 2 specification
@@ -682,12 +682,12 @@ Modelica 3.3 Revision 1 and/or Modelica 3.2 Revision 2 specification
 &Stefan Vorkoetter, Maplesoft, Waterloo, Canada
 \end{longtable}
 
-\section{Modelica 3.3}\doublelabel{modelica-3-3}
+\section{Modelica 3.3}\label{modelica-3-3}
 
 Modelica 3.3 was released on May 9, 2012. The Modelica 3.3 specification
 was edited by Hans Olsson, Hilding Elmqvist and Martin Otter.
 
-\subsection{Main changes in Modelica 3.3}\doublelabel{main-changes-in-modelica-3-3}
+\subsection{Main changes in Modelica 3.3}\label{main-changes-in-modelica-3-3}
 
 The following \emph{backward compatible extensions} have been introduced with Modelica 3.3:
 \begin{itemize}
@@ -764,7 +764,7 @@ The following changes in Modelica 3.3 are \emph{not} backwards compatible:
   are connected in the models
 \end{itemize}
 
-\subsection{Contributors to Modelica 3.3}\doublelabel{contributors-to-modelica-3-3}
+\subsection{Contributors to Modelica 3.3}\label{contributors-to-modelica-3-3}
 
 The language elements for describing synchronous behavior, \cref{synchronous-language-elements},
 was mainly developed by Hilding Elmqvist, Martin Otter, and Sven Erik
@@ -850,7 +850,7 @@ meetings and contributed to the Modelica 3.3 specification:
 &Dirk Zimmer, DLR-RM (German Aerospace Center), Oberpfaffenhofen, Germany
 \end{longtable}
 
-\subsection{Acknowledgments}\doublelabel{acknowledgments1}
+\subsection{Acknowledgments}\label{acknowledgments1}
 
 For the design of the synchronous language elements (\cref{synchronous-language-elements}) and
 synchronous state machines (\cref{state-machines}), and for the understanding of
@@ -865,12 +865,12 @@ very helpful discussions with
 \end{longtable}
 are appreciated.
 
-\section{Modelica 3.2 Revision 2}\doublelabel{modelica-3-2-revision-2}
+\section{Modelica 3.2 Revision 2}\label{modelica-3-2-revision-2}
 
 Modelica 3.2 Revision 2 was released 2013. The Modelica 3.2 Revision 2
 specification was edited by Hans Olsson and Martin Otter.
 
-\subsection{Main changes in Modelica 3.2 Revision 2}\doublelabel{main-changes-in-modelica-3-2-revision-2}
+\subsection{Main changes in Modelica 3.2 Revision 2}\label{main-changes-in-modelica-3-2-revision-2}
 
 The Modelica language was slightly adapted (in a backwards compatible
 way -- except as listed below) in order that the Modelica Standard
@@ -1008,7 +1008,7 @@ In addition several issues with the specification text were corrected:
   \href{https://github.com/modelica/ModelicaSpecification/issues/1140}{\#1140}.
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language, Version 3.2 Revision 2}\doublelabel{contributors-to-the-modelica-language-version-3-2-revision-2}
+\subsection{Contributors to the Modelica Language, Version 3.2 Revision 2}\label{contributors-to-the-modelica-language-version-3-2-revision-2}
 
 The following members of the Modelica Association contributed to the
 Modelica 3.2 Revision 2 specification (alphabetical list):
@@ -1037,12 +1037,12 @@ Martin Sjölund, PELAB, Linköping University, Linköping, Sweden
 
 Stefan Vorkoetter, Maplesoft, Waterloo, Canada
 
-\section{Modelica 3.2 Revision 1}\doublelabel{modelica-3-2-revision-1}
+\section{Modelica 3.2 Revision 1}\label{modelica-3-2-revision-1}
 
 Modelica 3.2 Revision 1 was released on Feb. 29, 2012. The Modelica 3.2
 Revision 1 specification was edited by Hans Olsson and Peter Fritzson.
 
-\subsection{Main changes in Modelica 3.2 Revision 1}\doublelabel{main-changes-in-modelica-3-2-revision-1}
+\subsection{Main changes in Modelica 3.2 Revision 1}\label{main-changes-in-modelica-3-2-revision-1}
 
 The Modelica language was not changed with respect to the previous
 version 3.2. Only issues with the specification text have been fixed. In
@@ -1144,7 +1144,7 @@ particular:
   Improved/corrected grammar definition
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language, Version 3.2 Revision 1}\doublelabel{contributors-to-the-modelica-language-version-3-2-revision-1}
+\subsection{Contributors to the Modelica Language, Version 3.2 Revision 1}\label{contributors-to-the-modelica-language-version-3-2-revision-1}
 
 The following members of the Modelica Association contributed to the
 Modelica 3.2 Revision 1 specification (alphabetical list):
@@ -1167,12 +1167,12 @@ Martin Sjölund, PELAB, Linköping University, Linköping, Sweden
 
 Stefan Vorkoetter, Maplesoft, Waterloo, Canada
 
-\section{Modelica 3.2}\doublelabel{modelica-3-2}
+\section{Modelica 3.2}\label{modelica-3-2}
 
 Modelica 3.2 was released on March 24, 2010. The Modelica 3.2
 specification was edited by Hans Olsson, Martin Otter and others.
 
-\subsection{Main changes in Modelica 3.2}\doublelabel{main-changes-in-modelica-3-2}
+\subsection{Main changes in Modelica 3.2}\label{main-changes-in-modelica-3-2}
 
 The following \emph{backward compatible extensions} have been introduced with Modelica 3.2:
 \begin{itemize}
@@ -1251,7 +1251,7 @@ The following changes in Modelica 3.2 are \emph{not} backwards compatible:
   3.1 form still for some time.
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language, Version 3.2}\doublelabel{contributors-to-the-modelica-language-version-3-2}
+\subsection{Contributors to the Modelica Language, Version 3.2}\label{contributors-to-the-modelica-language-version-3-2}
 
 The initial version of \emph{functions as formal inputs to functions} was
 proposed by Peter Fritzson.
@@ -1366,7 +1366,7 @@ Switzerland
 
 Dietmar Winkler, Telemark University College, Porsgrunn, Norway
 
-\subsection{Acknowledgments}\doublelabel{acknowledgments2}
+\subsection{Acknowledgments}\label{acknowledgments2}
 
 Partial financial support for the development of Modelica 3.2 by the
 following funding agencies has been received:
@@ -1394,13 +1394,13 @@ following funding agencies has been received:
   (\href{http://www.openprod.}{http://www.openprod.org}).
 \end{itemize}
 
-\section{Modelica 3.1}\doublelabel{modelica-3-1}
+\section{Modelica 3.1}\label{modelica-3-1}
 
 Modelica 3.1 was released on May 27, 2009. The Modelica 3.1
 specification was edited by Francesco Casella, Rüdiger Franke, Hans
 Olsson, Martin Otter, and Michael Sielemann.
 
-\subsection{Main changes in Modelica 3.1}\doublelabel{main-changes-in-modelica-3-1}
+\subsection{Main changes in Modelica 3.1}\label{main-changes-in-modelica-3-1}
 
 The following \emph{backward compatible extensions} have been introduced with Modelica 3.1:
 \begin{itemize}
@@ -1535,7 +1535,7 @@ The following changes in Modelica 3.1 are \emph{not} backwards compatible:
   bus from a block with a connect equation.
 \end{itemize}
 
-\subsection{Contributors to the Modelica Language, Version 3.1}\doublelabel{contributors-to-the-modelica-language-version-3-1}
+\subsection{Contributors to the Modelica Language, Version 3.1}\label{contributors-to-the-modelica-language-version-3-1}
 
 The concept of operator overloading was developed by Hans Olsson, based
 on work of Dag Brück, Peter Fritzson, and Martin Otter.
@@ -1634,7 +1634,7 @@ Switzerland
 
 Dietmar Winkler, TU Berlin, Germany
 
-\subsection{Acknowledgments}\doublelabel{acknowledgments3}
+\subsection{Acknowledgments}\label{acknowledgments3}
 
 Partial financial support for the development of Modelica 3.1 by the
 following funding agencies has been received:
@@ -1658,12 +1658,12 @@ following funding agencies has been received:
   Equation-Based System Modeling \& Simulation Languages}.
 \end{itemize}
 
-\section{Modelica 3.0}\doublelabel{modelica-3-0}
+\section{Modelica 3.0}\label{modelica-3-0}
 
 Modelica 3.0 was released Sept. 5, 2007. The Modelica 3.0 specification
 was edited by Peter Fritzson, Hans Olsson, and Martin Otter.
 
-\subsection{Contributors to the Modelica Language, Version 3.0}\doublelabel{contributors-to-the-modelica-language-version-3-0}
+\subsection{Contributors to the Modelica Language, Version 3.0}\label{contributors-to-the-modelica-language-version-3-0}
 
 The Modelica 3.0 specification was newly structured and written by Peter
 Fritzson using text from the previous specification and also adding new
@@ -1775,7 +1775,7 @@ Hubertus Tummescheit, Modelon AB, Lund, Sweden
 Hans-Jürg Wiesmann, ABB Switzerland Ltd.,Corporate Research, Baden,
 Switzerland
 
-\subsection{Main Changes in Modelica 3.0}\doublelabel{main-changes-in-modelica-3-0}
+\subsection{Main Changes in Modelica 3.0}\label{main-changes-in-modelica-3-0}
 
 Modelica 3.0 is a ``clean-up'' version of the Modelica language. For
 example, the specification is newly written to define the language in a
@@ -1914,13 +1914,13 @@ The following errors have been fixed in the Modelica specification:
   desired ``full Modelica name'' also for function calls).
 \end{itemize}
 
-\section{Modelica 2.2}\doublelabel{modelica-2-2}
+\section{Modelica 2.2}\label{modelica-2-2}
 
 Modelica 2.2 was released February 2, 2005. The Modelica 2.2
 specification was edited by Hans Olsson, Michael Tiller and Martin
 Otter.
 
-\subsection{Contributors to the Modelica Language, Version 2.2}\doublelabel{contributors-to-the-modelica-language-version-2-2}
+\subsection{Contributors to the Modelica Language, Version 2.2}\label{contributors-to-the-modelica-language-version-2-2}
 \indent\indent
 Bernhard Bachmann , University of Applied Sciences, Bielefeld, Germany
 
@@ -1972,7 +1972,7 @@ Hubertus Tummescheit, Modelon AB, Lund, Sweden
 Hans-Jürg Wiesmann, ABB Switzerland Ltd.,Corporate Research, Baden,
 Switzerland
 
-\subsection{Main Changes in Modelica 2.2}\doublelabel{main-changes-in-modelica-2-2}
+\subsection{Main Changes in Modelica 2.2}\label{main-changes-in-modelica-2-2}
 
 The main changes in Modelica 2.2 are:
 \begin{itemize}
@@ -2023,12 +2023,12 @@ The main changes in Modelica 2.2 are:
 
 The language changes are backward compatible.
 
-\section{Modelica 2.1}\doublelabel{modelica-2-1}
+\section{Modelica 2.1}\label{modelica-2-1}
 
 Modelica 2.1 was released January 30, 2004. The Modelica 2.1
 specification was edited by Hans Olsson and Martin Otter.
 
-\subsection{Contributors to the Modelica Language, Version 2.1}\doublelabel{contributors-to-the-modelica-language-version-2-1}
+\subsection{Contributors to the Modelica Language, Version 2.1}\label{contributors-to-the-modelica-language-version-2-1}
 \indent\indent
 Mikael Adlers, MathCore, Linköping, Sweden
 
@@ -2071,7 +2071,7 @@ U.S.A.
 Hans-Jürg Wiesmann, ABB Switzerland Ltd.,Corporate Research, Baden,
 Switzerland
 
-\subsection{Main Changes in Modelica 2.1}\doublelabel{main-changes-in-modelica-2-1}
+\subsection{Main Changes in Modelica 2.1}\label{main-changes-in-modelica-2-1}
 
 The main changes in Modelica 2.1 are:
 \begin{itemize}
@@ -2142,14 +2142,14 @@ introduction of the new keywords break and return, the new built-in
 package Connections and the removing of built-in function and attribute
 \lstinline!enable!.
 
-\section{Modelica 2.0}\doublelabel{modelica-2-0}
+\section{Modelica 2.0}\label{modelica-2-0}
 
 Modelica 2.0 was released January, 30 2002, and the draft was released
 on December 18 in 2001. The Modelica 2.0 specification was edited by
 Hans Olsson. Modelica is a registered trademark owned by the Modelica
 Association since November 2001.
 
-\subsection{Contributors to the Modelica Language, Version 2.0}\doublelabel{contributors-to-the-modelica-language-version-2-0}
+\subsection{Contributors to the Modelica Language, Version 2.0}\label{contributors-to-the-modelica-language-version-2-0}
 \indent\indent
 Peter Aronsson, Linköping University, Sweden
 
@@ -2190,7 +2190,7 @@ Hubertus Tummescheit, Lund Institute of Technology, Sweden
 Hans-Jürg Wiesmann, ABB Switzerland Ltd.,Corporate Research, Baden,
 Switzerland
 
-\subsection{Main Changes in Modelica 2.0}\doublelabel{main-changes-in-modelica-2-0}
+\subsection{Main Changes in Modelica 2.0}\label{main-changes-in-modelica-2-0}
 
 A detailed description of the enhancements introduced by Modelica 2.0 is
 given in the papers
@@ -2260,14 +2260,14 @@ introduction of the new keyword enumeration and the removal of the
 operator analysisType(). The library change of the block library which
 will become available soon requires changes in user-models.
 
-\section{Modelica 1.4}\doublelabel{modelica-1-4}
+\section{Modelica 1.4}\label{modelica-1-4}
 
 Modelica 1.4 was released December 15, 2000. The Modelica Association
 was formed in Feb. 5, 2000 and is now responsible for the design of the
 Modelica language. The Modelica 1.4 specification was edited by Hans
 Olsson and Dag Brück.
 
-\subsection{Contributors to the Modelica Language, Version 1.4}\doublelabel{contributors-to-the-modelica-language-version-1-4}
+\subsection{Contributors to the Modelica Language, Version 1.4}\label{contributors-to-the-modelica-language-version-1-4}
 \indent\indent
 Bernhard Bachmann, Fachhochschule Bielefeld, Germany
 
@@ -2312,7 +2312,7 @@ Hubertus Tummescheit, Lund Institute of Technology, Sweden
 
 Hans-Jürg Wiesmann, ABB Corporate Research Ltd., Baden, Switzerland
 
-\subsection{Contributors to the Modelica Standard Library}\doublelabel{contributors-to-the-modelica-standard-library}
+\subsection{Contributors to the Modelica Standard Library}\label{contributors-to-the-modelica-standard-library}
 % https://tex.stackexchange.com/questions/31555/how-can-i-indent-the-paragraphs-which-follow-a-heading
 \indent\indent
 Peter Beater, University of Paderborn, Germany
@@ -2327,7 +2327,7 @@ Germany
 
 Hubertus Tummescheit, Lund Institute of Technology, Sweden
 
-\subsection{Main Changes in Modelica 1.4}\doublelabel{main-changes-in-modelica-1-4}
+\subsection{Main Changes in Modelica 1.4}\label{main-changes-in-modelica-1-4}
 
 \begin{itemize}
 \item
@@ -2404,11 +2404,11 @@ when-condition is now defined in a more meaningful way (before Modelica
 1.4, every condition in a when-clause has a ``previous'' value of false),
 and (4) models containing the nondiscrete keyword which was removed.
 
-\section{Modelica 1.3 and Older Versions.}\doublelabel{modelica-1-3-and-older-versions}
+\section{Modelica 1.3 and Older Versions.}\label{modelica-1-3-and-older-versions}
 
 Modelica 1.3 was released December 15, 1999.
 
-\subsection{Contributors up to Modelica 1.3}\doublelabel{contributors-up-to-modelica-1-3}
+\subsection{Contributors up to Modelica 1.3}\label{contributors-up-to-modelica-1-3}
 The following list contributors and their affiliations at the time when
 Modelica 1.3 was released.
 
@@ -2461,7 +2461,7 @@ Hubertus Tummescheit, Lund Institute of Technology, Sweden
 
 Hans Vangheluwe, University of Gent, Belgium
 
-\subsection{Main Changes in Modelica 1.3}\doublelabel{main-changes-in-modelica-1-3}
+\subsection{Main Changes in Modelica 1.3}\label{main-changes-in-modelica-1-3}
 
 Modelica 1.3 was released December 15, 1999.
 \begin{itemize}
@@ -2477,7 +2477,7 @@ Modelica 1.3 was released December 15, 1999.
   Defined scope of for-loop variables.
 \end{itemize}
 
-\subsection{Main Changes in Modelica 1.2}\doublelabel{main-changes-in-modelica-1-2}
+\subsection{Main Changes in Modelica 1.2}\label{main-changes-in-modelica-1-2}
 
 Modelica 1.2 was released June 15, 1999.
 \begin{itemize}
@@ -2502,7 +2502,7 @@ Modelica 1.2 was released June 15, 1999.
   Introduced \lstinline!terminate! and \lstinline!analysisType!.
 \end{itemize}
 
-\subsection{Main Changes in Modelica 1.1}\doublelabel{main-changes-in-modelica-1-1}
+\subsection{Main Changes in Modelica 1.1}\label{main-changes-in-modelica-1-1}
 Modelica 1.1 was released in December 1998.
 
 Major changes:
@@ -2520,7 +2520,7 @@ Major changes:
   in Modelica 1.0).
 \end{itemize}
 
-\subsection{Modelica 1.0}\doublelabel{modelica-1-0}
+\subsection{Modelica 1.0}\label{modelica-1-0}
 
 Modelica 1, the first version of Modelica, was released in September
 1997, and had the language specification as a short appendix to the

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -1,14 +1,14 @@
-\chapter{Scoping, Name Lookup, and Flattening}\doublelabel{scoping-name-lookup-and-flattening}
+\chapter{Scoping, Name Lookup, and Flattening}\label{scoping-name-lookup-and-flattening}
 
 This chapter describes the scope rules, and most of the name lookup and
 flattening of Modelica.
 
-\section{Flattening Context}\doublelabel{flattening-context}
+\section{Flattening Context}\label{flattening-context}
 
 Flattening is made in a context which consists of a modification
 environment (\cref{modification-environment}) and an ordered set of enclosing classes.
 
-\section{Enclosing Classes}\doublelabel{enclosing-classes}
+\section{Enclosing Classes}\label{enclosing-classes}
 
 The classes lexically enclosing an element form an ordered set of
 enclosing classes. A class defined inside another class definition (the
@@ -47,7 +47,7 @@ and \lstinline!C3!. The set of enclosing classes of \lstinline!z! is \lstinline!
 enclosing class in that order.
 \end{example}
 
-\section{Static Name Lookup}\doublelabel{static-name-lookup}
+\section{Static Name Lookup}\label{static-name-lookup}
 
 Names are looked up at class flattening to find names of base classes,
 component types, etc. Implicitly defined names of record constructor
@@ -59,7 +59,7 @@ The reason to ignore the implicitly defined names is that a record and the impli
 and an enumeration type and the implicitly created conversion function (\cref{type-conversion-of-integer-to-enumeration-values}), have the same name.
 \end{nonnormative}
 
-\subsection{Simple Name Lookup}\doublelabel{simple-name-lookup}
+\subsection{Simple Name Lookup}\label{simple-name-lookup}
 
 When an element, equation, or section is flattened, any simple name
 (not composed using dot notation) is first looked up sequentially among
@@ -97,7 +97,7 @@ This lookup in each \emph{instance} scope is performed as follows:
 
 Import statements defined in inherited classes are ignored for the lookup, i.e.\ import statements are not inherited.
 
-\subsection{Composite Name Lookup}\doublelabel{composite-name-lookup}
+\subsection{Composite Name Lookup}\label{composite-name-lookup}
 
 For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ lookup is performed as follows:
 \begin{itemize}
@@ -154,7 +154,7 @@ end A;
 \end{lstlisting}
 \end{example}
 
-\subsection{Global Name Lookup}\doublelabel{global-name-lookup}
+\subsection{Global Name Lookup}\label{global-name-lookup}
 
 For a name starting with dot, e.g.: \lstinline!.A! (or \lstinline!.A.B!, \lstinline!.A.B.C! etc.) lookup is performed as follows:
 \begin{itemize}
@@ -181,11 +181,11 @@ The package-restriction ensures that global name lookup of
 component references can only find global constants.
 \end{nonnormative}
 
-\subsection{Lookup of Imported Names}\doublelabel{lookup-of-imported-names1}
+\subsection{Lookup of Imported Names}\label{lookup-of-imported-names1}
 
 See \cref{lookup-of-imported-names}.
 
-\section{Instance Hierarchy Name Lookup of Inner Declarations}\doublelabel{instance-hierarchy-name-lookup-of-inner-declarations}
+\section{Instance Hierarchy Name Lookup of Inner Declarations}\label{instance-hierarchy-name-lookup-of-inner-declarations}
 
 An element declared with the prefix \lstinline!outer! references an element instance
 with the same name but using the prefix \lstinline!inner! which is nearest in the
@@ -307,7 +307,7 @@ end A;
 \end{lstlisting}
 \end{example}
 
-\subsection{Example of Field Functions using Inner/Outer}\doublelabel{example-of-field-functions-using-inner-outer}
+\subsection{Example of Field Functions using Inner/Outer}\label{example-of-field-functions-using-inner-outer}
 
 \begin{nonnormative}
 Inner declarations can be used to define field functions, such
@@ -338,7 +338,7 @@ end C;
 \end{lstlisting}
 \end{nonnormative}
 
-\section{Simultaneous Inner/Outer Declarations}\doublelabel{simultaneous-inner-outer-declarations}
+\section{Simultaneous Inner/Outer Declarations}\label{simultaneous-inner-outer-declarations}
 
 An element declared with both the prefixes \lstinline!inner! and \lstinline!outer! conceptually
 introduces two declarations with the same name: one that follows the
@@ -387,7 +387,7 @@ end System;
 \end{lstlisting}
 \end{example}
 
-\section{Flattening Process}\doublelabel{flattening-process}
+\section{Flattening Process}\label{flattening-process}
 
 In order to guarantee that elements can be used before they are declared
 and that elements do not depend on the order of their declaration
@@ -409,7 +409,7 @@ The constants, parameters and variables are defined by globally unique
 identifiers and all references are resolved to the identifier of the
 referenced variable. No other transformations are performed.
 
-\subsection{Instantiation}\doublelabel{instantiation}
+\subsection{Instantiation}\label{instantiation}
 
 The instantiation is performed in two steps. First a class tree is
 created and then from that an instance tree for a particular model is
@@ -423,7 +423,7 @@ instantiated the corresponding diagnostics can be omitted (or be given).
 However, errors that should only be reported in a simulation model must
 be omitted there, since they are not part of the simulation model.
 
-\subsubsection{The Class Tree}\doublelabel{the-class-tree}
+\subsubsection{The Class Tree}\label{the-class-tree}
 
 All necessary libraries including the model which is to be instantiated
 are loaded from e.g.\ file system and form a so called \firstuse{class tree}.
@@ -436,7 +436,7 @@ The class tree is built up directly during parsing of the Modelica texts.  For e
 to the location of the class in the class hierarchy.  This tree can be seen as the abstract syntax tree (AST) of the loaded libraries.
 \end{nonnormative}
 
-\subsubsection{The Instance Tree}\doublelabel{the-instance-tree}
+\subsubsection{The Instance Tree}\label{the-instance-tree}
 
 The output of the instantiation process is an \firstuse{instance tree}.
 The instance tree consists of nodes representing the elements of a class
@@ -486,7 +486,7 @@ instance tree --- when searching for an element in an instance scope the search 
 import-statements are ignored.
 \end{nonnormative}
 
-\subsubsection{The Instantiation Procedure.}\doublelabel{the-instantiation-procedure}
+\subsubsection{The Instantiation Procedure.}\label{the-instantiation-procedure}
 
 The instantiation is a recursive procedure with the following inputs:
 \begin{itemize}
@@ -508,9 +508,9 @@ starting from the instance scope of the current element. References in
 modifications and equations are resolved later (during generation of
 flat equation system) using the same lookup.
 
-\subsubsection{Steps of Instantiation}\doublelabel{steps-of-instantiation}
+\subsubsection{Steps of Instantiation}\label{steps-of-instantiation}
 
-\paragraph*{The element itself}\doublelabel{the-element-itself}
+\paragraph*{The element itself}\label{the-element-itself}
 
 A partially instantiated class or component is an element that is ready
 to be instantiated; a partially instantiated element (i.e.\ class or
@@ -525,7 +525,7 @@ tree (using the redeclaration if any), modifiers merged to that class
 forming a new partially instantiated class that is instantiated as
 below.
 
-\paragraph*{The local contents of the element}\doublelabel{the-local-contents-of-the-element}
+\paragraph*{The local contents of the element}\label{the-local-contents-of-the-element}
 
 For local classes and components in the current class, instance nodes
 are created and inserted into the current instance. Modifiers (including
@@ -549,7 +549,7 @@ Extends clauses are not looked up, but empty extends clause nodes are
 created and inserted into the current instance -- to be able to preserve
 the declaration order of components.
 
-\paragraph*{The inherited contents of the element}\doublelabel{the-inherited-contents-of-the-element}
+\paragraph*{The inherited contents of the element}\label{the-inherited-contents-of-the-element}
 
 Classes of extends clauses of the current class are looked up in the
 instance tree, modifiers (including redeclarations) are merged, the
@@ -570,7 +570,7 @@ and only the first one of them is kept.  It is an error if they are not identica
 Only keeping the first among the children with the same name is important for function arguments where the order matters.
 \end{nonnormative}
 
-\paragraph*{Recursive instantiation of components}\doublelabel{recursive-instantiation-of-components}
+\paragraph*{Recursive instantiation of components}\label{recursive-instantiation-of-components}
 
 Components (local and inherited) are recursively instantiated.
 
@@ -664,7 +664,7 @@ Note that if \lstinline!D! was consistently replaced by \lstinline!A! in the exa
 classes called \lstinline!A!).
 \end{example}
 
-\subsection{Generation of the flat equation system}\doublelabel{generation-of-the-flat-equation-system}
+\subsection{Generation of the flat equation system}\label{generation-of-the-flat-equation-system}
 
 During this process, all references by name in conditional declarations,
 modifications, dimension definitions, annotations, equations and

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -6,7 +6,7 @@ flattening of Modelica.
 \section{Flattening Context}\doublelabel{flattening-context}
 
 Flattening is made in a context which consists of a modification
-environment (\autoref{modification-environment}) and an ordered set of enclosing classes.
+environment (\cref{modification-environment}) and an ordered set of enclosing classes.
 
 \section{Enclosing Classes}\doublelabel{enclosing-classes}
 
@@ -16,7 +16,7 @@ enclosing class) precedes its enclosing class definition in this set.
 
 Enclosing all class definitions is an unnamed enclosing class that
 contains all top-level class definitions, and not-yet read classes
-defined externally as described in \autoref{mapping-package-class-structures-to-a-hierarchical-file-system}. The order of
+defined externally as described in \cref{mapping-package-class-structures-to-a-hierarchical-file-system}. The order of
 top-level class definitions in the unnamed enclosing class is undefined.
 
 During flattening, the enclosing class of an element being flattened is
@@ -55,8 +55,8 @@ functions and enumeration type conversion functions are ignored during
 type name lookup. Names of record classes and enumeration types are ignored during function name lookup.
 
 \begin{nonnormative}
-The reason to ignore the implicitly defined names is that a record and the implicitly created record constructor function, see \autoref{record-constructor-functions},
-and an enumeration type and the implicitly created conversion function (\autoref{type-conversion-of-integer-to-enumeration-values}), have the same name.
+The reason to ignore the implicitly defined names is that a record and the implicitly created record constructor function, see \cref{record-constructor-functions},
+and an enumeration type and the implicitly created conversion function (\cref{type-conversion-of-integer-to-enumeration-values}), have the same name.
 \end{nonnormative}
 
 \subsection{Simple Name Lookup}\doublelabel{simple-name-lookup}
@@ -65,19 +65,19 @@ When an element, equation, or section is flattened, any simple name
 (not composed using dot notation) is first looked up sequentially among
 iteration variables (if any; see below), and then looked up sequentially in each
 member of the ordered set \emph{of instance scopes (see
-\autoref{the-class-tree}) corresponding to lexically enclosing classes} until a
+\cref{the-class-tree}) corresponding to lexically enclosing classes} until a
 match is found or an enclosing class is encapsulated. In the latter case
 the lookup stops except for the predefined types, functions and
 operators defined in this specification. For these cases the lookup continues in the global scope, where they are defined.
 
 The iteration variables are the implicitly declared iteration variable(s) if inside
-the body of a for-loop, \autoref{for-equations-repetitive-equation-structures} and \autoref{for-statement},
-or the body of a reduction expression, \autoref{reduction-functions-and-operators}.
+the body of a for-loop, \cref{for-equations-repetitive-equation-structures} and \cref{for-statement},
+or the body of a reduction expression, \cref{reduction-functions-and-operators}.
 
 Reference to variables successfully looked up in an enclosing class is
 only allowed for variables declared as constant. The values of modifiers
 are thus resolved in the \emph{instance} scope of which the modifier
-appears; if the use is in a modifier on a short class definition, see \autoref{short-class-definitions}.
+appears; if the use is in a modifier on a short class definition, see \cref{short-class-definitions}.
 
 This lookup in each \emph{instance} scope is performed as follows:
 \begin{itemize}
@@ -119,7 +119,7 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
 \item
   If the identifier denotes a class, that class is temporarily flattened
   (as if instantiating a component without modifiers of this class, see
-  \autoref{modification-environment}) and using the enclosing classes of the denoted class.
+  \cref{modification-environment}) and using the enclosing classes of the denoted class.
   The rest of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the
   declared named elements of the temporary flattened class. If the class
   does not satisfy the requirements for a package, the lookup is
@@ -132,7 +132,7 @@ The temporary class flattening performed for composite names
 follow the same rules as class flattening of the base class in an
 extends-clause, local classes and the type in a component clause, except
 that the environment is empty. See also \lstinline!MoistAir2! example in
-\autoref{redeclaration} for further explanations regarding looking inside
+\cref{redeclaration} for further explanations regarding looking inside
 partial packages.
 \end{nonnormative}
 \begin{example}
@@ -168,7 +168,7 @@ For a name starting with dot, e.g.: \lstinline!.A! (or \lstinline!.A.B!, \lstinl
 \item
   If the name is a composite name then the class \lstinline!A! is temporarily
   flattened with an empty environment (i.e.\ no modifiers, see
-  \autoref{modification-environment}) and using the enclosing classes of the denoted class. The rest
+  \cref{modification-environment}) and using the enclosing classes of the denoted class. The rest
   of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the declared named
   elements of the temporary flattened class. If the class does not
   satisfy the requirements for a package, the lookup is restricted to
@@ -183,7 +183,7 @@ component references can only find global constants.
 
 \subsection{Lookup of Imported Names}\doublelabel{lookup-of-imported-names1}
 
-See \autoref{lookup-of-imported-names}.
+See \cref{lookup-of-imported-names}.
 
 \section{Instance Hierarchy Name Lookup of Inner Declarations}\doublelabel{instance-hierarchy-name-lookup-of-inner-declarations}
 
@@ -193,7 +193,7 @@ enclosing instance hierarchy of the \lstinline!outer! element declaration.
 
 Outer component declarations may not have modifications (including binding equations).
 Outer class declarations should be defined using short-class
-definitions without modifications. However, see also \autoref{simultaneous-inner-outer-declarations}.
+definitions without modifications. However, see also \cref{simultaneous-inner-outer-declarations}.
 
 An \lstinline!outer! element reference in a simulation model requires that one
 corresponding \lstinline!inner! element declaration exist or can be created in a
@@ -212,7 +212,7 @@ unique way:
   declaration, then an \lstinline!inner! declaration of that class is automatically
   added at the top of the model and diagnostics is given.
 \item
-  The annotations defined in \autoref{annotations-for-the-graphical-user-interface} does not affect this process,
+  The annotations defined in \cref{annotations-for-the-graphical-user-interface} does not affect this process,
   other than that:
 
   \begin{itemize}
@@ -391,7 +391,7 @@ end System;
 
 In order to guarantee that elements can be used before they are declared
 and that elements do not depend on the order of their declaration
-(\autoref{declaration-order-and-usage-before-declaration}) in the enclosing class, the flattening proceeds in the
+(\cref{declaration-order-and-usage-before-declaration}) in the enclosing class, the flattening proceeds in the
 following two major steps:
 \begin{enumerate}
 \item
@@ -444,7 +444,7 @@ definition from the class tree. For a component the subtree of a
 particular node is created using the information from the class of the
 component clause and a new modification environment as result of merging
 the current modification environment with the modifications from the
-current element declaration (see \autoref{merging-of-modifications}).
+current element declaration (see \cref{merging-of-modifications}).
 
 The instance tree has the following properties:
 \begin{itemize}
@@ -541,8 +541,8 @@ Equations, algorithms, and annotations of the class and the component
 declaration are copied to the instance without merging.
 
 \begin{nonnormative}
-The annotations can be relevant for simulations, e.g.\ annotations for code generation (\autoref{annotations-for-code-generation}.), simulation experiments
-(\autoref{annotations-for-simulation-experiments}) or functions (\autoref{declaring-derivatives-of-functions}, \autoref{declaring-inverses-of-functions} and \autoref{external-function-interface}).
+The annotations can be relevant for simulations, e.g.\ annotations for code generation (\cref{annotations-for-code-generation}.), simulation experiments
+(\cref{annotations-for-simulation-experiments}) or functions (\cref{declaring-derivatives-of-functions}, \cref{declaring-inverses-of-functions} and \cref{external-function-interface}).
 \end{nonnormative}
 
 Extends clauses are not looked up, but empty extends clause nodes are
@@ -681,8 +681,8 @@ tree, e.g.\ in case of a constant in a package.
 \begin{nonnormative}
 To resolve the names, a name lookup using the instance tree is performed, starting at the instance scope (unless the name is fully qualified) of the modification, algorithm
 or equation.  If it is not found locally the search is continued at the instance of the lexically enclosing class of the scope (this is normally not equal to the parent of
-the current instance), and then continued with their parents as described in \autoref{static-name-lookup}.  If the found component is an outer declaration, the search is
-continued using the direct parents in the instance tree (see \autoref{instance-hierarchy-name-lookup-of-inner-declarations}).  If the lookup has to look into a class which
+the current instance), and then continued with their parents as described in \cref{static-name-lookup}.  If the found component is an outer declaration, the search is
+continued using the direct parents in the instance tree (see \cref{instance-hierarchy-name-lookup-of-inner-declarations}).  If the lookup has to look into a class which
 is not instantiated yet (or only partially instantiated), it is instantiated in place.
 \end{nonnormative}
 
@@ -722,7 +722,7 @@ instantiated):
       is formed from a reference to the name of the instance and the
       resolved modification value of the instance, and included into the
       equation system. Except if the value for an element of a record is
-      overridden by the value for an entire record; \autoref{merging-of-modifications}.
+      overridden by the value for an entire record; \cref{merging-of-modifications}.
     \end{itemize}
   \item
     If it is of simple type (\lstinline!Boolean!, \lstinline!Integer!, enumeration, \lstinline!Real!,
@@ -753,7 +753,7 @@ instantiated):
   handled.
 \item
   If there are function calls encountered during this process, the call
-  is filled up with default arguments as defined in \autoref{positional-or-named-input-arguments-of-functions}. These are
+  is filled up with default arguments as defined in \cref{positional-or-named-input-arguments-of-functions}. These are
   built from the modifications of input arguments which are resolved
   using their instance scope. The called function itself is looked up in
   the instance tree. All used functions are flattened and put into the
@@ -775,9 +775,9 @@ instantiated):
 \end{itemize}
 
 This leads to a flattened equation system, except for connect and transition statements. These have to be transformed as described in
-\autoref{connectors-and-connections} and \autoref{state-machines}.  This may lead to further changes in the instance tree (e.g.\ from expandable connectors
-(\autoref{expandable-connectors})) and additional equations in the flattened equation system (e.g.\ connect equations (\autoref{generation-of-connection-equations}),
-generated equations for state machine semantics (\autoref{semantics-summary})).
+\cref{connectors-and-connections} and \cref{state-machines}.  This may lead to further changes in the instance tree (e.g.\ from expandable connectors
+(\cref{expandable-connectors})) and additional equations in the flattened equation system (e.g.\ connect equations (\cref{generation-of-connection-equations}),
+generated equations for state machine semantics (\cref{semantics-summary})).
 
 \begin{nonnormative}
 After flattening, the resulting equation system is self

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -89,7 +89,7 @@ initial state and state variables are reset to their start values. If
 synchronize=true, any transition is disabled until all state machines of
 the from-state have reached final states, i.e.\ states without outgoing
 transitions. For the precise details about firing a transition, see
-\autoref{state-machine-semantics}.\\ \hline
+\cref{state-machine-semantics}.\\ \hline
 \lstinline!initialState(state)! & Argument \lstinline!state! is the block instance
 that is defined to be the initial state of a state machine. At the first
 clock tick of the state machine, this state becomes active.\\ \hline
@@ -160,7 +160,7 @@ lines.
 The annotation for graphics of \lstinline!transition! has the following
 structure: \lstinline!annotation(Line($\ldots$), Text($\ldots$))!; and for
 \lstinline!initialState()!: \emph{graphical-primitives}\lstinline!(Line($\ldots$))!; with \lstinline!Line!
-and \lstinline!Text! annotations defined in \autoref{annotations}.
+and \lstinline!Text! annotations defined in \cref{annotations}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -455,7 +455,7 @@ u!\textsubscript{2}! = v
 ...
 \end{lstlisting}
 
-The merge of the definitions of v is then made according to \autoref{merging-variable-definitions}:
+The merge of the definitions of v is then made according to \cref{merging-variable-definitions}:
 Merging Variable Definitions. The result is after
 simplification:
 \begin{lstlisting}[language=modelica,escapechar=!]

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -1,4 +1,4 @@
-\chapter{State Machines}\doublelabel{state-machines}
+\chapter{State Machines}\label{state-machines}
 
 \begin{nonnormative}
 This chapter defines language elements to define clocked state
@@ -46,7 +46,7 @@ properties are different to Lucid Synchrone 3.0:
 \end{itemize}
 \end{nonnormative}
 
-\section{Transitions}\doublelabel{transitions}
+\section{Transitions}\label{transitions}
 
 Any Modelica block instance without continuous-time equations or
 algorithms can potentially be a state of a state machine. A cluster of
@@ -141,7 +141,7 @@ equation
 \end{lstlisting}
 \end{example}
 
-\section{State Machine Graphics}\doublelabel{state-machine-graphics}
+\section{State Machine Graphics}\label{state-machine-graphics}
 
 \begin{nonnormative}
 The recommended layout of state machines is shown below for a
@@ -208,7 +208,7 @@ followed by a colon if \lstinline!priority! \textgreater{} 1.
 The \lstinline!initialState! line has a filled arrow head and a bullet at the
 opposite end of the initial state (as shown above).
 
-\section{State Machine Semantics}\doublelabel{state-machine-semantics}
+\section{State Machine Semantics}\label{state-machine-semantics}
 
 For the purpose of defining the semantics of state machines, assume that
 the data of all transitions are stored in an array of records:
@@ -238,7 +238,7 @@ state is active. For a top level state machine, reset is true at the
 first activation only. For sub-state machine, reset is propagated from
 the state machines higher up.
 
-\subsection{State Activation}\doublelabel{state-activation}
+\subsection{State Activation}\label{state-activation}
 
 The state update starts from \lstinline!nextState!, i.e., what has been determined to be the next state at the previous time.
 \lstinline!selectedState! takes into account if a reset of the state machine is to be done.
@@ -327,7 +327,7 @@ To enable a synchronize transition, all the stateMachineInFinalState
 conditions of all state machines within the meta state must be true. An
 example is given below in the semantic example model.
 
-\subsection{Reset Handling}\doublelabel{reset-handling}
+\subsection{Reset Handling}\label{reset-handling}
 
 A state can be reset for two reasons:
 \begin{itemize}
@@ -361,7 +361,7 @@ The second reset mechanism is implemented with the selectedReset~and
 nextReset~variables. If no reset transition is fired, the nextReset is
 set to false for the next cycle.
 
-\subsection{Activation handling}\doublelabel{activation-handling}
+\subsection{Activation handling}\label{activation-handling}
 
 The execution of a sub-state machine has to be suspended when its
 enclosing state is not active. This activation flag is given as a
@@ -369,7 +369,7 @@ enclosing state is not active. This activation flag is given as a
 maintains its previous state, by guarding the equations of the state
 variables \lstinline!nextState!, \lstinline!nextReset! and \lstinline!nextResetStates!.
 
-\subsection{Semantics Summary}\doublelabel{semantics-summary}
+\subsection{Semantics Summary}\label{semantics-summary}
 
 The entire semantics model is given below:
 \begin{lstlisting}[language=modelica]
@@ -404,7 +404,7 @@ machine should be reset";
   Boolean stateMachineInFinalState = finalStates[activeState];
 end StateMachineSemantics;
 \end{lstlisting}
-\subsection{Merging Variable Definitions}\doublelabel{merging-variable-definitions}
+\subsection{Merging Variable Definitions}\label{merging-variable-definitions}
 
 \begin{nonnormative}
 When a state class uses an \lstinline!outer output! declaration,
@@ -428,7 +428,7 @@ if not assigned in the initial state.
 A new assignment equation is formed which might be merged on higher
 levels in nested state machines.
 
-\subsection{Merging Connections to Multiple Outputs}\doublelabel{merging-connections-to-multiple-outputs}
+\subsection{Merging Connections to Multiple Outputs}\label{merging-connections-to-multiple-outputs}
 
 \begin{nonnormative}
 Since instances of blocks can be used as states of a state
@@ -465,7 +465,7 @@ u!\textsubscript{2}! = v
 ...
 \end{lstlisting}
 
-\subsection{Example}\doublelabel{example}
+\subsection{Example}\label{example}
 
 \begin{example}
 Consider the following hierarchical state machine:

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -16,12 +16,12 @@ algorithm-section :
 [ initial ] algorithm { statement ";" | annotation ";" }
 \end{lstlisting}
 
-Equation equality \lstinline!=! or any other kind of equation (see \autoref{equations}) shall
+Equation equality \lstinline!=! or any other kind of equation (see \cref{equations}) shall
 not be used in an algorithm section.
 
 \subsection{Initial Algorithm Sections}\doublelabel{initial-algorithm-sections}
 
-See \autoref{initialization-initial-equation-and-initial-algorithm} for a description of both initial algorithm sections and
+See \cref{initialization-initial-equation-and-initial-algorithm} for a description of both initial algorithm sections and
 initial equation sections.
 
 \subsection{Execution of an algorithm in a model}\doublelabel{execution-of-an-algorithm-in-a-model}
@@ -73,7 +73,7 @@ end Test;
 
 \subsection{Execution of the algorithm in a function}\doublelabel{execution-of-the-algorithm-in-a-function}
 
-See \autonameref{initialization-and-binding-equations-of-components-in-functions}.
+See \crefnameref{initialization-and-binding-equations-of-components-in-functions}.
 
 \section{Statements}\doublelabel{statements}
 
@@ -85,7 +85,7 @@ Names in statements are found as follows:
 \begin{itemize}
 \item
   If the name occurs inside an expression: it is first found among the
-  lexically enclosing reduction functions (see \autoref{reduction-functions-and-operators}) in order
+  lexically enclosing reduction functions (see \cref{reduction-functions-and-operators}) in order
   starting from the inner-most, and if not found it proceeds as if it
   were outside an expression:
 \item
@@ -160,7 +160,7 @@ multiple results is as follows:
 \end{lstlisting}
 
 \begin{nonnormative}
-Also see \autoref{simple-equality-equations} regarding calling functions with
+Also see \cref{simple-equality-equations} regarding calling functions with
 multiple results within equations.
 \end{nonnormative}
 
@@ -177,7 +177,7 @@ for for-indices loop
 end for
 \end{lstlisting}
 For-statements may optionally use several iterators (\lstinline!for-indices!), see
-\autoref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
+\cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
 \begin{lstlisting}[language=grammar]
 for-indices:
    for-index {"," for-index}
@@ -189,7 +189,7 @@ The following is an example of a prefix of a for-statement:
 \begin{lstlisting}[language=modelica]
 for IDENT in expression loop
 \end{lstlisting}
-The rules for for-statements are the same as for for-expressions in \autoref{explicit-iteration-ranges-of-for-equations} -
+The rules for for-statements are the same as for for-expressions in \cref{explicit-iteration-ranges-of-for-equations} -
 except that the \lstinline!expression! of a for-statement is not restricted to a parameter-expression.
 
 \begin{example}
@@ -322,7 +322,7 @@ programming languages, and is formally defined as follows:
 continues after the while-statement.
 \item If the \lstinline!expression! of the while-statement is true, the entire body of
 the while-statement is executed (except if a break-statement, see
-\autoref{break-statement}, or a return-statement, see \autoref{return-statements}, is executed),
+\cref{break-statement}, or a return-statement, see \cref{return-statements}, is executed),
 and then execution proceeds at step 1.
 \end{enumerate}
 
@@ -358,7 +358,7 @@ end findValue;
 
 \subsection{Return-Statements}\doublelabel{return-statements}
 
-Can only be used inside functions, see \autoref{function-return-statements}.
+Can only be used inside functions, see \cref{function-return-statements}.
 
 \subsection{If-Statement}\doublelabel{if-statement}
 
@@ -504,11 +504,11 @@ between equations and statements.
 
 \subsubsection{Assert Statement}\doublelabel{assert-statement}
 
-See \autoref{assert}. A failed assert stops the execution of the current
+See \cref{assert}. A failed assert stops the execution of the current
 algorithm.
 
 \subsubsection{Terminate Statement}\doublelabel{terminate-statement}
 
-See \autoref{terminate}. The terminate statement may not be in functions; In
+See \cref{terminate}. The terminate statement may not be in functions; In
 an algorithm outside a function it does not stop the execution of the
 current algorithm.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -1,4 +1,4 @@
-\chapter{Statements and Algorithm Sections}\doublelabel{statements-and-algorithm-sections}
+\chapter{Statements and Algorithm Sections}\label{statements-and-algorithm-sections}
 
 Whereas equations are very well suited for physical modeling, there are
 situations where computations are more conveniently expressed as
@@ -7,7 +7,7 @@ the algorithmic constructs that are available in Modelica.
 
 Statements are imperative constructs allowed in algorithm sections.
 
-\section{Algorithm Sections}\doublelabel{algorithm-sections}
+\section{Algorithm Sections}\label{algorithm-sections}
 
 An algorithm section is comprised of the keyword \lstinline!algorithm! followed by a
 sequence of statements. The formal syntax is as follows:
@@ -19,12 +19,12 @@ algorithm-section :
 Equation equality \lstinline!=! or any other kind of equation (see \cref{equations}) shall
 not be used in an algorithm section.
 
-\subsection{Initial Algorithm Sections}\doublelabel{initial-algorithm-sections}
+\subsection{Initial Algorithm Sections}\label{initial-algorithm-sections}
 
 See \cref{initialization-initial-equation-and-initial-algorithm} for a description of both initial algorithm sections and
 initial equation sections.
 
-\subsection{Execution of an algorithm in a model}\doublelabel{execution-of-an-algorithm-in-a-model}
+\subsection{Execution of an algorithm in a model}\label{execution-of-an-algorithm-in-a-model}
 
 An algorithm section is conceptually a code fragment that remains
 together and the statements of an algorithm section are executed in the
@@ -71,11 +71,11 @@ end Test;
 \end{lstlisting}
 \end{nonnormative}
 
-\subsection{Execution of the algorithm in a function}\doublelabel{execution-of-the-algorithm-in-a-function}
+\subsection{Execution of the algorithm in a function}\label{execution-of-the-algorithm-in-a-function}
 
 See \crefnameref{initialization-and-binding-equations-of-components-in-functions}.
 
-\section{Statements}\doublelabel{statements}
+\section{Statements}\label{statements}
 
 Statements are imperative constructs allowed in algorithm sections. A
 flattened statement is identical to the corresponding nonflattened
@@ -111,7 +111,7 @@ statement :
   comment
 \end{lstlisting}
 
-\subsection{Simple Assignment Statements}\doublelabel{simple-assignment-statements}
+\subsection{Simple Assignment Statements}\label{simple-assignment-statements}
 
 The syntax of simple assignment statement is as follows:
 \begin{lstlisting}[language=grammar]
@@ -121,7 +121,7 @@ component-reference ":=" expression
 The \lstinline!expression! is evaluated. The resulting value is stored into the
 variable denoted by \lstinline!component-reference!.
 
-\subsubsection{Assignments from Called Functions with Multiple Results}\doublelabel{assignments-from-called-functions-with-multiple-results}
+\subsubsection{Assignments from Called Functions with Multiple Results}\label{assignments-from-called-functions-with-multiple-results}
 
 There is a special form of assignment statement that is used only when
 the right-hand side contains a call to a function with multiple results.
@@ -164,11 +164,11 @@ Also see \cref{simple-equality-equations} regarding calling functions with
 multiple results within equations.
 \end{nonnormative}
 
-\subsubsection{Restrictions on assigned variables}\doublelabel{restrictions-on-assigned-variables}
+\subsubsection{Restrictions on assigned variables}\label{restrictions-on-assigned-variables}
 Only components of the restricted classes type, record, operator record, and connector may appear as left-hand-side in algorithms.
 This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple results.
 
-\subsection{For-statement}\doublelabel{for-statement}
+\subsection{For-statement}\label{for-statement}
 
 The syntax of a for-statement is as follows:
 \begin{lstlisting}[language=grammar]
@@ -213,7 +213,7 @@ equation
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Implicit Iteration Ranges}\doublelabel{implicit-iteration-ranges}
+\subsubsection{Implicit Iteration Ranges}\label{implicit-iteration-ranges}
 
 An iterator \lstinline!IDENT in range-expr! without the \lstinline!in range-expr! requires that
 the \lstinline!IDENT! appears as the subscript of one or several subscripted
@@ -262,7 +262,7 @@ The size of an array -- the iteration range is evaluated on entry to the
 for-loop and the array size may not change during the execution of the
 for-loop.
 
-\subsubsection{Types as Iteration Ranges }\doublelabel{types-as-iteration-ranges}
+\subsubsection{Types as Iteration Ranges }\label{types-as-iteration-ranges}
 
 The iteration range can be specified as \lstinline!Boolean! or as an enumeration
 type. This means iteration over the type from min to max, i.e.\ for
@@ -283,7 +283,7 @@ equation
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Nested For-Loops and Reduction Expressions with Multiple Iterators}\doublelabel{nested-for-loops-and-reduction-expressions-with-multiple-iterators}
+\subsubsection{Nested For-Loops and Reduction Expressions with Multiple Iterators}\label{nested-for-loops-and-reduction-expressions-with-multiple-iterators}
 
 The notation with several iterators is a shorthand notation for nested
 for-statements or for-equations (or reduction-expressions). For
@@ -305,7 +305,7 @@ algorithm
 \end{lstlisting}
 \end{example}
 
-\subsection{While-Statement}\doublelabel{while-statement}
+\subsection{While-Statement}\label{while-statement}
 
 The while-statement has the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -326,7 +326,7 @@ the while-statement is executed (except if a break-statement, see
 and then execution proceeds at step 1.
 \end{enumerate}
 
-\subsection{Break-Statement}\doublelabel{break-statement}
+\subsection{Break-Statement}\label{break-statement}
 
 The break-statement breaks the execution of the innermost while or
 for-loop enclosing the break-statement and continues execution after the
@@ -356,11 +356,11 @@ end findValue;
 \end{lstlisting}
 \end{example}
 
-\subsection{Return-Statements}\doublelabel{return-statements}
+\subsection{Return-Statements}\label{return-statements}
 
 Can only be used inside functions, see \cref{function-return-statements}.
 
-\subsection{If-Statement}\doublelabel{if-statement}
+\subsection{If-Statement}\label{if-statement}
 
 If-statements have the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -386,7 +386,7 @@ an else-clause exists, otherwise no body is selected). In an algorithm
 section, the selected body is then executed. The bodies that are not
 selected have no effect on that model evaluation.
 
-\subsection{When-Statements}\doublelabel{when-statements}
+\subsection{When-Statements}\label{when-statements}
 
 A when-statement has the following syntax:
 \begin{lstlisting}[language=grammar]
@@ -439,7 +439,7 @@ different models with different behavior depending on the order of the
 assignment to \lstinline!y1! and \lstinline!y3! in the algorithm.
 \end{example}
 
-\subsubsection{Restrictions on When-Statements}\doublelabel{restrictions-on-when-statements}
+\subsubsection{Restrictions on When-Statements}\label{restrictions-on-when-statements}
 
 \begin{itemize}
 \item
@@ -464,7 +464,7 @@ end when;
 \end{lstlisting}
 \end{example}
 
-\subsubsection{Defining When-Statements by If-Statements}\doublelabel{defining-when-statements-by-if-statements}
+\subsubsection{Defining When-Statements by If-Statements}\label{defining-when-statements-by-if-statements}
 
 A when-statement:
 \begin{lstlisting}[language=modelica]
@@ -496,18 +496,18 @@ statements within this special if-statement are only evaluated at event
 instants. The difference compared to the when-statements is that e.g.\ \lstinline!pre! may only be used on continuous-time real variables inside the body
 of a when-clause and not inside these if-statements.
 
-\subsection{Special Statements}\doublelabel{special-statements}
+\subsection{Special Statements}\label{special-statements}
 
 These special statements have the same form and semantics as the
 corresponding equations, apart from the general difference in semantics
 between equations and statements.
 
-\subsubsection{Assert Statement}\doublelabel{assert-statement}
+\subsubsection{Assert Statement}\label{assert-statement}
 
 See \cref{assert}. A failed assert stops the execution of the current
 algorithm.
 
-\subsubsection{Terminate Statement}\doublelabel{terminate-statement}
+\subsubsection{Terminate Statement}\label{terminate-statement}
 
 See \cref{terminate}. The terminate statement may not be in functions; In
 an algorithm outside a function it does not stop the execution of the

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -1,4 +1,4 @@
-\chapter{Stream Connectors}\doublelabel{stream-connectors}
+\chapter{Stream Connectors}\label{stream-connectors}
 
 The two basic variable types in a connector -- \emph{potential} (or \emph{across})
 variable and \emph{flow} (or \emph{through}) variable -- are not sufficient to
@@ -27,7 +27,7 @@ of the connector, irrespective of the actual flow direction.
 The rationale of the definition and typical use cases are described in
 \cref{derivation-of-stream-equations}.
 
-\section{Definition of Stream Connectors}\doublelabel{definition-of-stream-connectors}
+\section{Definition of Stream Connectors}\label{definition-of-stream-connectors}
 
 If at least one variable in a connector has the \lstinline!stream! prefix,
 the connector is called \firstuse{stream connector} and the corresponding
@@ -80,7 +80,7 @@ inquired through the built-in \lstinline!actualStream!, see
 \cref{stream-operator-actualstream}.
 \end{example}
 
-\section{Stream Operator inStream and Connection Equations}\doublelabel{stream-operator-instream-and-connection-equations}
+\section{Stream Operator inStream and Connection Equations}\label{stream-operator-instream-and-connection-equations}
 
 In combination with the stream variables of a connector, \lstinline!inStream! is designed to describe in a numerically
 reliable way the bi-directional transport of specific quantities carried
@@ -385,7 +385,7 @@ the connection set (i.e., equivalent to $m_{j}\text{\lstinline!.c.m_flow!} =
 position is set identically to closed by its controller.
 \end{nonnormative}
 
-\section{Stream Operator actualStream}\doublelabel{stream-operator-actualstream}
+\section{Stream Operator actualStream}\label{stream-operator-actualstream}
 
 \lstinline!actualStream! is provided for convenience, in
 order to return the actual value of the stream variable, depending on

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -25,7 +25,7 @@ the value the carried quantity would have if the fluid was flowing out
 of the connector, irrespective of the actual flow direction.
 
 The rationale of the definition and typical use cases are described in
-\autoref{derivation-of-stream-equations}.
+\cref{derivation-of-stream-equations}.
 
 \section{Definition of Stream Connectors}\doublelabel{definition-of-stream-connectors}
 
@@ -42,17 +42,17 @@ variable is called \firstuse{stream variable}. The following definitions hold:
   The idea is that all stream variables of a connector are associated with this flow variable.
   \end{nonnormative}
 \item
-  For every outside connector (see \autoref{inside-and-outside-connectors}), one
+  For every outside connector (see \cref{inside-and-outside-connectors}), one
   equation is generated for every variable with the \lstinline!stream!
   prefix (to describe the propagation of the stream variable
   along a model hierarchy). For the exact definition, see the end of
-  \autoref{stream-operator-instream-and-connection-equations}.
+  \cref{stream-operator-instream-and-connection-equations}.
 \item
-  For inside connectors (see \autoref{inside-and-outside-connectors}), variables
+  For inside connectors (see \cref{inside-and-outside-connectors}), variables
   with the \lstinline!stream! prefix do not lead to connection equations.
 \item
   Connection equations with stream variables are generated in a model when using \lstinline!inStream! or \lstinline!actualStream!,
-  see \autoref{stream-operator-instream-and-connection-equations} and \autoref{stream-operator-actualstream}.
+  see \cref{stream-operator-instream-and-connection-equations} and \cref{stream-operator-actualstream}.
 \end{itemize}
 
 \begin{example}
@@ -77,7 +77,7 @@ point. The stream properties for the other flow direction can be
 inquired with the built-in \lstinline!inStream!. The value of
 the stream variable corresponding to the actual flow direction can be
 inquired through the built-in \lstinline!actualStream!, see
-\autoref{stream-operator-actualstream}.
+\cref{stream-operator-actualstream}.
 \end{example}
 
 \section{Stream Operator inStream and Connection Equations}\doublelabel{stream-operator-instream-and-connection-equations}
@@ -95,7 +95,7 @@ stream variables.
 For the following definition it is assumed that $N$ inside connectors
 \lstinline!$m_{j}$.c! ($j = 1, 2, \ldots, N$) and $M$ outside connectors
 \lstinline!$c{k}$! ($k = 1, 2, \ldots, M$) belonging to the same connection set
-(see definition in \autoref{inside-and-outside-connectors}) are connected
+(see definition in \cref{inside-and-outside-connectors}) are connected
 together and a stream variable \lstinline!h_outflow! is associated with a flow
 variable \lstinline!m_flow! in connector \lstinline!c!.
 
@@ -142,7 +142,7 @@ adding to the model the conservation equations for mass and energy
 corresponding to the infinitesimally small volume spanning the
 connection set. The connection equation for the flow variables has
 already been added to the system according to the connection semantics
-of flow variables defined in \autoref{generation-of-connection-equations}.
+of flow variables defined in \cref{generation-of-connection-equations}.
 
 \begin{lstlisting}[language=modelica]
 // Standard connection equation for flow variables
@@ -189,7 +189,7 @@ end for;
 Neglecting zero flow conditions, the solution of the above-defined
 stream connection equations for \lstinline!inStream! values of inside connectors and
 outflow stream variables of outside connectors is (for a derivation, see
-\autoref{derivation-of-stream-equations}):
+\cref{derivation-of-stream-equations}):
 \begin{lstlisting}[language=modelica]
 inStream($m_i$.c.h_outflow) :=
   (sum(max(-$m_j$.c.m_flow,0)*$m_j$.c.h_outflow for j in cat(1, 1:i-1, i+1:N) +
@@ -228,7 +228,7 @@ approximate the solution in an open neighbourhood of that point.
 For example, assume that \lstinline!$m_{j}$.c.m_flow = $c_{k}$.m_flow = 0!, then all equations above are identically fulfilled and \lstinline!inStream! can have any value.
 \end{nonnormative}
 
-However, specific optimizations may be applied to avoid the regularization if the flow through one port is zero or non-negative, see \autoref{derivation-of-stream-equations}.
+However, specific optimizations may be applied to avoid the regularization if the flow through one port is zero or non-negative, see \cref{derivation-of-stream-equations}.
 It is required that \lstinline!inStream! is appropriately approximated when regularization is needed and the approximation must fulfill the following requirements:
 \begin{enumerate}
 \item
@@ -326,7 +326,7 @@ postiveMax(-$m_j$.c.m_flow, $s_i$) = max(-$m_j$.c.m_flow, $\mathit{eps1}$); // s
 \end{lstlisting}
 More sophisticated implementation, with smooth approximation, applied only when {all} flows are small:
 \begin{lstlisting}[language=modelica,escapechar=!]
-// Define a "small number" eps (nominal(v) is the nominal value of v - see !\autoref{attributes-start-fixed-nominal-and-unbounded}!)
+// Define a "small number" eps (nominal(v) is the nominal value of v - see !\cref{attributes-start-fixed-nominal-and-unbounded}!)
 eps := relativeTolerance*min(nominal($m_j$.c.m_flow));
 
 // Define a smooth curve, such that  alpha($s_i>=eps$)=1 and alpha($s_i<0$)=0
@@ -340,7 +340,7 @@ positiveMax((-$m_j$.c.m_flow,s_i) := alpha*max(-$m_j$.c.m_flow,0) + (1-alpha)*ep
 \end{lstlisting}
 
 The derivation of this implementation is discussed in
-\autoref{derivation-of-stream-equations}. Note that in the cases $N = 1,\, M = 0$ (unconnected port,
+\cref{derivation-of-stream-equations}. Note that in the cases $N = 1,\, M = 0$ (unconnected port,
 physically corresponding to a plugged-up flange), and $N = 2,\,  M = 0$
 (one-to-one connection), the result of \lstinline!inStream! is trivial
 and no non-linear equations are left in the model, despite the fact that

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -25,7 +25,7 @@ together with sample and (zero-order) hold elements}
 \begin{itemize}
 \item
   A periodic clock is defined with \lstinline!Clock(3)!. The argument
-  of \lstinline!Clock! defines the sampling interval (for details see \autoref{clock-constructors}).
+  of \lstinline!Clock! defines the sampling interval (for details see \cref{clock-constructors}).
 \item
   Clocked variables (such as yd, xd, ud) are associated uniquely
   with a clock and can only be directly accessed when the associated
@@ -90,8 +90,8 @@ ud = C*previous(xd) + D*yd;
 
 \begin{nonnormative}
 Periodically sampled control systems could also be defined with
-standard when-clauses, see \autoref{when-equations}, and the sample operator, see
-\autoref{event-related-operators-with-function-syntax}. For example:
+standard when-clauses, see \cref{when-equations}, and the sample operator, see
+\cref{event-related-operators-with-function-syntax}. For example:
 \begin{lstlisting}[language=modelica]
 when sample(0,3) then
   xd = A*pre(xd) + B*y;
@@ -194,15 +194,15 @@ In this section various terms are defined.
 %  \caption{The different kinds of discrete-time variables.  The \lstinline!hold! extrapolation of the clocked variable is illustrated with dashed green lines.}
 %\end{figure}
 
-In \autoref{discrete-time-expressions} the term \emph{discrete-time} Modelica expression and in \autoref{continuous-time-expressions} the term \emph{continuous-time} Modelica expression is defined.
+In \cref{discrete-time-expressions} the term \emph{discrete-time} Modelica expression and in \cref{continuous-time-expressions} the term \emph{continuous-time} Modelica expression is defined.
 In this chapter, two additional kinds of discrete-time expressions/variables are defined that are associated to clocks and are therefore called \firstuse{clocked discrete-time} expressions.  The
 different kinds of discrete-time variables in Modelica are defined below.
 
 \begin{definition}[Piecewise-constant variable]
-(See \autoref{discrete-time-expressions}.)  Variables \lstinline!m(t)! of base type \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, enumeration, and \lstinline!String! that are
+(See \cref{discrete-time-expressions}.)  Variables \lstinline!m(t)! of base type \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, enumeration, and \lstinline!String! that are
 \emph{constant} inside each interval t\textsubscript{i} $\le$ t \textless{} t\textsubscript{i+1} (= piecewise constant continuous-time variables).  In other words, \lstinline!m(t)! \emph{changes}
 value \emph{only at events}.  This means, \lstinline!m($t$)! = \lstinline!m($t_{i}$)!, for $t_{i} \leq t < t_{i+1}$.  Such variables depend continuously on time and they are discrete-time variables.
-See \autoref{fig:piecewise-constant-variable}.
+See \cref{fig:piecewise-constant-variable}.
 \end{definition}
 
 \begin{figure}[H]
@@ -214,7 +214,7 @@ See \autoref{fig:piecewise-constant-variable}.
 
 \begin{definition}[Clock variable]
 Clock variables \lstinline!c($t_{i}$)! are of base type \lstinline!Clock!.  A clock is either defined by a constructor (such as \lstinline!Clock(3)!) that defines when the clock ticks (is active) at
-a particular time instant, or it is defined with clock operators relatively to other clocks, see \autoref{base-clock-conversion-operators}.  See \autoref{fig:clock-variable}.
+a particular time instant, or it is defined with clock operators relatively to other clocks, see \cref{base-clock-conversion-operators}.  See \cref{fig:clock-variable}.
 \end{definition}
 
 \begin{example}
@@ -239,7 +239,7 @@ a clock \lstinline!c($t_{i}$)!.  A clocked variable can only be directly accesse
 where a clocked variable is required.
 
 At time instants where the associated clock is not active, the value of a clocked variable can be inquired by using an explicit cast operator, see below.  In such a case \lstinline!hold! semantics is
-used, in other words the value of the clocked variable from the last event instant is used.  See \autoref{fig:clocked-variable}.
+used, in other words the value of the clocked variable from the last event instant is used.  See \cref{fig:clocked-variable}.
 \end{definition}
 
 \begin{figure}[H]
@@ -279,7 +279,7 @@ A Component Expression can be constant or can vary with time.
 \end{nonnormative}
 \end{definition}
 
-In the following sections, when defining an operator with function calling syntax, there are some common restrictions being used for the input arguments (operands).  For example, an input argument to the operator may be required to be a component expression (\autoref{def:component-expression}) or parameter expression (\autoref{variability-of-expressions}).  To emphasize that there are no such restrictions, an input argument may be said to be just an expression.
+In the following sections, when defining an operator with function calling syntax, there are some common restrictions being used for the input arguments (operands).  For example, an input argument to the operator may be required to be a component expression (\cref{def:component-expression}) or parameter expression (\cref{variability-of-expressions}).  To emphasize that there are no such restrictions, an input argument may be said to be just an expression.
 
 \begin{nonnormative}
 The reason for restricting an input argument to be a component expression is that the start value of the input argument is returned before the first tick of the clock of the input argument and this
@@ -357,12 +357,12 @@ this out as well, if the when-clause is not present).
 \begin{tabular}{@{}p{119mm}@{}}
 \firstuse{Clock with Rational Interval}\\
 The first input argument, \lstinline!intervalCounter!, is a clocked Component
-Expression (see \autoref{argument-restrictions-component-expression}) or a parameter expression of type
+Expression (see \cref{argument-restrictions-component-expression}) or a parameter expression of type
 \lstinline!Integer! with \lstinline!min=0!. The optional second argument \lstinline!resolution!
 (default=1) is a parameter expression of type Integer with \lstinline!min=1! and
 \lstinline!unit="Hz"!. If \lstinline!intervalCounter! is a parameter expression with value
 zero, the period of the clock is derived by clock inference, see
-\autoref{sub-clock-inferencing}. The output argument is of base type Clock that ticks when time
+\cref{sub-clock-inferencing}. The output argument is of base type Clock that ticks when time
 becomes t\textsubscript{start}, t\textsubscript{start}+interval1,
 t\textsubscript{start}+interval1+interval2, ... The clock starts at the
 start of the simulation t\textsubscript{start} or when the controller is
@@ -376,7 +376,7 @@ intervalCounter/resolution, and so on. If interval is a parameter
 expression, the clock defines a periodic clock.
 
 \begin{nonnormative}
-The given interval and time shift can be modified by using the subSample, superSample, shiftSample and backSample operators on the returned clock, see \autoref{sub-clock-conversion-operators}.
+The given interval and time shift can be modified by using the subSample, superSample, shiftSample and backSample operators on the returned clock, see \cref{sub-clock-conversion-operators}.
 \end{nonnormative}
 
 \begin{example}
@@ -407,7 +407,7 @@ Note that operator \lstinline!interval(c)! of \lstinline!Clock c = Clock(nextInt
 \begin{tabular}{@{}p{119mm}@{}}
 \firstuse{Clock with Real Interval}\\
 The input argument, \lstinline!interval!, is a clocked Component Expression (see
-\autoref{argument-restrictions-component-expression}) or a parameter expression.
+\cref{argument-restrictions-component-expression}) or a parameter expression.
 The \lstinline!interval! must be strictly positive (\lstinline!interval>0.0!) of type \lstinline!Real! with \lstinline!unit="s"!.
 The output argument is of base type Clock that
 ticks when time becomes t\textsubscript{start},
@@ -422,7 +422,7 @@ interval is a parameter expression, the clock defines a periodic clock.
 \par
 \begin{nonnormative*}
 Note, the clock is defined with \lstinline!previous(interval)!.  Therefore, for sorting the input argument is treated as known. The given interval and time shift can be modified
-by using the subSample, superSample, shiftSample and backSample operators on the returned clock, see \autoref{sub-clock-conversion-operators}. There are restrictions where this
+by using the subSample, superSample, shiftSample and backSample operators on the returned clock, see \cref{sub-clock-conversion-operators}. There are restrictions where this
 operator can be used, see Clock expressions below.
 \end{nonnormative*}
 \end{tabular}\\ \hline
@@ -437,7 +437,7 @@ operator can be used, see Clock expressions below.
 The input argument, \lstinline!condition!, is a continuous-time expression of type
 Boolean. The optional \lstinline!startInterval! argument (default = 0.0) is the
 value returned by \lstinline!interval()! at the first tick of
-the clock, see \autoref{initialization-of-clocked-partitions}. The output argument is of base type Clock
+the clock, see \cref{initialization-of-clocked-partitions}. The output argument is of base type Clock
 that ticks when \lstinline!edge(condition)! becomes true.
 \begin{nonnormative}
 This clock is used to trigger a clocked partition due to a state event, that is a zero-crossing of a Real variable, in a continuous-time partition or due to a hardware interrupt
@@ -452,7 +452,7 @@ Clock c = Clock(angle > 0, 0.1) // before first tick of c:
 
 The implicitly given interval and time shift can be modified by
 using the subsample, superSample, shiftSample and backSample operators
-on the returned clock, see \autoref{sub-clock-conversion-operators}, provided the base
+on the returned clock, see \cref{sub-clock-conversion-operators}, provided the base
 interval is not smaller than the implicitly given interval.
 \end{example*}
 \end{tabular}\\ \hline
@@ -467,7 +467,7 @@ interval is not smaller than the implicitly given interval.
 The first input argument \lstinline!c! is a clock and the operator returns this
 clock. The returned clock is associated with the second input argument
 of type String \lstinline!solverMethod!. The meaning of solverMethod is defined
-in \autoref{solver-methods}. If the second input argument solverMethod is an empty
+in \cref{solver-methods}. If the second input argument solverMethod is an empty
 String, then this Clock-construct does not associate an integrator with the returned clock.
 \par
 \begin{example*}
@@ -487,7 +487,7 @@ exclusive associations of clocks are possible in one base partition:
 \begin{enumerate}
 \item
   One or more Rational interval clocks, provided they are consistent
-  with each other, see \autoref{sub-clock-inferencing}.
+  with each other, see \cref{sub-clock-inferencing}.
   \begin{nonnormative}
   For example, assume \lstinline!y = subSample(u)!, and \lstinline!Clock(1, 10)! is associated with \lstinline!u! and \lstinline!Clock(2, 10)! is associated with \lstinline!y!,
   then this is correct, but it would be an error if \lstinline!y! is associated with a \lstinline!Clock(1, 3)!.
@@ -514,7 +514,7 @@ Generally, every expression switching between clock variables must have
 parametric variability (in order that clock analysis can be
 performed when translating a model).
 Thus subscripts on Clock-variables and conditions of if-then-else switching between Clock-variables must
-be parameter expressions, and there are similar restrictions for sub-clock conversion operators \autoref{sub-clock-conversion-operators}.
+be parameter expressions, and there are similar restrictions for sub-clock conversion operators \cref{sub-clock-conversion-operators}.
 Otherwise, the following expressions are allowed:
 \begin{itemize}
 \item
@@ -559,11 +559,11 @@ previous operator. Such a variable is called a clocked state variable.
 \begin{longtable}[]{|l|p{12cm}|}
 \hline \endhead
 \lstinline!previous(u)! & The input argument is a \emph{component expression} (see
-\autoref{argument-restrictions-component-expression}) or a parameter expression. The return argument has the
+\cref{argument-restrictions-component-expression}) or a parameter expression. The return argument has the
 same type as the input argument. Input and return arguments are on the
 same clock. At the first tick of the clock of u or after a reset
-transition (see \autoref{reset-handling}), the start value of u is returned, see
-\autoref{initialization-of-clocked-partitions}. At subsequent activations of the clock of u, the value of
+transition (see \cref{reset-handling}), the start value of u is returned, see
+\cref{initialization-of-clocked-partitions}. At subsequent activations of the clock of u, the value of
 u from the previous clock activation is returned.\\ \hline
 \end{longtable}
 
@@ -580,13 +580,13 @@ clocked-time representation and vice versa:
 \hline \endhead
 \lstinline!sample(u, clock)! &
 Input argument u is a continuous-time expression according to
-\autoref{continuous-time-expressions}. The optional input argument clock is of type Clock, and can in a call be given as a named argument (with the name clock),
+\cref{continuous-time-expressions}. The optional input argument clock is of type Clock, and can in a call be given as a named argument (with the name clock),
 or as positional argument.
 The operator
 returns a clocked variable that has clock as associated clock and has the
 value of the left limit of u when clock is active (that is the value of u
 just before the event of c is triggered). If argument clock is not provided,
-it is inferred, see \autoref{sub-clock-inferencing}.
+it is inferred, see \cref{sub-clock-inferencing}.
 \par
 \begin{nonnormative*}
 Since the operator returns the left limit of u, it introduces
@@ -602,16 +602,16 @@ constant, a parameter or a piecewise constant expression.
 
 Note that \lstinline!sample! is an overloaded function: If
 \lstinline!sample! has two positional input arguments and the second argument is
-of type Real, it is the operator from \autoref{event-related-operators-with-function-syntax}. If
+of type Real, it is the operator from \cref{event-related-operators-with-function-syntax}. If
 \lstinline!sample! has one input argument, or it has two input
 arguments and the second argument if of type Clock, it is the base-clock
 conversion operator from this section.
 \end{nonnormative*}
 \\ \hline
 \lstinline!hold(u)! &
-Input argument \lstinline!u! is a clocked Component Expression (see \autoref{argument-restrictions-component-expression}) or a parameter expression.  The operator returns a piecewise constant
+Input argument \lstinline!u! is a clocked Component Expression (see \cref{argument-restrictions-component-expression}) or a parameter expression.  The operator returns a piecewise constant
 signal of the same type of \lstinline!u!.  When the clock of \lstinline!u! ticks, the operator returns \lstinline!u! and otherwise returns the value of \lstinline!u! from the last clock activation.
-Before the first clock activation of \lstinline!u!, the operator returns the start value of \lstinline!u!, see \autoref{initialization-of-clocked-partitions}.
+Before the first clock activation of \lstinline!u!, the operator returns the start value of \lstinline!u!, see \cref{initialization-of-clocked-partitions}.
 \par
 \begin{nonnormative*}
 Since the input argument is not defined before the first tick of the clock of u, the restriction is present, that it must be a Component Expression (or a parameter expression),
@@ -643,7 +643,7 @@ once at a time instant, and since the left limit of a variable does not
 change during event iteration (i.e., re-evaluating a base-clock
 partition associated with a condition clock always gives the same result
 because the sample(u) inputs do not change and therefore need not to be
-re-evaluated) all base-clock partitions, see \autoref{base-clock-partitioning}, need
+re-evaluated) all base-clock partitions, see \cref{base-clock-partitioning}, need
 not to be sorted with respect to each other. Instead, at an event
 instant, active base-clock partitions can be evaluated first (and once)
 in any order. Afterwards, the continuous-time partition is evaluated.
@@ -684,7 +684,7 @@ The clock of \lstinline!y = subSample(u, factor)! is factor-times slower than th
 operator returns the value of \lstinline!u!. The first activation of the clock of \lstinline!y!
 coincides with the first activation of the clock of \lstinline!u!, and then every activation of the clock of \lstinline!y!
 coincides with the every factor-th activativation of the clock of \lstinline!u!. If argument
-factor is not provided or is equal to zero, it is inferred, see \autoref{sub-clock-inferencing}.
+factor is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
 \\ \hline
 \lstinline!superSample(u, factor)!
 &
@@ -698,7 +698,7 @@ into factor activations, such that the activation 1+k*factor of \lstinline!y! co
 Thus \lstinline!subSample(superSample(u, factor), factor)=u!
 \end{nonnormative}
 If argument factor is not provided or is equal to zero, it
-is inferred, see \autoref{sub-clock-inferencing}. If an Event clock is associated to a
+is inferred, see \cref{sub-clock-inferencing}. If an Event clock is associated to a
 base-clock partition, all its sub-clock partitions must have resulting
 clocks that are sub-sampled with an Integer factor with respect to this
 base clock.
@@ -747,7 +747,7 @@ Clock y2 = shiftSample(u,2,3);// error (resolution must be 1)
 \end{tabular}
 &
 The input argument u is either a \emph{component expression} (see
-\autoref{argument-restrictions-component-expression}) or an expression of type Clock.
+\cref{argument-restrictions-component-expression}) or an expression of type Clock.
 This is an inverse of shiftSample such that \lstinline!Clock y=backSample(u, cnt, res)! implicitly defines
 a clock y such that \lstinline!shiftSample(y, cnt, res)! activates at the same times as u.
 It is an
@@ -756,7 +756,7 @@ error, if the clock of y starts before the base clock of u.
 At every
 tick of the clock of y, the operator returns the value of u from the
 last tick of the clock of u. If u is a clocked Component Expression, the
-operator returns the start value of u, see \autoref{initialization-of-clocked-partitions}, before the
+operator returns the start value of u, see \cref{initialization-of-clocked-partitions}, before the
 first tick of the clock of u.
 \par
 \begin{example*}
@@ -865,11 +865,11 @@ expression and every algorithm section is either continuous-time, or it
 is uniquely associated with exactly one clock. In the latter case it is
 called a clocked equation, a clocked expression or clocked algorithm
 section respectively. The associated clock is either explicitly defined
-by a when-clause, see \autoref{sub-clock-conversion-operators}, or it is implicitly defined by the
+by a when-clause, see \cref{sub-clock-conversion-operators}, or it is implicitly defined by the
 requirement that a clocked equation, a clocked expression and a clocked
 algorithm section must have the same clock as the variables used in them
 with exception of the expressions used as first arguments in the
-conversion operators of \autoref{partitioning-operators}. Clock inference means to infer the
+conversion operators of \cref{partitioning-operators}. Clock inference means to infer the
 clock of a variable, an equation, an expression or an algorithm section
 if the clock is not explicitly defined and is deduced from the required
 properties in the previous two paragraphs.
@@ -882,7 +882,7 @@ loops. The clock inference method uses the set of variable incidences of
 the equations, i.e., what variables that appear in each equation.
 
 Note that incidences of the first argument of clock conversion operators
-of \autoref{partitioning-operators} are handled specially.
+of \cref{partitioning-operators} are handled specially.
 
 \subsection{Flattening of Model}\doublelabel{flattening-of-model}
 
@@ -1001,7 +1001,7 @@ u = hold (yd2); // incidence(e) = {u}
 \subsection{Sub-clock Partitioning}\doublelabel{sub-clock-partitioning}
 
 For each clocked partition B\textsubscript{i}, identified in
-\autoref{base-clock-partitioning}, the sub-clock partitioning is performed with sub-clock inference
+\cref{base-clock-partitioning}, the sub-clock partitioning is performed with sub-clock inference
 which uses the following incidence definition:
 
 % This is not how you are supposed to format things in LaTeX
@@ -1028,7 +1028,7 @@ $V = \bigcup V_{ij}$
 $E = \bigcup E_{ij}$
 
 \begin{example}
-After sub-clock partitioning of the example from \autoref{base-clock-partitioning}, the following partitions are identified:
+After sub-clock partitioning of the example from \cref{base-clock-partitioning}, the following partitions are identified:
 \begin{lstlisting}[language=modelica]
 // Base partition 1 (clocked partition)
 // Sub-clock partition 1.1
@@ -1113,7 +1113,7 @@ clocked partition.
 
 \subsection{Clocked Discrete-Time and Clocked Discretized Continuous-Time Partition}\doublelabel{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}
 
-Additionally to the variability of expressions defined in \autoref{variability-of-expressions},
+Additionally to the variability of expressions defined in \cref{variability-of-expressions},
 an orthogonal concept \emph{clocked variability} is defined in this
 section. If not explicitly stated otherwise, an expression with a
 variability such as \emph{continuous-time} or \emph{discrete-time} means that
@@ -1122,14 +1122,14 @@ If an expression is present in a partition that is not a continuous-time
 partition, it is a \firstuse{clocked expression} and has
 \firstuse{clocked variability}.
 
-After sub-clock inferencing, see \autoref{sub-clock-inferencing}, every partition that is
+After sub-clock inferencing, see \cref{sub-clock-inferencing}, every partition that is
 associated to a clock has to be categorized as \firstuse{clocked
 discrete-time} or \firstuse{clocked discretized continuous-time}
 partition.
 
 If a clocked partition contains no operator \lstinline!der!,
 \lstinline!delay!, \lstinline!spatialDistribution!, no event related operators
-from \autoref{event-related-operators-with-function-syntax} (with exception of \lstinline!noEvent!), and no
+from \cref{event-related-operators-with-function-syntax} (with exception of \lstinline!noEvent!), and no
 \lstinline!when!-clause with a \lstinline!Boolean! condition, it is a \firstuse{clocked discrete-time} partition.
 
 \begin{nonnormative}
@@ -1138,13 +1138,13 @@ That is, the clocked discrete-time partition is a standard sampled data system t
 
 If a clocked partition is not a \emph{clocked discrete-time} partition, it
 is a \firstuse{clocked discretized continuous-time} partition. Such a
-partition has to be solved with a \emph{solver method} of \autoref{solver-methods}.
+partition has to be solved with a \emph{solver method} of \cref{solver-methods}.
 When \lstinline!previous(x)! is used on a continuous-time state variable \lstinline!x!, then
 \lstinline!previous(x)! uses the start value of \lstinline!x! as value for the first clock tick.
 
 In a clocked discrete-time partition all event generating mechanisms do
 no longer apply. Especially neither relations, nor one of the built-in
-operators of \autoref{event-triggering-mathematical-functions} (event triggering mathematical functions)
+operators of \cref{event-triggering-mathematical-functions} (event triggering mathematical functions)
 will trigger an event.
 
 \subsection{Solver Methods}\doublelabel{solver-methods}
@@ -1308,7 +1308,7 @@ or is given in the simulation environment.
 \subsection{Associating a Solver to a Partition}\doublelabel{associating-a-solver-to-a-partition}
 
 A \lstinline!solverMethod! can be associated to a clock with the overloaded Clock
-constructor Clock(c, solverMethod), see \autoref{clock-constructors}. If a clock is
+constructor Clock(c, solverMethod), see \cref{clock-constructors}. If a clock is
 associated with a clocked partition and a \lstinline!solverMethod! is associated
 with this clock, then the partition is integrated with it.
 
@@ -1331,7 +1331,7 @@ m*der(x2) = f;
 
 If a solverMethod is not explicitly associated with a partition, it is
 inferred with a similar mechanism as for sub-clock inferencing, see
-\autoref{sub-clock-inferencing}.
+\cref{sub-clock-inferencing}.
 
 For each sub-clock partition we build a set corresponding to this sub-clock partition.
 These sets are then merged as follows: for each set without a specified solverMethod we merge it
@@ -1398,11 +1398,11 @@ The following additional utility operators are provided:
 This operator returns true at the first tick of the clock of the
 expression, in which this operator is called. The operator returns false
 at all subsequent ticks of the clock. The optional argument u is only
-used for clock inference, see \autoref{clock-partitioning}.\\ \hline
+used for clock inference, see \cref{clock-partitioning}.\\ \hline
 \lstinline!interval(u)! &
 This operator returns the interval between the previous and present tick
 of the clock of the expression, in which this operator is called. The
-optional argument u is only used for clock inference, see \autoref{clock-partitioning}.
+optional argument u is only used for clock inference, see \cref{clock-partitioning}.
 At the first tick of the clock the following is returned: a) if the
 specified clock interval is parametric, this value is returned; b)
 otherwise the start value of the variable specifying the interval is

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1,11 +1,11 @@
-\chapter{Synchronous Language Elements}\doublelabel{synchronous-language-elements}
+\chapter{Synchronous Language Elements}\label{synchronous-language-elements}
 
 This section presents language elements for describing synchronous
 behavior suited for implementation of control systems.
 
-\section{Introduction}\doublelabel{introduction2}
+\section{Introduction}\label{introduction2}
 
-\subsection{Overview}\doublelabel{overview}
+\subsection{Overview}\label{overview}
 
 \begin{nonnormative}
 This chapter defines additional kinds of discrete-time
@@ -86,7 +86,7 @@ ud = C*previous(xd) + D*yd;
 \end{itemize}
 \end{nonnormative}
 
-\subsection{Rationale for Clocked Semantics}\doublelabel{rationale-for-clocked-semantics}
+\subsection{Rationale for Clocked Semantics}\label{rationale-for-clocked-semantics}
 
 \begin{nonnormative}
 Periodically sampled control systems could also be defined with
@@ -178,19 +178,19 @@ equations:
 \end{enumerate}
 \end{nonnormative}
 
-\section{Definitions}\doublelabel{definitions}
+\section{Definitions}\label{definitions}
 
 In this section various terms are defined.
 
-\subsection{Clocks and Clocked Variables}\doublelabel{clocks-and-clocked-variables}
+\subsection{Clocks and Clocked Variables}\label{clocks-and-clocked-variables}
 
 % We can't use \subfloat just yet due to LaTeXML issue:
 %   https://github.com/brucemiller/LaTeXML/issues/1292
 %\begin{figure}[tb]
 %  \centering
-%  \subfloat[A piecewise-constant variable.]{\includegraphics[width=5cm]{piecewise}\doublelabel{fig:piecewise-constant-variable}}
-%  \subfloat[A clock variable.]{\includegraphics[width=5cm]{clock}\doublelabel{fig:clock-variable}}
-%  \subfloat[A clocked variable.]{\includegraphics[width=5cm]{clocked}\doublelabel{fig:clocked-variable}}
+%  \subfloat[A piecewise-constant variable.]{\includegraphics[width=5cm]{piecewise}\label{fig:piecewise-constant-variable}}
+%  \subfloat[A clock variable.]{\includegraphics[width=5cm]{clock}\label{fig:clock-variable}}
+%  \subfloat[A clocked variable.]{\includegraphics[width=5cm]{clocked}\label{fig:clocked-variable}}
 %  \caption{The different kinds of discrete-time variables.  The \lstinline!hold! extrapolation of the clocked variable is illustrated with dashed green lines.}
 %\end{figure}
 
@@ -209,7 +209,7 @@ See \cref{fig:piecewise-constant-variable}.
   \begin{center}
     \includegraphics[width=3in]{piecewise}
   \end{center}
-  \caption{A piecewise-constant variable.}\doublelabel{fig:piecewise-constant-variable}
+  \caption{A piecewise-constant variable.}\label{fig:piecewise-constant-variable}
 \end{figure}
 
 \begin{definition}[Clock variable]
@@ -230,7 +230,7 @@ Clock c3 = subSample(c2, 4);
   \begin{center}
     \includegraphics[width=3in]{clock}
   \end{center}
-  \caption{A clock variable.}\doublelabel{fig:clock-variable}
+  \caption{A clock variable.}\label{fig:clock-variable}
 \end{figure}
 
 \begin{definition}[Clocked variable]
@@ -246,10 +246,10 @@ used, in other words the value of the clocked variable from the last event insta
   \begin{center}
     \includegraphics[width=3in]{clocked}
   \end{center}
-  \caption{A clocked variable.  The \lstinline!hold! extrapolation of the value at the last event instant is illustrated with dashed green lines.}\doublelabel{fig:clocked-variable}
+  \caption{A clocked variable.  The \lstinline!hold! extrapolation of the value at the last event instant is illustrated with dashed green lines.}\label{fig:clocked-variable}
 \end{figure}
 
-\subsection{Base-Clock and Sub-Clock Partitions}\doublelabel{base-clock-and-sub-clock-partitions}
+\subsection{Base-Clock and Sub-Clock Partitions}\label{base-clock-and-sub-clock-partitions}
 
 There are two kinds of \firstuse{clock partitions}:
 
@@ -263,14 +263,14 @@ A sub-clock partition identifies a subset of equations and a subset of variables
 partition, i.e., synchronized when the ticks of the respective clocks are simultaneous.
 \end{definition}
 
-\subsection{Argument Restrictions (Component Expression)}\doublelabel{argument-restrictions-component-expression}
+\subsection{Argument Restrictions (Component Expression)}\label{argument-restrictions-component-expression}
 
 The built-in operators (with function syntax) defined in the following
 sections have partially restrictions on their input arguments that are
 not present for Modelica functions. To define the restrictions, the
 following term is used.
 
-\begin{definition}[Component expression]\doublelabel{def:component-expression}
+\begin{definition}[Component expression]\label{def:component-expression}
 A Component Reference which is an Expression, i.e.\ does not refer to models or blocks with equations.  It is an instance of a (a) base type, (b) derived type, (c) record, (d) an array of such an
 instance (a-c), (e) one or more elements of such an array (d) defined by index expressions which are parameter expressions (see below), or (f) an element of records.
 \begin{nonnormative}
@@ -320,7 +320,7 @@ y3 = subSample(u, factor = 3 * u);     // error (general expression)
 Note that the operators defined in this chapter do not automatically vectorize,
 but some operate on arrays in a similar way.
 
-\section{Clock Constructors}\doublelabel{clock-constructors}
+\section{Clock Constructors}\label{clock-constructors}
 
 The following overloaded constructors are available to generate clocks, and
 it is possible to call them with the specified named arguments, or with positional arguments (according to the order below):
@@ -551,7 +551,7 @@ Otherwise, the following expressions are allowed:
   \end{example}
 \end{itemize}
 
-\section{Discrete States}\doublelabel{discrete-states}
+\section{Discrete States}\label{discrete-states}
 
 The previous value of a clocked variable can be accessed with the
 previous operator. Such a variable is called a clocked state variable.
@@ -567,12 +567,12 @@ transition (see \cref{reset-handling}), the start value of u is returned, see
 u from the previous clock activation is returned.\\ \hline
 \end{longtable}
 
-\section{Partitioning Operators}\doublelabel{partitioning-operators}
+\section{Partitioning Operators}\label{partitioning-operators}
 
 A set of \emph{clock conversion operators} together act as boundaries
 between different clock partitions.
 
-\subsection{Base-clock conversion operators}\doublelabel{base-clock-conversion-operators}
+\subsection{Base-clock conversion operators}\label{base-clock-conversion-operators}
 
 The following operators convert between a continuous-time and a
 clocked-time representation and vice versa:
@@ -654,7 +654,7 @@ storing it in a local variable of the partition and only using this
 local copy during evaluation of the equations in this partition.
 \end{example}
 
-\subsection{Sub-clock conversion operators}\doublelabel{sub-clock-conversion-operators}
+\subsection{Sub-clock conversion operators}\label{sub-clock-conversion-operators}
 
 The following operators convert between synchronous clocks:
 \begin{longtable}[]{|p{4cm}|p{11cm}|}
@@ -831,7 +831,7 @@ the current value, since it has no infinitesimal delay.
 Note that it is not legal to compute the derivative of the \lstinline!sample!, \lstinline!subSample!, \lstinline!superSample!, \lstinline!backSample!,
 \lstinline!shiftSample!, and \lstinline!noClock! operators.
 
-\section{Clocked When Clause}\doublelabel{clocked-when-clause}
+\section{Clocked When Clause}\label{clocked-when-clause}
 
 In addition to the previously discussed conditional when-clause, a
 \emph{clocked} when-clause is introduced:
@@ -849,7 +849,7 @@ allowed in a clocked when-clause.
 For a clocked when-clause, all equations inside the when-clause are
 clocked with the same clock given by the \emph{clock-expression}.
 
-\section{Clock Partitioning}\doublelabel{clock-partitioning}
+\section{Clock Partitioning}\label{clock-partitioning}
 
 This section defines how clock-partitions and clocks associated with
 equations are inferred.
@@ -884,7 +884,7 @@ the equations, i.e., what variables that appear in each equation.
 Note that incidences of the first argument of clock conversion operators
 of \cref{partitioning-operators} are handled specially.
 
-\subsection{Flattening of Model}\doublelabel{flattening-of-model}
+\subsection{Flattening of Model}\label{flattening-of-model}
 
 The clock partitioning is conceptually performed after model flattening,
 i.e., redeclarations have been elaborated, arrays of model components
@@ -903,7 +903,7 @@ is recursively replaced by a
 unique variable, v\textsubscript{i}, and the equation v\textsubscript{i}
 = expr\textsubscript{i} is added to the equation set.
 
-\subsection{Connected Components of the Equations and Variables Graph}\doublelabel{connected-components-of-the-equations-and-variables-graph}
+\subsection{Connected Components of the Equations and Variables Graph}\label{connected-components-of-the-equations-and-variables-graph}
 
 Consider the set E of equations and the set V of unknown variables (not
 constants and parameters) in a flattened model, i.e.\ M = \textless{}E,
@@ -920,7 +920,7 @@ A set of clock partitions is the \emph{connected components} (Wikipedia,
 \emph{Connected components}) of this graph with appropriate definition of
 the incidence operator.
 
-\subsection{Base-clock Partitioning}\doublelabel{base-clock-partitioning}
+\subsection{Base-clock Partitioning}\label{base-clock-partitioning}
 
 The goal is to identify all clocked equations and variables that should
 be executed together in the same task, as well as to identify the
@@ -998,7 +998,7 @@ u = hold (yd2); // incidence(e) = {u}
 \end{lstlisting}
 \end{example}
 
-\subsection{Sub-clock Partitioning}\doublelabel{sub-clock-partitioning}
+\subsection{Sub-clock Partitioning}\label{sub-clock-partitioning}
 
 For each clocked partition B\textsubscript{i}, identified in
 \cref{base-clock-partitioning}, the sub-clock partitioning is performed with sub-clock inference
@@ -1048,7 +1048,7 @@ u = hold (yd2);
 \end{lstlisting}
 \end{example}
 
-\subsection{Sub-clock Inferencing}\doublelabel{sub-clock-inferencing}
+\subsection{Sub-clock Inferencing}\label{sub-clock-inferencing}
 
 For each base-clock partition, the base interval needs to be determined
 and for each sub-clock partition, the sub-sampling factors and shift
@@ -1072,7 +1072,7 @@ range of 1 to 2\textsuperscript{63} can be handled.
 64 bit internal representation of numerator and denominator with sign can be used and gives minimum resolution 1.08E-19 seconds and maximum range 9.22E+18 seconds = 2.92E+11 years.
 \end{nonnormative}
 
-\section{Continuous-Time Equations in Clocked Partitions}\doublelabel{continuous-time-equations-in-clocked-partitions}
+\section{Continuous-Time Equations in Clocked Partitions}\label{continuous-time-equations-in-clocked-partitions}
 
 \begin{nonnormative}
 The goal is that every continuous-time Modelica model can be utilized in a sampled data control system.  This is achieved by solving the continuous-time equations with a defined
@@ -1111,7 +1111,7 @@ partitions. Hereby, a discretized continuous-time partition is seen as a
 clocked partition.
 
 
-\subsection{Clocked Discrete-Time and Clocked Discretized Continuous-Time Partition}\doublelabel{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}
+\subsection{Clocked Discrete-Time and Clocked Discretized Continuous-Time Partition}\label{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}
 
 Additionally to the variability of expressions defined in \cref{variability-of-expressions},
 an orthogonal concept \emph{clocked variability} is defined in this
@@ -1147,7 +1147,7 @@ no longer apply. Especially neither relations, nor one of the built-in
 operators of \cref{event-triggering-mathematical-functions} (event triggering mathematical functions)
 will trigger an event.
 
-\subsection{Solver Methods}\doublelabel{solver-methods}
+\subsection{Solver Methods}\label{solver-methods}
 
 The integration method associated with a clocked discretized
 continuous-time partition is defined with a string. A predefined type
@@ -1305,7 +1305,7 @@ equation systems, or the maximum number of iterations in case of hard realtime r
 or is given in the simulation environment.
 \end{nonnormative}
 
-\subsection{Associating a Solver to a Partition}\doublelabel{associating-a-solver-to-a-partition}
+\subsection{Associating a Solver to a Partition}\label{associating-a-solver-to-a-partition}
 
 A \lstinline!solverMethod! can be associated to a clock with the overloaded Clock
 constructor Clock(c, solverMethod), see \cref{clock-constructors}. If a clock is
@@ -1327,7 +1327,7 @@ m*der(x2) = f;
 \end{lstlisting}
 \end{example}
 
-\subsection{Inferencing of solverMethod}\doublelabel{inferencing-of-solvermethod}
+\subsection{Inferencing of solverMethod}\label{inferencing-of-solvermethod}
 
 If a solverMethod is not explicitly associated with a partition, it is
 inferred with a similar mechanism as for sub-clock inferencing, see
@@ -1374,7 +1374,7 @@ end IllegalInference;
 Here \lstinline!z! is a continuous-time equation connected directly to both \lstinline!x! and \lstinline!y! partitions that have different \lstinline!solverMethod!.
 \end{example}
 
-\section{Initialization of Clocked Partitions}\doublelabel{initialization-of-clocked-partitions}
+\section{Initialization of Clocked Partitions}\label{initialization-of-clocked-partitions}
 
 The standard scheme for initialization of Modelica models does not apply
 for clocked discrete-time partitions. Instead, initialization is
@@ -1389,7 +1389,7 @@ performed in the following way:
   \lstinline!previous! is applied, otherwise false.
 \end{itemize}
 
-\section{Other Operators}\doublelabel{other-operators}
+\section{Other Operators}\label{other-operators}
 
 The following additional utility operators are provided:
 \begin{longtable}[]{|l|p{12cm}|}
@@ -1464,7 +1464,7 @@ end MixedController;
 \end{lstlisting}
 \end{example}
 
-\section{Semantics}\doublelabel{semantics}
+\section{Semantics}\label{semantics}
 
 The execution of sub partitions requires exact time management for
 proper synchronization. The implication is that testing a Real valued

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -30,7 +30,7 @@ UNSIGNED-REAL = UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
      |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 \end{lstlisting}
 \textrm{S-CHAR} is any member of the Unicode character set
-(\url{http://www.unicode.org}; see \autoref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote """, and backslash "\textbackslash{}"
+(\url{http://www.unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote """, and backslash "\textbackslash{}"
 
 For identifiers the redundant escapes (`\lstinline!\?!' and `\lstinline!\"!') are the same as the corresponding non-escaped
 variants (`\lstinline!?!' and '\lstinline!"!').  The single quotes are part of an identifier. E.g.\ \lstinline!'x'! and

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -1,5 +1,5 @@
-\chapter{Modelica Concrete Syntax}\doublelabel{modelica-concrete-syntax}
-\section{Lexical conventions}\doublelabel{lexical-conventions}
+\chapter{Modelica Concrete Syntax}\label{modelica-concrete-syntax}
+\section{Lexical conventions}\label{lexical-conventions}
 
 The following syntactic meta symbols are used (extended BNF):
 \begin{lstlisting}[language=grammar]
@@ -72,15 +72,15 @@ Note:
   text. Previously the grammar used underscore.
 \end{itemize}
 
-\section{Grammar}\doublelabel{grammar}
-\subsection{Stored Definition -- Within}\doublelabel{stored-definition-within}
+\section{Grammar}\label{grammar}
+\subsection{Stored Definition -- Within}\label{stored-definition-within}
 \begin{lstlisting}[language=grammar]
 stored-definition:
    [ within [ name ] ";" ]
    { [ final ] class-definition ";" }
 \end{lstlisting}
 
-\subsection{Class Definition}\doublelabel{class-definition}
+\subsection{Class Definition}\label{class-definition}
 \begin{lstlisting}[language=grammar]
 class-definition :
    [ encapsulated ] class-prefixes
@@ -152,7 +152,7 @@ import-list :
    IDENT { "," IDENT }
 \end{lstlisting}
 
-\subsection{Extends}\doublelabel{extends}
+\subsection{Extends}\label{extends}
 \begin{lstlisting}[language=grammar]
 extends-clause :
    extends type-specifier [ class-modification ] [ annotation-clause ]
@@ -161,7 +161,7 @@ constraining-clause :
    constrainedby type-specifier [ class-modification ]
 \end{lstlisting}
 
-\subsection{Component Clause}\doublelabel{component-clause}
+\subsection{Component Clause}\label{component-clause}
 \begin{lstlisting}[language=grammar]
 component-clause:
    type-prefix type-specifier [ array-subscripts ] component-list
@@ -182,7 +182,7 @@ declaration :
    IDENT [ array-subscripts ] [ modification ]
 \end{lstlisting}
 
-\subsection{Modification}\doublelabel{modification}
+\subsection{Modification}\label{modification}
 \begin{lstlisting}[language=grammar]
 modification :
    class-modification [ "=" expression ]
@@ -223,7 +223,7 @@ short-class-definition :
    class-prefixes short-class-specifier
 \end{lstlisting}
 
-\subsection{Equations}\doublelabel{equations1}
+\subsection{Equations}\label{equations1}
 \begin{lstlisting}[language=grammar]
 equation-section :
    [ initial ] equation { equation ";" }
@@ -311,7 +311,7 @@ when-statement :
 connect-clause :
    connect "(" component-reference "," component-reference ")"
 \end{lstlisting}
-\subsection{Expressions}\doublelabel{expressions1}
+\subsection{Expressions}\label{expressions1}
 \begin{lstlisting}[language=grammar]
 expression :
    simple-expression

--- a/chapters/unitexpressions.tex
+++ b/chapters/unitexpressions.tex
@@ -1,4 +1,4 @@
-\chapter{Unit Expressions}\doublelabel{unit-expressions}
+\chapter{Unit Expressions}\label{unit-expressions}
 
 Unless otherwise stated, the syntax and semantics of unit expressions in
 Modelica conform with the international standards
@@ -16,7 +16,7 @@ Examples for the syntax of unit expressions used in Modelica: \lstinline!"N.m"!,
 \lstinline!"kg.m/s2"!, \lstinline!"kg.m.s-2"! \lstinline!"1/rad"!,
 \lstinline!"mm/s"!.
 
-\section{The Syntax of Unit Expressions}\doublelabel{the-syntax-of-unit-expressions}
+\section{The Syntax of Unit Expressions}\label{the-syntax-of-unit-expressions}
 \begin{lstlisting}[language=grammar]
 unit_expression:
    unit_numerator [ "/" unit_denominator ]
@@ -88,7 +88,7 @@ micro.
 A tool may present \lstinline!Ohm! as $\Omega$ and the prefix \lstinline!u! as $\mu$, and similarly \lstinline!m2! as $m^2$.
 \end{nonnormative}
 
-\section{Examples}\doublelabel{examples2}
+\section{Examples}\label{examples2}
 
 The unit expression \lstinline!"m"! means meter and not milli
 (10\textsuperscript{-3}), since prefixes cannot be used in isolation.

--- a/preamble.tex
+++ b/preamble.tex
@@ -323,6 +323,8 @@
 \Crefname{paragraph}{Section}{Sections}
 \crefname{subparagraph}{section}{sections}
 \Crefname{subparagraph}{Section}{Sections}
+\crefname{equation}{}{}
+\Crefname{equation}{}{}
 
 \newcommand{\crefnameref}[1]{\cref{#1}~\emph{\nameref*{#1}}}
 \newcommand{\Crefnameref}[1]{\Cref{#1}~\emph{\nameref*{#1}}}

--- a/preamble.tex
+++ b/preamble.tex
@@ -37,13 +37,11 @@
 %\usepackage{t1enc}
 \usepackage{graphicx}
 \graphicspath{{media/}{../media/}} % so that chapter files can also find the images
-\def\figureautorefname{figure} % Use lower case initial, just like for sections.
 
 % Don't use subfig.sty until this LaTeXML issue has been fixed:
 % - https://github.com/brucemiller/LaTeXML/issues/1292
 % Leaving commented-out code as a hint to anyone who considers using subfig.
 %\usepackage{subfig}
-%\newcommand{\subfigureautorefname}{\figureautorefname}
 
 \usepackage{verbatim}
 % The fixltx2e that was used for textsubscript is no longer needed for pdf, but is needed by latexml
@@ -138,11 +136,11 @@
 % Formatting of table headings.
 \newcommand{\tablehead}[1]{\textit{#1}}
 
-\newcommand{\autonameref}[1]{\autoref{#1}~\emph{\nameref*{#1}}}
-
 \newcommand{\glossaryitem}[1]{\textbf{#1}}
 
 \newcommand{\bibitemtitle}[1]{\emph{#1}}
+
+\usepackage[nameinlink,noabbrev]{cleveref}
 
 % Environment for definitions.
 \usepackage{amsthm}
@@ -160,7 +158,8 @@
 % so instead we make the 'definition' environment a wrapper around the amsthm-base environment.
 \makeatletter
 \newtheorem{definition@inner}{Definition}[chapter]
-\newcommand{\definition@innerautorefname}{definition}
+\crefname{definition@inner}{definition}{definitions}
+\Crefname{definition@inner}{Definition}{Definitions}
 \newenvironment{definition}{\begin{definition@inner}}{\qed\end{definition@inner}}
 \makeatother
 
@@ -316,11 +315,18 @@
 \newcommand{\textgreatereq}{$\geq$}
 \newcommand{\textlesseq}{$\leq$}
 
-% Change all autoref variants below chapter to use "section"
-\def\subsectionautorefname{section}
-\def\subsubsectionautorefname{section}
-\def\paragraphautorefname{section}
-\def\subparagraphautorefname{section}
+% Change all \cref and \Cref variants below chapter to use "section"
+\crefname{subsection}{section}{sections}
+\Crefname{subsection}{Section}{Sections}
+\crefname{subsubsection}{section}{sections}
+\Crefname{subsubsection}{Section}{Sections}
+\crefname{paragraph}{section}{sections}
+\Crefname{paragraph}{Section}{Sections}
+\crefname{subparagraph}{section}{sections}
+\Crefname{subparagraph}{Section}{Sections}
+
+\newcommand{\crefnameref}[1]{\cref{#1}~\emph{\nameref*{#1}}}
+\newcommand{\Crefnameref}[1]{\Cref{#1}~\emph{\nameref*{#1}}}
 
 % Make all description lists break the line after each key.
 % henrikt-ma: Commenting out use of the enumitem package, see above.

--- a/preamble.tex
+++ b/preamble.tex
@@ -79,8 +79,6 @@
 %\usepackage{enumitem} % Package not available for continuous integration builds.
 \usepackage{color}
 \usepackage[table]{xcolor}
-%\def\doublelabel#1{\label{#1}\hypertarget{#1}{}}
-\def\doublelabel#1{\label{#1}}
 \def\S0#1#2{\hypertarget{#2}\chapter{#1}\label{#2}}
 \def\S1#1#2{\hypertarget{#2}\section{#1}\label{#2}}
 \def\S2#1#2{\hypertarget{#2}\subsection{#1}\label{#2}}

--- a/preamble.tex
+++ b/preamble.tex
@@ -141,6 +141,7 @@
 \newcommand{\bibitemtitle}[1]{\emph{#1}}
 
 \usepackage[nameinlink,noabbrev]{cleveref}
+\def\autoref#1{\errmessage{You are not supposed to use \autoref; use \cref or \Cref instead.}}
 
 % Environment for definitions.
 \usepackage{amsthm}

--- a/preamble.tex
+++ b/preamble.tex
@@ -323,8 +323,12 @@
 \Crefname{paragraph}{Section}{Sections}
 \crefname{subparagraph}{section}{sections}
 \Crefname{subparagraph}{Section}{Sections}
-\crefname{equation}{}{}
-\Crefname{equation}{}{}
+
+% We can't use cleveref.sty the way we want for equations until this LaTeXML has been fixed:
+% - https://github.com/brucemiller/LaTeXML/issues/1306
+% In the meantime, we use \eqref to achieve the same result.
+%\crefname{equation}{}{}
+%\Crefname{equation}{}{}
 
 \newcommand{\crefnameref}[1]{\cref{#1}~\emph{\nameref*{#1}}}
 \newcommand{\Crefnameref}[1]{\Cref{#1}~\emph{\nameref*{#1}}}


### PR DESCRIPTION
The _cleveref.sty_ package provides better alternatives to `\autoref`, most importantly allowing cross references to be placed at the beginning of a sentence without forcing all link text to start with an uppercase letter.  It also unifies the formatting of all cross references using a single but flexible mechanism, and is supported by LaTeXML.
