### PR TITLE
Restore2597

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -858,7 +858,7 @@ parameter Real t(unit="s", displayUnit="ms") = 0.1
   The intent is that the text is easily readable,
   thus if \lstinline!par! is of an enumeration type, replace \lstinline!%par! by the item name,
   not by the full name.
-   \begin{example}
+  \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \lstinline!%par! should be displayed as \emph{Periodic}.
   \end{example}
   The form \%\{\emph{par\}} allows component-references, and can be directly

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -842,7 +842,7 @@ and using the longest sequence of identifier characters - alphanumeric and under
 \item
   \%\% replaced by \%
 \item
-  \%name replaced by the name of the component (i.e. the identifier for
+  \%name replaced by the name of the component (i.e., the identifier for
   it in the enclosing class).
 \item
   \%class replaced by the name of the class (only the last part of the hierarchical name).

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -835,10 +835,20 @@ with transparent background and no border around the text (and without
 outline). The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.
 
 There are a number of common macros that can be used in the text, and
-they should be replaced when displaying the text as follows:
+they should be replaced when displaying the text as follows (in order so that the ones highest up has priority,
+and using the longest sequence of identifier characters - alphanumeric and \_):
+
 \begin{itemize}
 \item
-  \%\emph{par} and \%\{\emph{par\}} replaced by the value of the parameter \lstinline!par!.
+  \%\% replaced by \%
+\item
+  \%name replaced by the name of the component (i.e.\ the identifier for
+  it in in the enclosing class).
+\item
+  \%class replaced by the name of the class (only the last part of the hierarchical name).
+\item
+  \%\emph{par} and \%\{\emph{par\}} replaced by the value of the
+  parameter \lstinline!par!.
   If the value is numeric, tools shall display the value with \lstinline!displayUnit!, formatted according to bipm-specification.
   E.g., for
 \begin{lstlisting}[language=modelica]
@@ -848,20 +858,13 @@ parameter Real t(unit="s", displayUnit="ms") = 0.1
   The intent is that the text is easily readable,
   thus if \lstinline!par! is of an enumeration type, replace \lstinline!%par! by the item name,
   not by the full name.
-  \begin{example}
+   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \lstinline!%par! should be displayed as \emph{Periodic}.
   \end{example}
   The form \%\{\emph{par\}} allows component-references, and can be directly
   followed by a letter. Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w!
   directly followed by \emph{x} and the value of \lstinline!h! -- and \lstinline!%wxh! gives the value of the
   parameter \lstinline!wxh!. If the parameter does not exist it is an error.
-\item
-  \%\% replaced by \%
-\item
-  \%name replaced by the name of the component (i.e.\ the identifier for
-  it in in the enclosing class).
-\item
-  \%class replaced by the name of the class (only the last part of the hierarchical name).
 \end{itemize}
 
 The style attribute \lstinline!fontSize! specifies the font size. If the \lstinline!fontSize!

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -835,15 +835,15 @@ with transparent background and no border around the text (and without
 outline). The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.
 
 There are a number of common macros that can be used in the text, and
-they should be replaced when displaying the text as follows (in order so that the ones highest up has priority,
+they should be replaced when displaying the text as follows (in order such that the earliest ones have precedence,
 and using the longest sequence of identifier characters - alphanumeric and \_):
 
 \begin{itemize}
 \item
   \%\% replaced by \%
 \item
-  \%name replaced by the name of the component (i.e.\ the identifier for
-  it in in the enclosing class).
+  \%name replaced by the name of the component (i.e. the identifier for
+  it in the enclosing class).
 \item
   \%class replaced by the name of the class (only the last part of the hierarchical name).
 \item

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -861,7 +861,7 @@ parameter Real t(unit="s", displayUnit="ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \lstinline!%par! should be displayed as \emph{Periodic}.
   \end{example}
-  The form \%\{\emph{par\}} allows component-references, and can be directly
+  The form \%\{\emph{par\}} allows component-references and is required for quoted identifiers, and can be directly
   followed by a letter. Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w!
   directly followed by \emph{x} and the value of \lstinline!h! -- and \lstinline!%wxh! gives the value of the
   parameter \lstinline!wxh!. If the parameter does not exist it is an error.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -836,7 +836,7 @@ outline). The contents inherited from \lstinline!FilledShape! is deprecated, but
 
 There are a number of common macros that can be used in the text, and
 they should be replaced when displaying the text as follows (in order such that the earliest ones have precedence,
-and using the longest sequence of identifier characters - alphanumeric and \_):
+and using the longest sequence of identifier characters - alphanumeric and underscore):
 
 \begin{itemize}
 \item


### PR DESCRIPTION
Closes #2597 
Note that on master i.e. was changed to i.e.\ but on this branch it was changed to i.e., and this is seen as stylistically better and there is no need for both.
