### PR TITLE
Tone down syntax highlighting of recognized identifiers

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -173,8 +173,8 @@
 \setcounter{secnumdepth}{5}
 % Note: Toc changed for appendex
 \setcounter{tocdepth}{1}
-\definecolor{keywordcolor1}{rgb}{0,0,.4}
-\definecolor{keywordcolor2}{rgb}{.90,0,0}
+\definecolor{keywordcolor1}{rgb}{0, 0, .4}
+\definecolor{keywordcolor2}{rgb}{0.48, 0.26, 0.04} % Red color used in the past: {.90, 0, 0}
 
 % When producing PDF, the ttfamily looks better in size \small, but with LaTeXML this becomes too small,
 % and the size is applied deep down on the HTML elements, making it hard to adjust using CSS.

--- a/preamble.tex
+++ b/preamble.tex
@@ -176,7 +176,6 @@
 \definecolor{keywordcolor1} {rgb}{0.00, 0.20, 0.47}
 \definecolor{keywordcolor3} {rgb}{0.33, 0.24, 0.03} % Red color used in the past: {0.90, 0.00, 0.00}
 \definecolor{commentcolor}  {rgb}{0.07, 0.46, 0.00}
-\definecolor{semicoloncolor}{rgb}{0.60, 0.60, 0.60}
 
 % When producing PDF, the ttfamily looks better in size \small, but with LaTeXML this becomes too small,
 % and the size is applied deep down on the HTML elements, making it hard to adjust using CSS.
@@ -227,7 +226,6 @@
         terminal,noEvent,smooth,sample,pre,edge,change,reinit,%
         previous,hold,subSample,superSample,shiftSample,backSample,noClock,firstTick,interval,%
         Real,Integer,Boolean,String},%
