### PR TITLE
Define meaning of empty Axis.unit

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -169,6 +169,9 @@ end Axis;
 
 When an axis bound isn't provided, the tool computes one automatically.  When \lstinline!min! or \lstinline!max! is specified, it is an error to leave \lstinline!unit! empty.
 
+An empty \lstinline!unit! means that each expression plotted against it uses its own \lstinline!displayUnit!.  It is not required that the different expressions have compatible units; instead a unitless
+axis may be used, with unit information attached to curve legends instead.
+
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty.
 
 When an axis label isn't provided, the tool produces a default label.  Providing the empty string as axis label means that no label should be shown.  Variable replacements, as described in

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -169,16 +169,12 @@ end Axis;
 
 When an axis bound isn't provided, the tool computes one automatically.
 
-The Modelica tool is responsible for showing the unit used for values at the
-axis tick marks, so the axis \lstinline!label! shall not contain the unit.
-
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a
 warning and treat the \lstinline!unit! as if it was not specified.
 
-When an axis label isn't provided, the tool produces a default label. Providing
-the empty string as axis label means that no label should be shown. Variable
-replacements, as described in \cref{variable-replacements}, can be used in
-the \lstinline!label! of \lstinline!Axis!
+When an axis label isn't provided, the tool produces a default label.  Providing the empty string as axis label means that no label should be shown.  Variable replacements, as described in
+\cref{variable-replacements}, can be used in the \lstinline!label! of \lstinline!Axis!  The Modelica tool is responsible for showing the unit used for values at the axis tick marks, so the axis
+\lstinline!label! shall not contain the unit.
 
 \subsubsection{Plot Curves}\label{plot-curves}
 The actual data to plot is specified in the \lstinline!curves! of a \lstinline!Plot!:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -177,7 +177,7 @@ When \lstinline!unit! is empty, and axis bounds are to be determined automatical
 user, on the other hand, a tool may choose a unit for the variable such that the range of the variable values (expressed in the chosen unit) fit nicely with the range of the unitless axis.
 \end{nonnormative}
 
-If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty.
+If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty, as well as ignore any setting for \lstinline!min! and \lstinline!max!.
 
 When an axis label isn't provided, the tool produces a default label.  Providing the empty string as axis label means that no label should be shown.  Variable replacements, as described in
 \cref{variable-replacements}, can be used in the \lstinline!label! of \lstinline!Axis!  The Modelica tool is responsible for showing the unit used for values at the axis tick marks, so the axis

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -162,15 +162,14 @@ Properties may be defined for each \lstinline!Plot! axis:
 record Axis
   Real min "Axis lower bound";
   Real max "Axis upper bound";
-  String unit "Unit of min and max";
+  String unit = "" "Unit of min and max";
   String label "Axis label";
 end Axis;
 \end{lstlisting}
 
-When an axis bound isn't provided, the tool computes one automatically.  When \lstinline!min! or \lstinline!max! is specified, it is an error to leave \lstinline!unit! unspecified.
+When an axis bound isn't provided, the tool computes one automatically.  When \lstinline!min! or \lstinline!max! is specified, it is an error to leave \lstinline!unit! empty.
 
-If a tool does not recognize the \lstinline!unit!, it is recommended to issue a
-warning and treat the \lstinline!unit! as if it was not specified.
+If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty.
 
 When an axis label isn't provided, the tool produces a default label.  Providing the empty string as axis label means that no label should be shown.  Variable replacements, as described in
 \cref{variable-replacements}, can be used in the \lstinline!label! of \lstinline!Axis!  The Modelica tool is responsible for showing the unit used for values at the axis tick marks, so the axis
@@ -189,9 +188,8 @@ end Curve;
 The mandatory \lstinline!x! and \lstinline!y! expressions are restricted to be
 component references refering to a scalar variable or \lstinline!time!. It
 is an error if \lstinline!x! or \lstinline!y! does not designate a scalar variable.
-It is an error if the unit of an expression (i.e., a variable's \lstinline!unit!,
-or second for \lstinline!time!) is incompatible with the \lstinline!unit! of the
-corresponding axis.
+When the \lstinline!unit! of an \lstinline!Axis! is non-empty, it is an error if the unit of the corresponding \lstinline!Curve! expression (i.e., a variable's \lstinline!unit!,
+or second for \lstinline!time!) is incompatible with the axis unit.
 
 When \lstinline!legend! isn't provided, the tool produces a default based on
 \lstinline!x! and/or \lstinline!y!.  Providing the empty string as

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -167,7 +167,7 @@ record Axis
 end Axis;
 \end{lstlisting}
 
-When an axis bound isn't provided, the tool computes one automatically.
+When an axis bound isn't provided, the tool computes one automatically.  When \lstinline!min! or \lstinline!max! is specified, it is an error to leave \lstinline!unit! unspecified.
 
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a
 warning and treat the \lstinline!unit! as if it was not specified.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -167,10 +167,15 @@ record Axis
 end Axis;
 \end{lstlisting}
 
-When an axis bound isn't provided, the tool computes one automatically.  When \lstinline!min! or \lstinline!max! is specified, it is an error to leave \lstinline!unit! empty.
+When an axis bound isn't provided, the tool computes one automatically.
 
-An empty \lstinline!unit! means that each expression plotted against it uses its own \lstinline!displayUnit!.  It is not required that the different expressions have compatible units; instead a unitless
-axis may be used, with unit information attached to curve legends instead.
+An empty \lstinline!unit! means that the axis is unitless, and each expression plotted against it may use its own unit determined by the tool.  The tool is responsible for conveying the information
+about choice of unit for the different variables, for instance by attaching this information to curve legends.
+
+\begin{nonnormative}
+When \lstinline!unit! is empty, and axis bounds are to be determined automatically, a natural choice of unit could be the variable's \lstinline!displayUnit!.  When axis bounds are specified by the
+user, on the other hand, a tool may choose a unit for the variable such that the range of the variable values (expressed in the chosen unit) fit nicely with the range of the unitless axis.
+\end{nonnormative}
 
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty.
 


### PR DESCRIPTION
This PR tries to address the problem that it is currently not allowed to leave the `unit` of an `Axis` empty, which in turn must be interpreted as also the axis specifications `x` and `y` of a `Plot` being mandatory.  I don't think it was intended to add the burden of specifying axes for every `Plot`, and specifying that it means to leave the `unit` empty opens up for an interesting feature currently not present in the MCP.

This PR is a follow-up to #2579.