### PR TITLE
Clarify HTML encoded contents.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -50,10 +50,10 @@ giving a textual description, the \lstinline!revisions! annotation giving a list
 of revisions and other annotations defined by a tool.
 How the tool interprets the information in \lstinline!Documentation! is
 unspecified. If the string starts with the tag
-\lstinline!</html>! or \lstinline!<HTML>! the entire contents is HTML encoded
+\lstinline!<html>! or \lstinline!<HTML>! the entire string is HTML encoded
 (and is assumed to end with \lstinline!</html>! or \lstinline!</HTML>! and shall
 be rendered as HTML even if the end-tags are missing),
-otherwise the entire contents is rendered as is.
+otherwise the entire string is rendered as is.
 The HTML encoded content may contain links. For external
 links see \cref{external-resources}. Links to Modelica classes may be defined with
 the HTML link command using scheme \lstinline!Modelica!

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -49,10 +49,12 @@ The \lstinline!Documentation! annotation can contain the \lstinline!info! annota
 giving a textual description, the \lstinline!revisions! annotation giving a list
 of revisions and other annotations defined by a tool.
 How the tool interprets the information in \lstinline!Documentation! is
-unspecified. Within a string of the \lstinline!Documentation! annotation, the
-tags \lstinline!<HTML>! and \lstinline!</HTML>! or
-\lstinline!<html>! and \lstinline!</html>! define
-optionally begin and end of content that is HTML encoded. For external
+unspecified. If the string starts with the tag
+\lstinline!</html>! or \lstinline!<HTML>! the entire contents is HTML encoded
+(and is assumed to end with \lstinline!</html>! or \lstinline!</HTML>! and shall
+be rendered as HTML even if the end-tags are missing),
+otherwise the entire contents is rendered as is.
+The HTML encoded content may contain links. For external
 links see \cref{external-resources}. Links to Modelica classes may be defined with
 the HTML link command using scheme \lstinline!Modelica!
 (using its lower case form in the URI, see \cref{external-resources}), e.g.,


### PR DESCRIPTION
Closes #2593

Note: Whether `</html>` is required or not is still a bit unclear. The important part is that the contents is rendered the same regardless of that, we can later either clarify that it is not required - or that it is required (but the documentation should still be rendered as if it were present). The <HTML> variant was also part of the original text.