### PR TITLE
Just install cleveref.sty on 'master'

### DIFF
--- a/.CI/latexml/Dockerfile
+++ b/.CI/latexml/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i s,http://archive.ubuntu.com/ubuntu/,mirror://mirrors.ubuntu.com/mirro
  && $INSTALL/install-tl --profile texlive.profile \
  && rm texlive.profile \
  && tlmgr update --self --all --reinstall-forcibly-removed \
- && tlmgr install latexmk listings xcolor float multirow tocloft parskip etoolbox \
+ && tlmgr install latexmk listings cleveref xcolor float multirow tocloft parskip etoolbox \
  && cpanm JSON \
  && cpanm LaTeXML \
  && apt-get autoremove -qy make gcc curl wget git cpanminus libxml2-dev libxslt-dev \


### PR DESCRIPTION
As I'm not sure that this commit had the intended effect when appearing in the PR branch of #2611, I'm trying to install the package first on the _master_ branch (without using the package, since that would prevent merging this PR due do a failing CI check).  Hopefully, this will at the same time fix the CI build of #2611.
