### PR TITLE
When speaking of when-equations, don't say "when-statements"

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -279,7 +279,7 @@ variable.  The start-value of the special functions \lstinline!initial!, \lstinl
 
 \begin{itemize}
 \item
-  When-statements may not occur inside initial equations.
+  When-equations may not occur inside initial equations.
 \item
   When-equations cannot be nested.
 \end{itemize}


### PR DESCRIPTION
(For when-statements, we already have the corresponding rule listed in 11.2.7.1 _Restrictions on When-Statements_.)
