### PR TITLE
Mandate that Axis.unit is used for axis tick labels

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -160,17 +160,16 @@ the variable replacements described in \cref{variable-replacements}.
 Properties may be defined for each \lstinline!Plot! axis:
 \begin{lstlisting}[language=modelica]
 record Axis
-  Real min "Axis lower bound";
-  Real max "Axis upper bound";
-  String unit "Unit of min and max";
+  Real min "Axis lower bound, in 'unit'";
+  Real max "Axis upper bound, in 'unit'";
+  String unit "Unit of axis tick labels";
   String label "Axis label";
 end Axis;
 \end{lstlisting}
 
 When an axis bound isn't provided, the tool computes one automatically.
 
-The Modelica tool is responsible for showing the unit used for values at the
-axis tick marks, so the axis \lstinline!label! shall not contain the unit.
+The Modelica tool is responsible for showing that values at the axis tick marks are expressed in \lstinline!unit!, so the axis \lstinline!label! shall not contain this information.
 
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a
 warning and treat the \lstinline!unit! as if it was not specified.


### PR DESCRIPTION
When working on #2632 – what it means to not specify `unit` – we got aware that we were also missing the important meaning of _only_ specifying `unit` for an `Axis`.  More generally, the `unit` should serve two independent purposes:
- It is the unit in which to express values showed on the axis tick labels.
- It is the unit used to define the axis boundaries `min` and `max`.
