### PR TITLE
Cleanup listings related to external-clauses

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1743,7 +1743,7 @@ package Modelica
 end Modelica;
 
 model UserModel
-  parameter Real p=Modelica.Math.sin(2);
+  parameter Real p = Modelica.Math.sin(2);
 end UserModel;
 \end{lstlisting}
 \end{example}
@@ -2088,7 +2088,7 @@ of the function).
 function foo
   input Real x;
   input Real y;
-  output Real z=x;
+  output Real z = x;
   external "FORTRAN 77"
     myfoo(x, y, z);
 end foo;
@@ -2099,20 +2099,20 @@ function f
   input Real a;
   output Real b;
 algorithm
-  b:=foo(a,a);
-  b:=foo(b,2*b);
+  b := foo(a, a);
+  b := foo(b, 2 * b);
 end f;
 \end{lstlisting}
 can on most systems be transformed into the following C function:
 \begin{lstlisting}[language=C]
 double f(double a) {
-  extern void myfoo_(double*,double*,double*);
-  double b,temp1,temp2;
+  extern void myfoo_(double*, double*, double*);
+  double b, temp1, temp2;
 
-  myfoo_(&a,&a,&b);
-  temp1=2*b;
-  temp2=b;
-  myfoo_(&b,&temp1,&temp2);
+  myfoo_(&a, &a, &b);
+  temp1 = 2 * b;
+  temp2 = b;
+  myfoo_(&b, &temp1, &temp2);
 
   return temp2;
 }
@@ -2130,7 +2130,7 @@ would have to change the interface function \lstinline!foo! to:
 \begin{lstlisting}[language=modelica]
 function foo
   input Real x;
-  protected Real xtemp=x; // Temporary used because myfoo changes its input
+  protected Real xtemp = x; // Temporary used because myfoo changes its input
   public input Real y;
   output Real z;
   external "FORTRAN 77"
@@ -2145,8 +2145,8 @@ of X3J3/90.4). For the few (if any) FORTRAN~77 compilers that strictly
 follow the standard and are unable to handle aliasing between input
 variables the tool must transform the first call of \lstinline!foo! into:
 \begin{lstlisting}[language=C]
-temp1=a; /* Temporary to avoid aliasing */
-myfoo_(&a,&temp1,&b);
+temp1 = a; /* Temporary to avoid aliasing */
+myfoo_(&a, &temp1, &b);
 \end{lstlisting}
 
 The use of the function \lstinline!foo! in Modelica is uninfluenced by these considerations.
@@ -2232,16 +2232,16 @@ Use of external functions and of object libraries:
 \begin{lstlisting}[language=modelica]
 package ExternalFunctions
   model Example
-    Real x(start=1.0),y(start=2.0);
+    Real x(start = 1.0), y(start = 2.0);
   equation
-    der(x)=-ExternalFunc1(x);
-    der(y)=-ExternalFunc2(y);
+    der(x) = -ExternalFunc1(x);
+    der(y) = -ExternalFunc2(y);
   end Example;
 
   model OtherExample
-    Real x(start=1.0);
+    Real x(start = 1.0);
   equation
-    der(x)=-ExternalFunc3(x);
+    der(x) = -ExternalFunc3(x);
   end OtherExample;
 
   function ExternalFunc1

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1996,7 +1996,7 @@ end fie;
 \end{lstlisting}
 This corresponds to the following C prototype:
 \begin{lstlisting}[language=C]
-double fie(double *, size\_t, size\_t);
+double fie(double *, size_t, size_t);
 \end{lstlisting}
 \end{example}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -362,8 +362,8 @@ end evaluateLinear;
 impure function receiveRealSignal // impure function
   input HardwareDriverID id;
   output Real y;
-  external "C"
-    y = receiveSignal(id);
+external "C"
+  y = receiveSignal(id);
 end receiveRealSignal;
 \end{lstlisting}
 Examples of allowed optimizations of pure functions:
@@ -1700,8 +1700,9 @@ The format of an external function declaration is as follows.
 function IDENT description-string
   { component-clause ";" }
   [ protected { component-clause ";" } ]
-  external [ language-specification ] [
-  external-function-call ] [annotation ] ";"
+external [ language-specification ]
+  [ external-function-call ]
+    [annotation ] ";"
   [ annotation ";" ]
 end IDENT;
 \end{lstlisting}
@@ -1736,8 +1737,8 @@ package Modelica
     function sin
       input Real x;
       output Real y;
-      external "builtin"
-        y = sin(x);
+    external "builtin"
+      y = sin(x);
     end sin;
   end Math;
 end Modelica;
