### PR TITLE
Variability in record member declaration

### DIFF
--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -79,13 +79,25 @@ Seen this way, the rules about which functions may be called in the body of a fu
 
 This covers what one can currently express in full Modelica.  In the future, one might also introduce _pure discrete_ functions that don't have side effects, but that must be re-evaluated at events, even if the arguments are constant.
 
-## Variability in record member declaration
+## Variability specification inside types
 
-This section is work in progress.  The goal is to get rid of one or both of the variability prefixes `constant` and `parameter` from record member declarations.
+In a record definition it is possible to have variability prefixes (`parameter` or `constant`) on the record member component declarations.  This results in a type containing variability specification, referred to as a _variability-constrained type_.  Unless clear from context, types that are not variability-constrained should be referred to as _variability-free types_.
 
-For `constant`, this is of particular interest due to the way we have restricted the attribute modifiers to only allow constant modifiers.  For value modification, this would make the most sense for — again — constant modifiers, but that seems to be mostly useful for record members declared `constant`.  If we would get rid of the `constant` modifier inside record definitions, this might allow us to conclude that we don't really need value modifiers in records at all.
+Variability-constrained types may only be used in the following restrictive ways:
+- Definition of new types (that will also be variability-constrained).
+- Model component declaration.
+- A (sub-) expression of variability-constrained type (such as a reference to a model component declared with such type) may only be used in one of the following ways:
+  - Component references.  That is, accessing a member of a record, application of array subscripts, and combinations thereof.  Note that the resulting expression might again be of variability-constrained type, in which case these restrictions must also be met recursively.
+  - Passing as argument to a function.  It is possible for a variability-constrained record member to be received by a record member without variability constraint, and structural subtyping also allows the receiving record type to not have members corresponding to the variability-constrained members of the passed record.
+  - Alone on one side of an equation in solved form, or as left hand side of an assignment statement.  In this case a variability-constrained record member (at any depth) that does not have a corresponding record member on the other side of the equation (right side of assignment) is not considered part of the equation or assignment.
 
-For `parameter`, we should keep in mind that many of the members declared `parameter` in full Modelica are actually structural parameters that will turn into `constant` in Flat Modelica.  Hence, we need to keep those structural parameters in mind when thinking about getting rid of `constant`.  Then, we must also consider the impact of removing the possibility to declara non-structural members with `parameter` variability.
+The restrictions above should be considered preliminary, as we have yet to find out in more details how these restrictions can be met in real world applications.
+
+It is expected that the restrictions on variability-constrained types will sometime require a type to exist in both a variability-constrained and variability-free variant.  It remains to find out whether the most useful variability-free variants are such that the variability-constrained members of records have been removed, or such that just the variability-constraints have been removed.
+
+The last of the ways that an expression of variability-constrained type may be used – that is, in a solved equation or assignment – is an extension of full Modelica that is provided to mitigate potential problems caused by needing to have two Flat Modelica variants of the same full Modelica type.
+
+Examples of how variability-constrained full Modelica types can be handled in Flat Modelica are collected in variability-constrained-types.md.
 
 ## Array size
 

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -79,6 +79,14 @@ Seen this way, the rules about which functions may be called in the body of a fu
 
 This covers what one can currently express in full Modelica.  In the future, one might also introduce _pure discrete_ functions that don't have side effects, but that must be re-evaluated at events, even if the arguments are constant.
 
+## Variability in record member declaration
+
+This section is work in progress.  The goal is to get rid of one or both of the variability prefixes `constant` and `parameter` from record member declarations.
+
+For `constant`, this is of particular interest due to the way we have restricted the attribute modifiers to only allow constant modifiers.  For value modification, this would make the most sense for — again — constant modifiers, but that seems to be mostly useful for record members declared `constant`.  If we would get rid of the `constant` modifier inside record definitions, this might allow us to conclude that we don't really need value modifiers in records at all.
+
+For `parameter`, we should keep in mind that many of the members declared `parameter` in full Modelica are actually structural parameters that will turn into `constant` in Flat Modelica.  Hence, we need to keep those structural parameters in mind when thinking about getting rid of `constant`.  Then, we must also consider the impact of removing the possibility to declara non-structural members with `parameter` variability.
+
 ## Array size
 
 ### Array types

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -97,7 +97,7 @@ It is expected that the restrictions on variability-constrained types will somet
 
 The last of the ways that an expression of variability-constrained type may be used – that is, in a solved equation or assignment – is an extension of full Modelica that is provided to mitigate potential problems caused by needing to have two Flat Modelica variants of the same full Modelica type.
 
