### PR TITLE
Fix some white-space irregularities in the grammar

### DIFF
--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -84,13 +84,20 @@ stored-definition :
 \subsection{Class Definition}\label{class-definition}
 \begin{lstlisting}[language=grammar]
 class-definition :
-   [ encapsulated ] class-prefixes
-   class-specifier
+   [ encapsulated ] class-prefixes class-specifier
 
 class-prefixes :
    [ partial ]
-   ( class | model | [ operator ] record | block | [ expandable ] connector | type |
-   package | [ pure | impure ] [ operator ] function | operator )
+   ( class
+     | model
+     | [ operator ] record
+     | block
+     | [ expandable ] connector
+     | type
+     | package
+     | [ pure | impure ] [ operator ] function
+     | operator
+   )
 
 class-specifier :
    long-class-specifier | short-class-specifier | der-class-specifier
@@ -98,7 +105,7 @@ class-specifier :
 long-class-specifier :
    IDENT description-string composition end IDENT
    | extends IDENT [ class-modification ] description-string composition
-   end IDENT
+     end IDENT
 
 short-class-specifier :
    IDENT "=" base-prefix type-specifier [ array-subscripts ]
@@ -111,16 +118,16 @@ der-class-specifier :
 base-prefix :
    [ input | output ]
 
-enum-list : enumeration-literal { "," enumeration-literal}
+enum-list : enumeration-literal { "," enumeration-literal }
 
 enumeration-literal : IDENT description
 
 composition :
    element-list
-   { public element-list |
-     protected element-list |
-     equation-section |
-     algorithm-section
+   { public element-list
+     | protected element-list
+     | equation-section
+     | algorithm-section
    }
    [ external [ language-specification ]
    [ external-function-call ] [ annotation-clause ] ";" ]
@@ -137,17 +144,23 @@ element-list :
    { element ";" }
 
 element :
-   import-clause |
-   extends-clause |
-   [ redeclare ]
-   [ final ]
-   [ inner ] [ outer ]
-   ( class-definition | component-clause |
-   replaceable ( class-definition | component-clause )
-   [ constraining-clause description ] )
+   import-clause
+   | extends-clause
+   | [ redeclare ]
+     [ final ]
+     [ inner ] [ outer ]
+     ( class-definition
+       | component-clause
+       | replaceable ( class-definition | component-clause )
+         [ constraining-clause description ]
+     )
 
 import-clause :
-   import ( IDENT "=" name | name [ ".*" | "." ( "*" | "{" import-list "}" ) ] ) description
+   import
+   ( IDENT "=" name
+     | name [ ".*" | "." ( "*" | "{" import-list "}" ) ]
+   )
+   description
 
 import-list :
    IDENT { "," IDENT }
@@ -169,7 +182,8 @@ component-clause :
 
 type-prefix :
    [ flow | stream ]
-   [ discrete | parameter | constant ] [ input | output ]
+   [ discrete | parameter | constant ]
+   [ input | output ]
 
 component-list :
    component-declaration { "," component-declaration }
@@ -239,18 +253,21 @@ equation :
      | for-equation
      | connect-clause
      | when-equation
-     | component-reference function-call-args )
+     | component-reference function-call-args
+   )
    description
 
 statement :
    ( component-reference ( ":=" expression | function-call-args )
-     | "(" output-expression-list ")" ":=" component-reference function-call-args
+     | "(" output-expression-list ")" ":="
+       component-reference function-call-args
      | break
      | return
      | if-statement
      | for-statement
      | while-statement
-     | when-statement )
+     | when-statement
+   )
    description
 
 if-equation :
@@ -286,7 +303,7 @@ for-statement :
    end for
 
 for-indices :
-   for-index {"," for-index}
+   for-index { "," for-index }
 
 for-index :
    IDENT [ in expression ]
@@ -300,25 +317,29 @@ when-equation :
    when expression then
      { equation ";" }
    { elsewhen expression then
-     { equation ";" } }
+     { equation ";" }
+   }
    end when
 
 when-statement :
    when expression then
      { statement ";" }
    { elsewhen expression then
-     { statement ";" } }
+     { statement ";" }
+   }
    end when
 
 connect-clause :
    connect "(" component-reference "," component-reference ")"
 \end{lstlisting}
+
 \subsection{Expressions}\label{expressions1}
 \begin{lstlisting}[language=grammar]
 expression :
    simple-expression