@@ -1934,7 +1935,7 @@ If the external function is written in FORTRAN~77, i.e.:
 function foo
   input Real a[:,:,:];
   output Real x;
-  external "FORTRAN 77";
+external "FORTRAN 77";
 end foo;
 \end{lstlisting}
 the default assumptions correspond to a FORTRAN~77 function
@@ -1966,8 +1967,8 @@ function foo
   input Integer i;
   output Real u1[size(y,1)];
   output Integer u2[size(y,2)];
-  external "FORTRAN 77"
-    myfoo(x, y, size(x,1), size(y,2), u1, i, u2);
+external "FORTRAN 77"
+  myfoo(x, y, size(x,1), size(y,2), u1, i, u2);
 end foo;
 \end{lstlisting}
 The corresponding FORTRAN~77 subroutine would be declared as follows:
@@ -2089,8 +2090,8 @@ function foo
   input Real x;
   input Real y;
   output Real z = x;
-  external "FORTRAN 77"
-    myfoo(x, y, z);
+external "FORTRAN 77"
+  myfoo(x, y, z);
 end foo;
 \end{lstlisting}
 The following Modelica function:
@@ -2133,8 +2134,8 @@ function foo
   protected Real xtemp = x; // Temporary used because myfoo changes its input
   public input Real y;
   output Real z;
-  external "FORTRAN 77"
-    myfoo(xtemp, y, z);
+external "FORTRAN 77"
+  myfoo(xtemp, y, z);
 end foo;
 \end{lstlisting}
 
@@ -2247,8 +2248,8 @@ package ExternalFunctions
   function ExternalFunc1
     input Real x;
     output Real y;
-    external "C"
-      y = ExternalFunc1_ext(x)
+  external "C"
+    y = ExternalFunc1_ext(x)
       annotation(Library = "ExternalLib1",
                  Include = "#include \"ExternalFunc1.h\"");
   end ExternalFunc1;
@@ -2256,7 +2257,7 @@ package ExternalFunctions
   function ExternalFunc2
     input Real x;
     output Real y;
-    external "C"
+  external "C"
       annotation(Library = "ExternalLib2",
                  Include = "#include \"ExternalFunc2.h\"");
   end ExternalFunc2;
@@ -2264,7 +2265,7 @@ package ExternalFunctions
   function ExternalFunc3
     input Real x;
     output Real y;
-    external "C"
+  external "C"
       annotation(Include = "#include \"ExternalFunc3.c\"");
   end ExternalFunc3;
 end ExternalFunctions;
@@ -2379,8 +2380,8 @@ function foo
   input Integer y;
   output Real u1;
   output Integer u2;
-  external "C"
-    myfoo(x, u1, y, u2);
+external "C"
+  myfoo(x, u1, y, u2);
 end foo;
 \end{lstlisting}
 This corresponds to the following C prototype:
@@ -2409,8 +2410,8 @@ function foo
   input Integer y;
   output Real funcvalue;
   output Integer out1;
-  external "C"
-    funcvalue = myfoo(x, y, out1);
+external "C"
+  funcvalue = myfoo(x, y, out1);
 end foo;
 \end{lstlisting}
 This corresponds to the following C prototype:
@@ -2640,14 +2641,14 @@ class MyTable
     input String fileName = "";
     input String tableName = "";
     output MyTable table;
-    external "C"
-      table = initMyTable(fileName, tableName);
+  external "C"
+    table = initMyTable(fileName, tableName);
   end constructor;
 
   function destructor "Release storage of table"
     input MyTable table;
-    external "C"
-      closeMyTable(table);
+  external "C"
+    closeMyTable(table);
   end destructor;
 end MyTable;
 \end{lstlisting}
@@ -2668,8 +2669,8 @@ function interpolateMyTable "Interpolate in table"
   input MyTable table;
   input Real u;
   output Real y;
-  external "C"
-    y = interpolateMyTable(table, u);
+external "C"
+  y = interpolateMyTable(table, u);
 end interpolateTable;
 \end{lstlisting}
 The external C functions may be defined in the following way:

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -362,7 +362,8 @@ end evaluateLinear;
 impure function receiveRealSignal // impure function
   input HardwareDriverID id;
   output Real y;
-  external "C" y = receiveSignal(id);
+  external "C"
+    y = receiveSignal(id);
 end receiveRealSignal;
 \end{lstlisting}
 Examples of allowed optimizations of pure functions:
@@ -1735,7 +1736,8 @@ package Modelica
     function sin
       input Real x;
       output Real y;