-Examples of how variability-constrained full Modelica types can be handled in Flat Modelica are collected in variability-constrained-types.md.
+A [separate document](variability-constrained-types.md) gives examples of how variability-constrained types may arise in Flat Modelica, and how their constraints can be handled.
 
 ## Array size
 

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -29,7 +29,7 @@ record 'M.Resistor' /* Variability-constrained type */
 end 'M.Resistor';
 
 model 'M'
-  parameter Real 'r1';
+  parameter Real 'r1'; /* Parameter declared with variability-free type Real. */
   'M.Resistor' 'comp1'('r' = 'r1');
   'M.Resistor' 'comp2';
   Real 'i1' = 'comp1'.'i';

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -24,7 +24,7 @@ end M;
 The same hierarchical structure can be represented in Flat Modelica:
 ```
 record 'M.Resistor' /* Variability-constrained type */
-  parameter Real 'r';
+  parameter Real 'r'; /* Parameter declared with variability-free type Real. */
   Real 'i';
 end 'M.Resistor';
 

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -78,3 +78,7 @@ end 'M';
 ## Record including its own array dimension
 
 TODO: Example with time-varying polynomial.
+
+## Connector with parameter
+
+TODO: Describe what happens to a full Modelica connector with a parameter inside.  In particular, what is the corresponding Flat Modelica record?

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -50,7 +50,7 @@ To start with each occurrence of `'comp1'` (which has variability-constrained ty
 An easy example to start with is a record that is only meant to be used for parameters (such records can be found, for example, in `Modelica.Electrical.Batteries.ParameterRecords`):
 ```
 model M
-  model Parameters
+  record Parameters
     parameter Real x;
     parameter Real y;
   end Parameters;
@@ -65,8 +65,8 @@ end M;
 In this case, there seems to be no need to preserve the variability-constraints in the Flat Modelica type:
 ```
 record 'M.Parameters'
-    Real 'x';
-    Real 'y';
+  Real 'x';
+  Real 'y';
 end 'M.Parameters';
 
 model 'M'

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -1,0 +1,80 @@
+# Veriability-constrained types by example
+
+As described in differences.md, a variability-constrained type is one where some record members have been declared with variability prefix (`parameter` or `constant` – `discrete` is currently _not_ an actual variability prefix in Modelica, but implies being discrete-time in a way that makes it impossible to use in a type).  In Flat Modelica, such types are only allowed in model component declarations, and this document gives examples of how this constraint be handled.
+
+## Hierarchical representation of model structure
+
+This model represents the typical situation in full Modelica, where parameters live side by side with time-varying variables at different levels of the component hierarchy:
+```
+model M
+  model Resistor
+    parameter Real r;
+    Real i;
+  equation
+    i = 1 / r;
+  end Resistor;
+
+  parameter Real r1
+  Resistor comp1(r = r1);
+  Resistor comp2;
+  Real i1 = comp1.i;
+end M;
+```
+
+The same hierarchical structure can be represented in Flat Modelica:
+```
+record 'M.Resistor' /* Variability-constrained type */
+  parameter Real 'r';
+  Real 'i';
+end 'M.Resistor';
+
+model 'M'
+  parameter Real 'r1'
+  'M.Resistor' 'comp1'('r' = 'r1');
+  'M.Resistor' 'comp2';
+  Real 'i1' = 'comp1'.'i';
+equation
+  'comp1'.'i' = 1 / 'comp1'.'r';
+  'comp2'.'i' = 1 / 'comp2'.'r';
+end 'M';
+```
+
+For this use of a variability-constrained Flat Modelica record, there is typcailly no need to have a variability-free variant of the same type, and the interesting part is to verify that the Flat Modelica equations don't have illegal sub-expressions of variability-constrained type.  Consider the first equation,
+```
+  'comp1'.'i' = 1 / 'comp1'.'r';
+```
+To start with each occurrence of `'comp1'` (which has variability-constrained type) is in the form of a component reference.  The first of these, `'comp1'.'i'` is a continuous-time expression of type `Real`.  The other, `'comp1'.'r'` is a parameter expression of type `Real`.  That is, `'comp1'.'r'` does not have variability-constrained type; it is just a normal expression having parameter variability.  Hence, there are no illegal occurrences of sub-expressions of variability-constrained type.
+
+## Records with the same constrain on all members
+
+An easy example to start with is a record that is only meant to be used for parameters (such records can be found, for example, in `Modelica.Electrical.Batteries.ParameterRecords`):
+```
+model M
+  model Parameters
+    parameter Real x;
+    parameter Real y;
+  end Parameters;
+
+  parameter Parameters[2] data = {Parameters(1, 2), Parameters(3, 4)};
+  Analog.Basic.Resistor[2] r(final R = data.x, final T_ref = data.y);
+end M;
+```
+
+(Someone has to remind us why the `data` was additionally declared `parameter`.)
+
+In this case, there seems to be no need to preserve the variability-constraints in the Flat Modelica type:
+```
+record 'M.Parameters'
+    Real 'x';
+    Real 'y';
+end 'M.Parameters';
+
+model 'M'
+  parameter 'M.Parameters'[2] 'data' = {'M.Parameters'(1, 2), 'M.Parameters'(3, 4)};
+  'Analog.Basic.Resistor'[2] 'r'('R' = 'data'.'x', T_ref = 'data'.'y');
+end 'M';
+```
+
+## Record including its own array dimension
+
+TODO: Example with time-varying polynomial.

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -45,7 +45,7 @@ For this use of a variability-constrained Flat Modelica record, there is typcail
 ```
 To start with each occurrence of `'comp1'` (which has variability-constrained type) is in the form of a component reference.  The first of these, `'comp1'.'i'` is a continuous-time expression of type `Real`.  The other, `'comp1'.'r'` is a parameter expression of type `Real`.  That is, `'comp1'.'r'` does not have variability-constrained type; it is just a normal expression having parameter variability.  Hence, there are no illegal occurrences of sub-expressions of variability-constrained type.
 
