### PR TITLE
Deprecate byte order mark

### DIFF
--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -22,9 +22,9 @@ several places; for details see \cref{lexical-conventions}.
 \section{Comments}\label{comments}
 
 There are two kinds of comments in Modelica which are not lexical units
-in the language and therefore are treated as whitespace by a Modelica
-translator. The whitespace characters are space, tabulator, and line
-separators (carriage return and line feed); and whitespace cannot occur
+in the language and therefore are treated as white-space by a Modelica
+translator. The white-space characters are space, tabulator, and line
+separators (carriage return and line feed); and white-space cannot occur
 inside tokens, e.g., \textless{}= must be written as two characters
 without space or comments between them.  The following comment variants are
 available:

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -213,10 +213,7 @@ entity falls into one of the following two groups:
   File in the file system.
 \end{itemize}
 
-Each Modelica file in the file-system is stored in UTF-8 format (defined
-by The Unicode Consortium; \lstinline!http://www.unicode.org!) and may start with
-the UTF-8 encoded byte order mark (\lstinline!0xef 0xbb 0xbf!); this is treated as
-whitespace in the grammar.
+Each Modelica file in the file-system is stored in UTF-8 format (defined by The Unicode Consortium; \lstinline!http://www.unicode.org!).  A deprecated feature is that the file may start with the UTF-8 encoded BOM (byte order mark; \lstinline!0xef 0xbb 0xbf!); this is treated as whitespace in the grammar.  Since the use of BOM is deprecated, tools can ignore any BOM when reading, and it is recommended to never write it.
 
 \begin{nonnormative}
 Tools may also store classes in data-base systems, but that is not standardized.

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -213,7 +213,7 @@ entity falls into one of the following two groups:
   File in the file system.
 \end{itemize}
 
-Each Modelica file in the file-system is stored in UTF-8 format (defined by The Unicode Consortium; \lstinline!http://www.unicode.org!).  A deprecated feature is that the file may start with the UTF-8 encoded BOM (byte order mark; \lstinline!0xef 0xbb 0xbf!); this is treated as whitespace in the grammar.  Since the use of BOM is deprecated, tools can ignore any BOM when reading, and it is recommended to never write it.
+Each Modelica file in the file-system is stored in UTF-8 format (defined by The Unicode Consortium; \lstinline!http://www.unicode.org!).  A deprecated feature is that the file may start with the UTF-8 encoded BOM (byte order mark; \lstinline!0xef 0xbb 0xbf!); this is treated as white-space in the grammar.  Since the use of BOM is deprecated, tools can ignore any BOM when reading, and it is recommended to never write it.
 
 \begin{nonnormative}
 Tools may also store classes in data-base systems, but that is not standardized.

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -216,7 +216,7 @@ entity falls into one of the following two groups:
 Each Modelica file in the file-system is stored in UTF-8 format (defined
 by The Unicode Consortium; \lstinline!http://www.unicode.org!) and may start with
 the UTF-8 encoded byte order mark (\lstinline!0xef 0xbb 0xbf!); this is treated as
-white-space in the grammar.
+whitespace in the grammar.
 
 \begin{nonnormative}
 Tools may also store classes in data-base systems, but that is not standardized.

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1130,7 +1130,7 @@ particular:
   Defined flipping more precisely.
 \item
   \cref{lexical-conventions} Lexical conventions\\
-  More precisely defined whitespace and comments.
+  More precisely defined white-space and comments.
 \item
   \cref{grammar} Grammar\\
   Improved/corrected grammar definition
@@ -1196,7 +1196,7 @@ The following \emph{backward compatible extensions} have been introduced with Mo
   Indian users (see grammar changes in \cref{lexical-conventions}). Modelica files are
   UTF-8 encoded, and can start with the UTF-8 encoded byte order mark
   (0xef 0xbb 0xbf) to indicate that it may contain UTF-8 characters;
-  this is treated as whitespace in the grammar (see \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
+  this is treated as white-space in the grammar (see \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
 \item
   Constants can once again be modified unless declared final -- as this is already used in packages.  (See \cref{constant-expressions}).
 \item

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1196,7 +1196,7 @@ The following \emph{backward compatible extensions} have been introduced with Mo
   Indian users (see grammar changes in \cref{lexical-conventions}). Modelica files are
   UTF-8 encoded, and can start with the UTF-8 encoded byte order mark
   (0xef 0xbb 0xbf) to indicate that it may contain UTF-8 characters;
-  this is treated as white-space in the grammar (see \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
+  this is treated as whitespace in the grammar (see \cref{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}).
 \item
   Constants can once again be modified unless declared final -- as this is already used in packages.  (See \cref{constant-expressions}).
 \item

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -6,7 +6,7 @@ The following syntactic meta symbols are used (extended BNF):
 [ ] optional
 { } repeat zero or more times
 | or
-"text" The text is treated as a single token (no whitespace between any characters)
+"text" The text is treated as a single token (no white-space between any characters)
 \end{lstlisting}
 
 The following lexical units are defined (the ones in boldface are the
@@ -40,9 +40,9 @@ variants (`\lstinline!?!' and '\lstinline!"!').  The single quotes are part of a
 Note:
 \begin{itemize}
 \item
-  Whitespace and comments can be used between separate lexical units
+  White-space and comments can be used between separate lexical units
   and/or symbols, and also separates them. Each lexical unit will consume the maximum number of characters from the input stream.
-  Whitespace and comments
+  White-space and comments
   cannot be used inside other lexical units, except for STRING and
   Q-IDENT where they are treated as part of the STRING or Q-IDENT
   lexical unit.

--- a/preamble.tex
+++ b/preamble.tex
@@ -248,7 +248,7 @@
 \lstset{ %
   backgroundcolor=\color{white},   % choose the background color
   mathescape=true,
-  breaklines=true,                 % automatic line breaking only at whitespace
+  breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
   commentstyle=\color[rgb]{0,0.4,0}\sffamily,    % comment style


### PR DESCRIPTION
Fixes #2675

Almost according to decision at phone meeting: breaking down in to shorter sentences, and introducing the abbreviation _BOM_ before using it.