-   | if expression then expression { elseif expression then expression }
-   else expression
+   | if expression then expression
+     { elseif expression then expression }
+     else expression
 
 simple-expression :
    logical-expression [ ":" logical-expression [ ":" logical-expression ] ]
@@ -365,11 +386,14 @@ primary :
    | "{" array-arguments "}"
    | end
 
-UNSIGNED-NUMBER : UNSIGNED-INTEGER | UNSIGNED-REAL
+UNSIGNED-NUMBER :
+   UNSIGNED-INTEGER | UNSIGNED-REAL
 
-type-specifier : ["."] name
+type-specifier :
+   ["."] name
 
-name : IDENT { "." IDENT }
+name :
+   IDENT { "." IDENT }
 
 component-reference :
    [ "." ] IDENT [ array-subscripts ] { "." IDENT [ array-subscripts ] }

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -21,14 +21,15 @@ S-CHAR = see below
 Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")"
    | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
    | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
-S-ESCAPE = "\'" | "\"" | "\?" | "\\" |
-         "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
+S-ESCAPE = "\'" | "\"" | "\?" | "\\"
+   | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 UNSIGNED-INTEGER = DIGIT { DIGIT }
-UNSIGNED-REAL = UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
-   |  UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ]
-        ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
-   |   "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
+UNSIGNED-REAL =
+   UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
+   | UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ]
+     ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
+   | "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
 \end{lstlisting}
 \textrm{S-CHAR} is any member of the Unicode character set
 (\url{http://www.unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote `"', and backslash `\textbackslash{}'.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -119,9 +119,11 @@ der-class-specifier :
 base-prefix :
    [ input | output ]
 
-enum-list : enumeration-literal { "," enumeration-literal }
+enum-list :
+   enumeration-literal { "," enumeration-literal }
 
-enumeration-literal : IDENT description
+enumeration-literal :
+   IDENT description
 
 composition :
    element-list

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -76,7 +76,7 @@ Note:
 \section{Grammar}\label{grammar}
 \subsection{Stored Definition -- Within}\label{stored-definition-within}
 \begin{lstlisting}[language=grammar]
-stored-definition:
+stored-definition :
    [ within [ name ] ";" ]
    { [ final ] class-definition ";" }
 \end{lstlisting}
@@ -164,19 +164,20 @@ constraining-clause :
 
 \subsection{Component Clause}\label{component-clause}
 \begin{lstlisting}[language=grammar]
-component-clause:
+component-clause :
    type-prefix type-specifier [ array-subscripts ] component-list
 
 type-prefix :
    [ flow | stream ]
    [ discrete | parameter | constant ] [ input | output ]
+
 component-list :
    component-declaration { "," component-declaration }
 
 component-declaration :
    declaration [ condition-attribute ] description
 
-condition-attribute:
+condition-attribute :
    if expression
 
 declaration :
@@ -200,7 +201,7 @@ argument :
    element-modification-or-replaceable
    | element-redeclaration
 
-element-modification-or-replaceable:
+element-modification-or-replaceable :
    [ each ] [ final ] ( element-modification | element-replaceable )
 
 element-modification :
@@ -210,7 +211,7 @@ element-redeclaration :
    redeclare [ each ] [ final ]
    ( short-class-definition | component-clause1 | element-replaceable )
 
-element-replaceable:
+element-replaceable :
    replaceable ( short-class-definition | component-clause1 )
    [ constraining-clause ]
 
@@ -287,7 +288,7 @@ for-statement :
 for-indices :
    for-index {"," for-index}
 
-for-index:
+for-index :
    IDENT [ in expression ]
 
 while-statement :
@@ -377,7 +378,7 @@ function-call-args :
    "(" [ function-arguments ] ")"
 
 function-arguments :
-expression [ "," function-arguments-non-first | for for-indices ]
+   expression [ "," function-arguments-non-first | for for-indices ]
    | function-partial-application [ "," function-arguments-non-first ]
    | named-arguments
 
@@ -401,7 +402,7 @@ function-argument :
 function-partial-application :
    function type-specifier "(" [ named-arguments ] ")"
 
-output-expression-list:
+output-expression-list :
    [ expression ] { "," [ expression ] }
 
 expression-list :
@@ -417,7 +418,7 @@ description :
    description-string [ annotation-clause ]
 
 description-string :
-[ STRING { "+" STRING } ]
+   [ STRING { "+" STRING } ]
 
 annotation-clause :
    annotation class-modification


### PR DESCRIPTION
I was just trying to answer a question by referring to the grammar, and found these irregularities that were really making reading the grammar more difficult that it needs to be.
