### PR TITLE
Improve formatting

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1420,14 +1420,14 @@ earlier version to a current one.
 Version numbers are of the forms:
 \begin{itemize}
 \item
-  Main release versions: """ \lstinline!UNSIGNED-INTEGER! \{ "." \lstinline!UNSIGNED-INTEGER! \} """\\
-  Example: "2.1"
+  Main release versions: \lstinline!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } """!\\
+  Example: \lstinline!"2.1"!
 \item
-  Pre-release versions: """ \lstinline!UNSIGNED-INTEGER! \{ "." \lstinline!UNSIGNED-INTEGER! \} " " \{\lstinline!S-CHAR!\} """\\
-  Example: "2.1 Beta 1"
+  Pre-release versions: \lstinline!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } " " {S-CHAR} """!\\
+  Example: \lstinline!"2.1 Beta 1"!
 \item
-  Un-ordered versions: """ \lstinline!NON-DIGIT! \{\lstinline!S-CHAR!\} """\\
-  Example: "Test 1"
+  Un-ordered versions: \lstinline!""" NON-DIGIT {S-CHAR} """!\\
+  Example: \lstinline!"Test 1"!
 \end{itemize}
 
 The main release versions are ordered using the hierarchical numerical

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -120,7 +120,7 @@ The annotations listed below, appearing directly inside \lstinline!annotation($\
 \end{center}
 
 \begin{annotationdefinition}[Evaluate]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "Evaluate" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -137,7 +137,7 @@ If \lstinline!Evaluate = false!, the model developer proposes to not utilize the
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[HideResult]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "HideResult" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -154,7 +154,7 @@ For example, a tool is not expected to provide means to plot a variable with \ls
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[Inline]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "Inline" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -171,7 +171,7 @@ If \lstinline!Inline = true!, the model developer proposes to not inline the fun
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[LateInline]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "LateInline" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -198,7 +198,7 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[InlineAfterIndexReduction]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "InlineAfterIndexReduction" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -209,7 +209,7 @@ If \lstinline!true!, the model developer proposes to inline the function after t
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[GenerateEvents]
-\begin{synopsis}[grammar]\begin{lstlisting}
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "GenerateEvents" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -224,9 +224,9 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[smoothOrder]
-\begin{synopsis}[grammar]\begin{lstlisting}
-smoothOrder "=" UNSIGNED-NUMBER ")"
-smoothOrder "(" normallyConstant "=" IDENT [ "," normallyConstant "=" IDENT ] ")" "=" UNSIGNED-NUMBER ")"
+\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+"smoothOrder" "=" UNSIGNED-NUMBER ")"
+"smoothOrder" "(" "normallyConstant" "=" IDENT [ "," "normallyConstant" "=" IDENT ] ")" "=" UNSIGNED-NUMBER ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 This annotation has only an effect within a function declaration.
@@ -254,10 +254,10 @@ experiment-annotation:
       {"," experimentOption}] ")" ] ")"
 
 experimentOption:
-  StartTime "=" [ "+" | "-" ] UNSIGNED-NUMBER |
-  StopTime  "=" [ "+"  | "-"] UNSIGNED-NUMBER |
-  Interval "=" UNSIGNED-NUMBER |
-  Tolerance "=" UNSIGNED-NUMBER
+  "StartTime" "=" [ "+" | "-" ] UNSIGNED-NUMBER |
+  "StopTime"  "=" [ "+"  | "-"] UNSIGNED-NUMBER |
+  "Interval" "=" UNSIGNED-NUMBER |
+  "Tolerance" "=" UNSIGNED-NUMBER
 \end{lstlisting}
 
 The experiment annotation defines the default start time (StartTime) in

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1420,13 +1420,13 @@ earlier version to a current one.
 Version numbers are of the forms:
 \begin{itemize}
 \item
-  Main release versions: \lstinline!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } """!\\
+  Main release versions: \lstinline[language=grammar]!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } """!\\
   Example: \lstinline!"2.1"!
 \item