-      external "builtin" y=sin(x);
+      external "builtin"
+        y = sin(x);
     end sin;
   end Math;
 end Modelica;
@@ -1964,7 +1966,8 @@ function foo
   input Integer i;
   output Real u1[size(y,1)];
   output Integer u2[size(y,2)];
-  external "FORTRAN 77" myfoo(x, y, size(x,1), size(y,2), u1, i, u2);
+  external "FORTRAN 77"
+    myfoo(x, y, size(x,1), size(y,2), u1, i, u2);
 end foo;
 \end{lstlisting}
 The corresponding FORTRAN~77 subroutine would be declared as follows:
@@ -2086,7 +2089,8 @@ function foo
   input Real x;
   input Real y;
   output Real z=x;
-  external "FORTRAN 77" myfoo(x,y,z);
+  external "FORTRAN 77"
+    myfoo(x, y, z);
 end foo;
 \end{lstlisting}
 The following Modelica function:
@@ -2129,7 +2133,8 @@ function foo
   protected Real xtemp=x; // Temporary used because myfoo changes its input
   public input Real y;
   output Real z;
-  external "FORTRAN 77" myfoo(xtemp,y,z);
+  external "FORTRAN 77"
+    myfoo(xtemp, y, z);
 end foo;
 \end{lstlisting}
 
@@ -2243,21 +2248,24 @@ package ExternalFunctions
     input Real x;
     output Real y;
     external "C"
-    y=ExternalFunc1_ext(x) annotation(Library="ExternalLib1",
-      Include="#include \"ExternalFunc1.h\"");
+      y = ExternalFunc1_ext(x)
+      annotation(Library = "ExternalLib1",
+                 Include = "#include \"ExternalFunc1.h\"");
   end ExternalFunc1;
 
   function ExternalFunc2
     input Real x;
     output Real y;
-    external "C" annotation(Library="ExternalLib2",
-      Include="#include \"ExternalFunc2.h\"");
+    external "C"
+      annotation(Library = "ExternalLib2",
+                 Include = "#include \"ExternalFunc2.h\"");
   end ExternalFunc2;
 
   function ExternalFunc3
     input Real x;
     output Real y;
-    external "C" annotation(Include="#include \"ExternalFunc3.c\"");
+    external "C"
+      annotation(Include = "#include \"ExternalFunc3.c\"");
   end ExternalFunc3;
 end ExternalFunctions;
 
@@ -2371,7 +2379,8 @@ function foo
   input Integer y;
   output Real u1;
   output Integer u2;
-  external "C" myfoo(x, u1, y, u2);
+  external "C"
+    myfoo(x, u1, y, u2);
 end foo;
 \end{lstlisting}
 This corresponds to the following C prototype:
@@ -2400,7 +2409,8 @@ function foo
   input Integer y;
   output Real funcvalue;
   output Integer out1;
-  external "C" funcvalue = myfoo(x, y, out1);
+  external "C"
+    funcvalue = myfoo(x, y, out1);
 end foo;
 \end{lstlisting}
 This corresponds to the following C prototype:
@@ -2630,12 +2640,14 @@ class MyTable
     input String fileName = "";
     input String tableName = "";
     output MyTable table;
-    external "C" table = initMyTable(fileName, tableName);
+    external "C"
+      table = initMyTable(fileName, tableName);
   end constructor;
 
   function destructor "Release storage of table"
     input MyTable table;
-    external "C" closeMyTable(table);
+    external "C"
+      closeMyTable(table);
   end destructor;
 end MyTable;
 \end{lstlisting}
@@ -2656,7 +2668,8 @@ function interpolateMyTable "Interpolate in table"
   input MyTable table;
   input Real u;
   output Real y;
-  external "C" y = interpolateMyTable(table, u);
+  external "C"
+    y = interpolateMyTable(table, u);
 end interpolateTable;
 \end{lstlisting}
 The external C functions may be defined in the following way:

--- a/preamble.tex
+++ b/preamble.tex
@@ -302,6 +302,7 @@
         else,enum,extern,float,for,goto,if,int,long,register,return,%
         short,signed,sizeof,static,struct,switch,typedef,union,unsigned,%
         void,volatile,while},
+    % henrikt-ma: How about adding some highlighting of 'size_t' as a recognized name?
     sensitive,
     morecomment=[s]{/*}{*/},
     morecomment=[l]//, % nonstandard


### PR DESCRIPTION
This is a follow-up to the recent breaking of some long lines in listings.  The external-clauses become really long when they have the `Library` and `Include` annotations, and this proposes a systematic way of getting good looking external-clauses (along with some related but minor cleanup).