-    literate=*{;}{{{\color{semicoloncolor};}}}{1}, % Grayed out semicolon.
     comment=[l]{//}, % comment lines
     morecomment=[s]{/*}{*/}, % comment blocs
     morestring=[b]{'},

--- a/preamble.tex
+++ b/preamble.tex
@@ -173,8 +173,9 @@
 \setcounter{secnumdepth}{5}
 % Note: Toc changed for appendex
 \setcounter{tocdepth}{1}
-\definecolor{keywordcolor1}{rgb}{0, 0, .4}
-\definecolor{keywordcolor2}{rgb}{0.48, 0.26, 0.04} % Red color used in the past: {.90, 0, 0}
+\definecolor{keywordcolor1} {rgb}{0.00, 0.20, 0.47}
+\definecolor{keywordcolor3} {rgb}{0.33, 0.24, 0.03} % Red color used in the past: {0.90, 0.00, 0.00}
+\definecolor{commentcolor}  {rgb}{0.42, 0.60, 0.24}
 
 % When producing PDF, the ttfamily looks better in size \small, but with LaTeXML this becomes too small,
 % and the size is applied deep down on the HTML elements, making it hard to adjust using CSS.
@@ -245,17 +246,17 @@
     morekeywords=[1]{|}
 }[keywords,comments,strings]
 
-\lstset{ %
+\lstset{%
   backgroundcolor=\color{white},   % choose the background color
   mathescape=true,
   breaklines=true,                 % automatic line breaking only at whitespace
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color[rgb]{0,0.4,0}\sffamily,    % comment style
+  commentstyle=\color{commentcolor}\sffamily, % comment style
   keywordstyle=\color{blue}\ttfamily\bfseries,       % keyword style
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
-  keywordstyle=[3]\color{keywordcolor2},
+  keywordstyle=[3]\color{keywordcolor3},
   stringstyle=\color{black},     % string literal style
   language=[short]modelica,     % Language that will be used by default, in particluar by plain \lstinline.
   showstringspaces=false,

--- a/preamble.tex
+++ b/preamble.tex
@@ -186,6 +186,14 @@
 \let\smallifpdf\normalsize
 \fi
 
+% It would be nice to have comments set in normal variable-width font without any sort of
+% column alignment by the listsings.sty package, just like the comments look in the LaTeXML build.
+% Adding the following \commentfullflexible to the 'commentstyle'
+% makes words look good, but the words are still aligned in mysterious ways.
+%\makeatletter
+%\let\commentfullflexible\lst@column@fullflexible
+%\makeatother
+
 % See https://github.com/modelica-tools/listings-modelica/blob/master/listings-modelica.cfg
 % Note: Changed comment color from green to [rgb]{0,0.4,0} - since the other variant was too distracting
 % And added pure,impure,stream as keywords

--- a/preamble.tex
+++ b/preamble.tex
@@ -176,6 +176,7 @@
 \definecolor{keywordcolor1} {rgb}{0.00, 0.20, 0.47}
 \definecolor{keywordcolor3} {rgb}{0.33, 0.24, 0.03} % Red color used in the past: {0.90, 0.00, 0.00}
 \definecolor{commentcolor}  {rgb}{0.42, 0.60, 0.24}
+\definecolor{semicoloncolor}{rgb}{0.60, 0.60, 0.60}
 
 % When producing PDF, the ttfamily looks better in size \small, but with LaTeXML this becomes too small,
 % and the size is applied deep down on the HTML elements, making it hard to adjust using CSS.
@@ -226,6 +227,7 @@
         terminal,noEvent,smooth,sample,pre,edge,change,reinit,%
         previous,hold,subSample,superSample,shiftSample,backSample,noClock,firstTick,interval,%
         Real,Integer,Boolean,String},%
+    literate=*{;}{{{\color{semicoloncolor};}}}{1}, % Grayed out semicolon.
     comment=[l]{//}, % comment lines
     morecomment=[s]{/*}{*/}, % comment blocs
     morestring=[b]{'},

--- a/preamble.tex
+++ b/preamble.tex
@@ -81,7 +81,7 @@
 \usepackage{hyperref}
 % The bookmarks are used as table-of-contents in Acrobat
 % The default (magenta for urls and red for internal links) isn't nice
-\hypersetup{bookmarksnumbered=true, colorlinks=true, urlcolor=blue, linkcolor=blue}
+\hypersetup{bookmarksnumbered=true, hidelinks, urlcolor=blue, linkcolor=blue}
 \usepackage{multirow} % for multirow entries in tables
 \usepackage{listings}
 %\usepackage{enumitem} % Package not available for continuous integration builds.

--- a/preamble.tex
+++ b/preamble.tex
@@ -175,7 +175,7 @@
 \setcounter{tocdepth}{1}
 \definecolor{keywordcolor1} {rgb}{0.00, 0.20, 0.47}
 \definecolor{keywordcolor3} {rgb}{0.33, 0.24, 0.03} % Red color used in the past: {0.90, 0.00, 0.00}
-\definecolor{commentcolor}  {rgb}{0.42, 0.60, 0.24}
+\definecolor{commentcolor}  {rgb}{0.07, 0.46, 0.00}
 \definecolor{semicoloncolor}{rgb}{0.60, 0.60, 0.60}
 
 % When producing PDF, the ttfamily looks better in size \small, but with LaTeXML this becomes too small,

--- a/preamble.tex
+++ b/preamble.tex
@@ -253,7 +253,7 @@
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
   commentstyle=\color{commentcolor}\sffamily, % comment style
-  keywordstyle=\color{blue}\ttfamily\bfseries,       % keyword style
+  keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
   keywordstyle=[3]\color{keywordcolor3},


### PR DESCRIPTION
The current color of the "keyword" group (let's call the members the _recognized identifiers_) including things like `connect`, `der` and `Real` (but not the true keywords such as `if`, `parameter` and `terminate`) is a very bright red that makes these words really pop out of the text.  This PR wants to address this by using a more toned down color instead.

To start with, the proposed solution is just to change the bright red to brown, but we should probably also discuss the other (true) keyword color, and make sure that the colors we choose go well together.
