### PR TITLE
Allow Dialog for classes as well, with restriction.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1159,7 +1159,7 @@ an obsolete class (as a base-class or as the class of one of the components)
 that shall be updated - ideally without impacting users of the class.
 If that is not possible the current class can have also have an obsolete-annotation.
 
-A component declaration may have the following annotations:
+A component declaration may have the following annotation:
 \begin{lstlisting}[language=modelica]
 annotation(unassignedMessage = "message");
 \end{lstlisting}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1198,7 +1198,7 @@ annotation(Dialog(enable = true, tab = "General",
                   connectorSizing = false));
 \end{lstlisting}
 For a short replaceable class definition only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and
-\lstinline!groupImage! are supported.
+\lstinline!groupImage! are allowed.
 
 The annotations \lstinline!tab! and \lstinline!group! define the placement of
 the component or of variables in a dialog with optional tab and group

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1188,7 +1188,7 @@ end Frame;
 \end{lstlisting}
 \end{example}
 
-A component or a short replaceable class may have the following annotation:
+A component declaration or a short replaceable class definition may have the following annotation:
 \begin{lstlisting}[language=modelica]
 annotation(Dialog(enable = true, tab = "General",
                   group = "",
@@ -1197,7 +1197,7 @@ annotation(Dialog(enable = true, tab = "General",
                   groupImage="modelica://MyPackage/Resources/Images/switch.png",
                   connectorSizing = false));
 \end{lstlisting}
-For a short replaceable class only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and
+For a short replaceable class definition only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and
 \lstinline!groupImage! are supported.
 
 The annotations \lstinline!tab! and \lstinline!group! define the placement of

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1159,7 +1159,7 @@ an obsolete class (as a base-class or as the class of one of the components)
 that shall be updated - ideally without impacting users of the class.
 If that is not possible the current class can have also have an obsolete-annotation.
 
-A declaration may have the following annotations:
+A component declaration may have the following annotations:
 \begin{lstlisting}[language=modelica]
 annotation(unassignedMessage = "message");
 \end{lstlisting}
@@ -1188,6 +1188,7 @@ end Frame;
 \end{lstlisting}
 \end{example}
 
+A component or a short replaceable class may have the following annotation:
 \begin{lstlisting}[language=modelica]
 annotation(Dialog(enable = true, tab = "General",
                   group = "",
@@ -1196,6 +1197,8 @@ annotation(Dialog(enable = true, tab = "General",
                   groupImage="modelica://MyPackage/Resources/Images/switch.png",
                   connectorSizing = false));
 \end{lstlisting}
+For a short replaceable class only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and
+\lstinline!groupImage! are supported.
 
 The annotations \lstinline!tab! and \lstinline!group! define the placement of
 the component or of variables in a dialog with optional tab and group


### PR DESCRIPTION
This allows Dialog with group, tab, enable, groupImage for replaceable types.
Also slightly clarifies the previous annotation.
Closes #2617

Note that since this is an actual change we should vote on it before accepting it.