-## Records with the same constrain on all members
+## Records with the same constraint on all members
 
 An easy example to start with is a record that is only meant to be used for parameters (such records can be found, for example, in `Modelica.Electrical.Batteries.ParameterRecords`):
 ```

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -14,7 +14,7 @@ model M
     i = 1 / r;
   end Resistor;
 
-  parameter Real r1
+  parameter Real r1;
   Resistor comp1(r = r1);
   Resistor comp2;
   Real i1 = comp1.i;
@@ -29,7 +29,7 @@ record 'M.Resistor' /* Variability-constrained type */
 end 'M.Resistor';
 
 model 'M'
-  parameter Real 'r1'
+  parameter Real 'r1';
   'M.Resistor' 'comp1'('r' = 'r1');
   'M.Resistor' 'comp2';
   Real 'i1' = 'comp1'.'i';

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -1,6 +1,6 @@
 # Veriability-constrained types by example
 
-As described in differences.md, a variability-constrained type is one where some record members have been declared with variability prefix (`parameter` or `constant` – `discrete` is currently _not_ an actual variability prefix in Modelica, but implies being discrete-time in a way that makes it impossible to use in a type).  In Flat Modelica, such types are only allowed in model component declarations, and this document gives examples of how this constraint be handled.
+[As described elsewhere](differences.md), a variability-constrained type is one where some record members have been declared with variability prefix (`parameter` or `constant` – `discrete` is currently _not_ an actual variability prefix in Modelica, but implies being discrete-time in a way that makes it impossible to use in a type).  In Flat Modelica, such types are only allowed in model component declarations, and this document gives examples of how this constraint be handled.
 
 ## Hierarchical representation of model structure
 

--- a/RationaleMCP/0031/variability-constrained-types.md
+++ b/RationaleMCP/0031/variability-constrained-types.md
@@ -1,4 +1,4 @@
-# Veriability-constrained types by example
+# Variability-constrained types by example
 
 [As described elsewhere](differences.md), a variability-constrained type is one where some record members have been declared with variability prefix (`parameter` or `constant` – `discrete` is currently _not_ an actual variability prefix in Modelica, but implies being discrete-time in a way that makes it impossible to use in a type).  In Flat Modelica, such types are only allowed in model component declarations, and this document gives examples of how this constraint be handled.
 


### PR DESCRIPTION
From the current placeholder text under the section _Variability in record member declaration_ in _differences.md_:

> The goal is to get rid of one or both of the variability prefixes `constant` and `parameter` from record member declarations.
>
> For `constant`, this is of particular interest due to the way we have restricted the attribute modifiers to only allow constant modifiers.  For value modification, this would make the most sense for — again — constant modifiers, but that seems to be mostly useful for record members declared `constant`.  If we would get rid of the `constant` modifier inside record definitions, this might allow us to conclude that we don't really need value modifiers in records at all.
>
> For `parameter`, we should keep in mind that many of the members declared `parameter` in full Modelica are actually structural parameters that will turn into `constant` in Flat Modelica.  Hence, we need to keep those structural parameters in mind when thinking about getting rid of `constant`.  Then, we must also consider the impact of removing the possibility to declara non-structural members with `parameter` variability.