-  Pre-release versions: \lstinline!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } " " {S-CHAR} """!\\
+  Pre-release versions: \lstinline[language=grammar]!""" UNSIGNED-INTEGER { "." UNSIGNED-INTEGER } " " {S-CHAR} """!\\
   Example: \lstinline!"2.1 Beta 1"!
 \item
-  Un-ordered versions: \lstinline!""" NON-DIGIT {S-CHAR} """!\\
+  Un-ordered versions: \lstinline[language=grammar]!""" NON-DIGIT {S-CHAR} """!\\
   Example: \lstinline!"Test 1"!
 \end{itemize}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -120,7 +120,7 @@ The annotations listed below, appearing directly inside \lstinline!annotation($\
 \end{center}
 
 \begin{annotationdefinition}[Evaluate]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "Evaluate" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -137,7 +137,7 @@ If \lstinline!Evaluate = false!, the model developer proposes to not utilize the
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[HideResult]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "HideResult" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -154,7 +154,7 @@ For example, a tool is not expected to provide means to plot a variable with \ls
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[Inline]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "Inline" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -171,7 +171,7 @@ If \lstinline!Inline = true!, the model developer proposes to not inline the fun
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[LateInline]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "LateInline" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -198,7 +198,7 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[InlineAfterIndexReduction]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "InlineAfterIndexReduction" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -209,7 +209,7 @@ If \lstinline!true!, the model developer proposes to inline the function after t
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[GenerateEvents]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "GenerateEvents" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -224,7 +224,7 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[smoothOrder]
-\begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
+\begin{synopsis}[grammar]\begin{lstlisting}
 "smoothOrder" "=" UNSIGNED-NUMBER ")"
 "smoothOrder" "(" "normallyConstant" "=" IDENT
             { "," "normallyConstant" "=" IDENT } ")" "=" UNSIGNED-NUMBER ")"

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -108,13 +108,13 @@ The annotations listed below, appearing directly inside \lstinline!annotation($\
 \tablehead{Annotation} & \tablehead{Description} & \tablehead{Details}\\
 \hline
 \hline
-\lstinline[language=grammar]!"Evaluate"! & Use parameter value for symbolic processing & \Cref{modelica:Evaluate}\\
-\lstinline[language=grammar]!"HideResult"! & Don't show component's simulator result & \Cref{modelica:HideResult}\\
-\lstinline[language=grammar]!"Inline"! & Inline function & \Cref{modelica:Inline}\\
-\lstinline[language=grammar]!"LateInline"! & Inline after all symbolic transformations & \Cref{modelica:LateInline}\\
-\lstinline[language=grammar]!"InlineAfterIndexReduction"! & Inline after index reduction & \Cref{modelica:InlineAfterIndexReduction}\\
-\lstinline[language=grammar]!"GenerateEvents"! & Generate events for zero crossings in function & \Cref{modelica:GenerateEvents}\\
-\lstinline[language=grammar]!"smoothOrder"! & Function smoothness guarantee & \Cref{modelica:smoothOrder}\\
+\lstinline!Evaluate! & Use parameter value for symbolic processing & \Cref{modelica:Evaluate}\\
+\lstinline!HideResult! & Don't show component's simulator result & \Cref{modelica:HideResult}\\
+\lstinline!Inline! & Inline function & \Cref{modelica:Inline}\\
+\lstinline!LateInline! & Inline after all symbolic transformations & \Cref{modelica:LateInline}\\
+\lstinline!InlineAfterIndexReduction! & Inline after index reduction & \Cref{modelica:InlineAfterIndexReduction}\\
+\lstinline!GenerateEvents! & Generate events for zero crossings in function & \Cref{modelica:GenerateEvents}\\
+\lstinline!smoothOrder! & Function smoothness guarantee & \Cref{modelica:smoothOrder}\\
 \hline
 \end{tabular}
 \end{center}
@@ -227,7 +227,7 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "smoothOrder" "=" UNSIGNED-NUMBER ")"
 "smoothOrder" "(" "normallyConstant" "=" IDENT 
-             { "," "normallyConstant" "=" IDENT } ")" "=" UNSIGNED-NUMBER ")"
+            { "," "normallyConstant" "=" IDENT } ")" "=" UNSIGNED-NUMBER ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 This annotation has only an effect within a function declaration.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -43,7 +43,7 @@ vendor-specific annotations.
 
 \begin{lstlisting}[language=grammar]
 documentation-annotation:
-   annotation "(" Documentation "(" "info" "=" STRING 
+   annotation "(" Documentation "(" "info" "=" STRING
                                ["," "revisions" "=" STRING ] ")" ")"
 \end{lstlisting}
 The \lstinline!Documentation! annotation can contain the \lstinline!info! annotation
@@ -226,7 +226,7 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \begin{annotationdefinition}[smoothOrder]
 \begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "smoothOrder" "=" UNSIGNED-NUMBER ")"
-"smoothOrder" "(" "normallyConstant" "=" IDENT 
+"smoothOrder" "(" "normallyConstant" "=" IDENT
             { "," "normallyConstant" "=" IDENT } ")" "=" UNSIGNED-NUMBER ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
@@ -1610,7 +1610,7 @@ function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mu=4);
 \begin{lstlisting}[language=modelica]
 convertModifiers("OldClass",
 {"OldModifier1=default1", "OldModifier2=default2", ...},
-{"NewModifier1=...%OldModifier2%...", "NewModifier2=...", ...} 
+{"NewModifier1=...%OldModifier2%...", "NewModifier2=...", ...}
   [, simplify=true] )
 \end{lstlisting}
 
@@ -1689,7 +1689,7 @@ convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
    {"hideConnector"}, {"use_numberPort=not %hideConnector%"})
 
 convertModifiers("Modelica.Blocks.Math.LinearDependency",
-   {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"}, 
+   {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"},
    true)
 convertClass(
    "Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines",
@@ -1776,7 +1776,7 @@ String dateModified  "UTC date and time of the latest change to the package
                       in the following format (with one space between date
                       and time): YYYY-MM-DD hh:mm:ssZ";
 String revisionId    "Revision identifier of the version management system used
-                      to manage this library. It marks the latest submitted 
+                      to manage this library. It marks the latest submitted
                       change to any file belonging to the package";
 \end{lstlisting}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -43,7 +43,8 @@ vendor-specific annotations.
 
 \begin{lstlisting}[language=grammar]
 documentation-annotation:
-   annotation "(" Documentation "(" "info" "=" STRING ["," "revisions" "=" STRING ] ")" ")"
+   annotation "(" Documentation "(" "info" "=" STRING 
+                               ["," "revisions" "=" STRING ] ")" ")"
 \end{lstlisting}
 The \lstinline!Documentation! annotation can contain the \lstinline!info! annotation
 giving a textual description, the \lstinline!revisions! annotation giving a list
@@ -1162,11 +1163,12 @@ end Frame;
 
 A component declaration or a short replaceable class definition may have the following annotation:
 \begin{lstlisting}[language=modelica]
-annotation(Dialog(enable = true, tab = "General",
+annotation(Dialog(enable = true,
+                  tab = "General",
                   group = "",
                   showStartAttribute = false,
                   colorSelector = false,
-                  groupImage="modelica://MyPackage/Resources/Images/switch.png",
+                  groupImage="modelica://MyPackage/Resources/Images/load.png",
                   connectorSizing = false));
 \end{lstlisting}
 For a short replaceable class definition only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and
@@ -1504,8 +1506,9 @@ required when upgrading.
 
 \subsubsection{Conversion rules}\label{conversion-rules}
 
+% Using mbox to avoid having line starting with ","
 There are a number of functions: \lstinline!convertClass!, \lstinline!convertClassIf!,
-\lstinline!convertElement!, \lstinline!convertModifiers!, \lstinline!convertMessage! defined as follows. The
+\lstinline!convertElement!, \mbox{\lstinline!convertModifiers!,} \lstinline!convertMessage! defined as follows. The
 calls of these functions do not directly convert, instead they define
 conversion rules as below. The order between the function calls does not
 matter, instead the longer paths (in terms number of hierarchical names)
@@ -1606,7 +1609,8 @@ function f=Modelica.Mechanics.MultiBody.World.gravityAcceleration(mu=4);
 \begin{lstlisting}[language=modelica]
 convertModifiers("OldClass",
 {"OldModifier1=default1", "OldModifier2=default2", ...},
-{"NewModifier1=...%OldModifier2%...", "NewModifier2=...", ...} [, simplify=true] )
+{"NewModifier1=...%OldModifier2%...", "NewModifier2=...", ...} 
+  [, simplify=true] )
 \end{lstlisting}
 
 Normal case; if any modifier among \lstinline!OldModifier! exist then replace all of
@@ -1672,22 +1676,24 @@ using the parameter.
 The conversion
 \begin{lstlisting}[language=modelica]
 convertClass("Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe",
-              "Modelica.Thermal.FluidHeatFlow.Components.Pipe")
+             "Modelica.Thermal.FluidHeatFlow.Components.Pipe")
 convertModifiers({"Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe"},
-                 fill("",0), {"useHeatPort=false"})
+   fill("",0), {"useHeatPort=false"})
 
 convertClass("Modelica.StateGraph.Temporary.NumericValue",
-              "Modelica.Blocks.Interaction.Show.RealValue")
+             "Modelica.Blocks.Interaction.Show.RealValue")
 convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
-                  {"Value"}, {"number=%Value%"})
+   {"Value"}, {"number=%Value%"})
 convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
-                  {"hideConnector"}, {"use_numberPort=not %hideConnector%"})
+   {"hideConnector"}, {"use_numberPort=not %hideConnector%"})
 
 convertModifiers("Modelica.Blocks.Math.LinearDependency",
-                 {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"}, true)
-convertClass("Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines",
-              "Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines")
-convertElement({"Modelica.Electrical.Machines.Interfaces.PartialBasicDCMachine"},
+   {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"}, 
+   true)
+convertClass(
+   "Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines",
+   "Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines")
+convertElement("Modelica.Electrical.Machines.Interfaces.PartialBasicDCMachine",
                 "quasiStationary", "quasiStatic")
 convertElement("Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited",
                 "quasiStationary", "quasiStatic")
@@ -1695,10 +1701,12 @@ convertElement("Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMach
 converts
 \begin{lstlisting}[language=modelica]
 Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe pipe1;
-Modelica.StateGraph.Temporary.NumericValue tempValue(Value=10, hideConnector=true);
+Modelica.StateGraph.Temporary.NumericValue tempValue(Value=10,
+   hideConnector=true);
 Modelica.Blocks.Math.LinearDependency linearDep(y0=2, k2=1);
 model A
-  extends Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited;
+  import Modelica.Electrical.Machines.BasicMachines;
+  extends BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited;
 end A;
 model B
   extends A;
@@ -1711,7 +1719,8 @@ Modelica.Thermal.FluidHeatFlow.Components.Pipe pipe1(useHeatPort=false);
 Modelica.Blocks.Interaction.Show.RealValue(number=10, use_numberPort=not true);
 Modelica.Blocks.Math.LinearDependency linearDep(y0=2, k1=0, k2=2);
 model A
-  extends Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines.DC_ElectricalExcited;
+  import Modelica.Electrical.Machines.BasicMachines;
+  extends BasicMachines.QuasiStaticDCMachines.DC_ElectricalExcited;
 end A;
 model B
   extends A;
@@ -1762,12 +1771,12 @@ version number:
 \begin{lstlisting}[language=modelica]
 String versionDate   "UTC date of first version build (in format: YYYY-MM-DD)";
 Integer versionBuild "Larger number is a more recent maintenance update";
-String dateModified  "UTC date and time of the latest change to the package in the
-                      following format (with one space between date and time):
-                      YYYY-MM-DD hh:mm:ssZ";
+String dateModified  "UTC date and time of the latest change to the package
+                      in the following format (with one space between date
+                      and time): YYYY-MM-DD hh:mm:ssZ";
 String revisionId    "Revision identifier of the version management system used
-                      to manage this library. It marks the latest submitted change to
-                      any file belonging to the package";
+                      to manage this library. It marks the latest submitted 
+                      change to any file belonging to the package";
 \end{lstlisting}
 
 \begin{example}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -226,7 +226,8 @@ This annotation is for example used in \lstinline!Modelica.Media.Water.IF97_Util
 \begin{annotationdefinition}[smoothOrder]
 \begin{synopsis}[grammar]\begin{lstlisting}[language=grammar]
 "smoothOrder" "=" UNSIGNED-NUMBER ")"
-"smoothOrder" "(" "normallyConstant" "=" IDENT [ "," "normallyConstant" "=" IDENT ] ")" "=" UNSIGNED-NUMBER ")"
+"smoothOrder" "(" "normallyConstant" "=" IDENT 
+             { "," "normallyConstant" "=" IDENT } ")" "=" UNSIGNED-NUMBER ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 This annotation has only an effect within a function declaration.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2243,13 +2243,15 @@ package ExternalFunctions
     input Real x;
     output Real y;
     external "C"
-    y=ExternalFunc1_ext(x) annotation(Library="ExternalLib1",Include="#include \"ExternalFunc1.h\"");
+    y=ExternalFunc1_ext(x) annotation(Library="ExternalLib1",
+      Include="#include \"ExternalFunc1.h\"");
   end ExternalFunc1;
 
   function ExternalFunc2
     input Real x;
     output Real y;
-    external "C" annotation(Library="ExternalLib2", Include="#include \"ExternalFunc2.h\"");
+    external "C" annotation(Library="ExternalLib2", 
+      Include="#include \"ExternalFunc2.h\"");
   end ExternalFunc2;
 
   function ExternalFunc3

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2250,7 +2250,7 @@ package ExternalFunctions
   function ExternalFunc2
     input Real x;
     output Real y;
-    external "C" annotation(Library="ExternalLib2", 
+    external "C" annotation(Library="ExternalLib2",
       Include="#include \"ExternalFunc2.h\"");
   end ExternalFunc2;
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -18,15 +18,15 @@ Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
 NONDIGIT = "_" | letters "a" to "z" | letters "A" to "Z"
 STRING = """ { S-CHAR | S-ESCAPE } """
 S-CHAR = see below
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" 
-   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" 
+Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")"
+   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
    | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
 S-ESCAPE = "\'" | "\"" | "\?" | "\\" |
          "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 UNSIGNED-INTEGER = DIGIT { DIGIT }
 UNSIGNED-REAL = UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
-   |  UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ] 
+   |  UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ]
         ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
    |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 \end{lstlisting}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -31,7 +31,7 @@ UNSIGNED-REAL = UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
    |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 \end{lstlisting}
 \textrm{S-CHAR} is any member of the Unicode character set
-(\url{http://www.unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote """, and backslash "\textbackslash{}"
+(\url{http://www.unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote `"', and backslash `\textbackslash{}'.
 
 For identifiers the redundant escapes (`\lstinline!\?!' and `\lstinline!\"!') are the same as the corresponding non-escaped
 variants (`\lstinline!?!' and '\lstinline!"!').  The single quotes are part of an identifier. E.g.\ \lstinline!'x'! and

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -18,16 +18,17 @@ Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
 NONDIGIT = "_" | letters "a" to "z" | letters "A" to "Z"
 STRING = """ { S-CHAR | S-ESCAPE } """
 S-CHAR = see below
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" | "," |
-         "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" |
-        "{" | "}" | "|" | "~" | " " | """
+Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" 
+   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" 
+   | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
 S-ESCAPE = "\'" | "\"" | "\?" | "\\" |
          "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 UNSIGNED-INTEGER = DIGIT { DIGIT }
 UNSIGNED-REAL = UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
-     |  UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ] ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
-     |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
+   |  UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ] 
+        ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
+   |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 \end{lstlisting}
 \textrm{S-CHAR} is any member of the Unicode character set
 (\url{http://www.unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote """, and backslash "\textbackslash{}"


### PR DESCRIPTION
A number of minor stylistic improvements.
Made as separate commits to make it easier to discuss them individually.
I agree that manual line-breaking is a bit bad, but for code it seems ok.