### PR TITLE
Styling of document title, front pages, and navbar

### DIFF
--- a/MLS.tex
+++ b/MLS.tex
@@ -6,7 +6,7 @@
 % Define title for use by LaTeXML.
 % An extended title is defined separately in the 'titlepage'.
 \newcommand{\mlsversion}{3.5-dev}
-\title{Modelica\textsuperscript{\textregistered} Language Specification Version \mlsversion}
+\title{Modelica\textsuperscript{\textregistered} Language Specification version~\mlsversion}
 
 \date{\today}
 

--- a/MLS.tex
+++ b/MLS.tex
@@ -16,7 +16,7 @@
 
 \begin{document}
 
-% Setting pageanhor false for these unnumbered pages
+% Setting pageanchor false for these unnumbered pages
 % Changed back after abstract
 % The downside is that you cannot go to them in acrobat
 % This is from https://tex.stackexchange.com/questions/18924/pdftex-warning-ext4-destination-with-the-same-identifier-nam-epage-1-has

--- a/MLS.tex
+++ b/MLS.tex
@@ -3,17 +3,10 @@
 \usepackage[utf8]{inputenc}
 \input{preamble.tex}
 
-\title{%
-\ifpdf
-\begin{center}
-\includegraphics[width=8cm]{Modelica_Language}
-\end{center}
-~\\[2\baselineskip]
-\fi
-Modelica\textsuperscript{\textregistered} -- A Unified Object-Oriented Language for Systems Modeling\\[2\baselineskip]
-Language Specification\\[2\baselineskip]
-Version 3.5-dev%
-}
+% Define title for use by LaTeXML.
+% An extended title is defined separately in the 'titlepage'.
+\newcommand{\mlsversion}{3.5-dev}
+\title{Modelica\textsuperscript{\textregistered} Language Specification Version \mlsversion}
 
 \date{\today}
 
@@ -23,7 +16,38 @@ Version 3.5-dev%
 
 \begin{document}
 % Title
-\maketitle
+% Need to somehow work around the issue that LaTeXML puts the abstract before the title page, see LaTeXML issue:
+% - https://github.com/brucemiller/LaTeXML/issues/1395
+\begin{titlepage}
+% Note that things like \vspace and linebreaks with height (\\[2\baselineskip]) are lost in generated HTML;
+% only line breaks and paragraph breaks survive.
+\addtolength{\parskip}{\baselineskip}% Lots of space between paragraphs on the PDF title page.
+\begin{center}
+\ifpdf
+\includegraphics[width=8cm]{Modelica_Language}
+\else
+\includegraphics[width=15cm]{Modelica_Language}
+\fi
+\vspace{3cm}
+
+\huge
+Modelica\textsuperscript{\textregistered} -- A Unified Object-Oriented Language for~Systems Modeling
+
+Language Specification
+
+Version \mlsversion
+
+\vspace{3cm}% This has no effect in the generated HTML.
+
+\Large
+\makeatletter
+\@date
+
+\@author
+\makeatother
+\end{center}
+\end{titlepage}
+
 % Add new Modelica Language logotype
 % The header ruler looks odd as Modelica Language define a natural line that is further up
 % We also need to fill the vertical space on the right
@@ -31,6 +55,7 @@ Version 3.5-dev%
 %
 % Using nouppercase since it is seems more normal for the sections, and is also
 % needed for over-determined connectors (as it would otherwise overflow)
+\cleardoublepage
 \pagestyle{fancy}
 \rhead{Modelica Language Specification 3.5-dev\\ \nouppercase{\rightmark} \vspace{1mm}}
 \lhead{\includegraphics[height=6.5mm]{Modelica_Language}}

--- a/MLS.tex
+++ b/MLS.tex
@@ -15,20 +15,27 @@
 % The other parts start on new page and could be optionally included
 
 \begin{document}
+
+% Setting pageanhor false for these unnumbered pages
+% Changed back after abstract
+% The downside is that you cannot go to them in acrobat
+% This is from https://tex.stackexchange.com/questions/18924/pdftex-warning-ext4-destination-with-the-same-identifier-nam-epage-1-has
+% The accepted solution did not seem to work
+\hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
+
 % Title
-% Need to somehow work around the issue that LaTeXML puts the abstract before the title page, see LaTeXML issue:
-% - https://github.com/brucemiller/LaTeXML/issues/1395
 \begin{titlepage}
 % Note that things like \vspace and linebreaks with height (\\[2\baselineskip]) are lost in generated HTML;
 % only line breaks and paragraph breaks survive.
 \addtolength{\parskip}{\baselineskip}% Lots of space between paragraphs on the PDF title page.
+\vspace*{\fill}
 \begin{center}
 \ifpdf
 \includegraphics[width=8cm]{Modelica_Language}
 \else
 \includegraphics[width=15cm]{Modelica_Language}
 \fi
-\vspace{3cm}
+\vspace{1cm}
 
 \huge
 Modelica\textsuperscript{\textregistered} -- A Unified Object-Oriented Language for~Systems Modeling
@@ -37,7 +44,7 @@ Language Specification
 
 Version \mlsversion
 
-\vspace{3cm}% This has no effect in the generated HTML.
+\vspace{1cm}% This has no effect in the generated HTML.
 
 \Large
 \makeatletter
@@ -46,6 +53,13 @@ Version \mlsversion
 \@author
 \makeatother
 \end{center}
+
+\ifpdf
+\vfill
+\else
+\newpage % In the HTML, this will appear as some extra vertical space.
+\fi
+\input{chapters/abstract}
 \end{titlepage}
 
 % Add new Modelica Language logotype
@@ -61,9 +75,12 @@ Version \mlsversion
 \lhead{\includegraphics[height=6.5mm]{Modelica_Language}}
 \renewcommand{\headrulewidth}{0.0pt}
 
-% Abstract
-\input{chapters/abstract}
+\hypersetup{pageanchor=true}
 
+% Copyright
+\input{chapters/copyright}
+
+\cleardoublepage
 \tableofcontents
 
 % Preface

--- a/MLS.tex
+++ b/MLS.tex
@@ -64,6 +64,8 @@ Version \mlsversion
 % Abstract
 \input{chapters/abstract}
 
+\tableofcontents
+
 % Preface
 \input{chapters/preface}
 

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -1,10 +1,10 @@
-% Setting pageanhor false for these unnumbered pages
-% Changed back after abstract
-% The downside is that you cannot go to them in acrobat
-% This is from https://tex.stackexchange.com/questions/18924/pdftex-warning-ext4-destination-with-the-same-identifier-nam-epage-1-has
-% The accepted solution did not seem to work
-\hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
-\begin{abstract}
+% Can't use the 'abstract' environment as long as LaTeXML puts the abstract before the title page, see LaTeXML issue:
+% - https://github.com/brucemiller/LaTeXML/issues/1395
+\begin{center}
+\large\bfseries\sffamily
+\abstractname
+\end{center}
+
 This document defines the Modelica\footnote{%
 \firstuse{Modelica} is a registered trademark of the Modelica Association.
 }
@@ -17,15 +17,3 @@ A Modelica tool will have enough information to decide that automatically.
 Modelica is designed such that available, specialized algorithms can be utilized to enable efficient handling of large models having more than one hundred thousand equations.
 Modelica is suited and used for hardware-in-the-loop simulations and for embedded control systems.
 More information is available at \url{https://www.modelica.org}.
-\end{abstract}
-
-\hypersetup{pageanchor=true}
-Copyright \textcopyright{} 1998-2020, Modelica Association (\url{https://www.modelica.org})
-
-All rights reserved.
-Reproduction or use of editorial or pictorial content is permitted, i.e., this document can be freely distributed especially electronically, provided the copyright notice and these conditions are retained.
-No patent liability is assumed with respect to the use of information contained herein.
-While every precaution has been taken in the preparation of this document no responsibility for errors or omissions is assumed.
-
-The contributors to this and to previous versions of this document are listed in \cref{modelica-revision-history}.
-All contributors worked voluntarily and without compensation.

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -5,37 +5,27 @@
 % The accepted solution did not seem to work
 \hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
 \begin{abstract}
-This document defines the Modelica\footnote{Modelica is a registered
-  trademark of the Modelica Association} language, version 3.5, which is
-developed by the Modelica Association, a non-profit organization with
-seat in Linköping, Sweden. Modelica is a freely available,
-object-oriented language for modeling of large, complex, and
-heterogeneous systems. It is suited for multi-domain modeling, for
-example, mechatronic models in robotics, automotive and aerospace
-applications involving mechanical, electrical, hydraulic control and
-state machine subsystems, process oriented applications and generation
-and distribution of electric power. Models in Modelica are
-mathematically described by differential, algebraic and discrete
-equations. No particular variable needs to be solved for manually. A
-Modelica tool will have enough information to decide that automatically.
-Modelica is designed such that available, specialized algorithms can be
-utilized to enable efficient handling of large models having more than
-one hundred thousand equations. Modelica is suited and used for
-hardware-in-the-loop simulations and for embedded control systems. More
-information is available at \url{https://www.modelica.org}.
+This document defines the Modelica\footnote{%
+Modelica is a registered trademark of the Modelica Association
+}
+language, version 3.5, which is developed by the Modelica Association, a non-profit organization with seat in Linköping, Sweden.
+Modelica is a freely available, object-oriented language for modeling of large, complex, and heterogeneous systems.
+It is suited for multi-domain modeling, for example, mechatronic models in robotics, automotive and aerospace applications involving mechanical, electrical, hydraulic control and state machine subsystems, process oriented applications and generation and distribution of electric power.
+Models in Modelica are mathematically described by differential, algebraic and discrete equations.
+No particular variable needs to be solved for manually.
+A Modelica tool will have enough information to decide that automatically.
+Modelica is designed such that available, specialized algorithms can be utilized to enable efficient handling of large models having more than one hundred thousand equations.
+Modelica is suited and used for hardware-in-the-loop simulations and for embedded control systems.
+More information is available at \url{https://www.modelica.org}.
 \end{abstract}
 
 \hypersetup{pageanchor=true}
 Copyright \textcopyright{} 1998-2020, Modelica Association (\url{https://www.modelica.org})
 
-All rights reserved. Reproduction or use of editorial or pictorial
-content is permitted, i.e., this document can be freely distributed
-especially electronically, provided the copyright notice and these
-conditions are retained. No patent liability is assumed with respect to
-the use of information contained herein. While every precaution has been
-taken in the preparation of this document no responsibility for errors
-or omissions is assumed.
+All rights reserved.
+Reproduction or use of editorial or pictorial content is permitted, i.e., this document can be freely distributed especially electronically, provided the copyright notice and these conditions are retained.
+No patent liability is assumed with respect to the use of information contained herein.
+While every precaution has been taken in the preparation of this document no responsibility for errors or omissions is assumed.
 
-The contributors to this and to previous versions of this document are
-listed in \cref{modelica-revision-history}. All contributors worked voluntarily and without
-compensation.
+The contributors to this and to previous versions of this document are listed in \cref{modelica-revision-history}.
+All contributors worked voluntarily and without compensation.

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -39,5 +39,3 @@ or omissions is assumed.
 The contributors to this and to previous versions of this document are
 listed in \cref{modelica-revision-history}. All contributors worked voluntarily and without
 compensation.
-
-\tableofcontents

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -8,7 +8,7 @@
 This document defines the Modelica\footnote{%
 Modelica is a registered trademark of the Modelica Association
 }
-language, version 3.5, which is developed by the Modelica Association, a non-profit organization with seat in Linköping, Sweden.
+language, version~\mlsversion, which is developed by the Modelica Association, a non-profit organization with seat in Linköping, Sweden.
 Modelica is a freely available, object-oriented language for modeling of large, complex, and heterogeneous systems.
 It is suited for multi-domain modeling, for example, mechatronic models in robotics, automotive and aerospace applications involving mechanical, electrical, hydraulic control and state machine subsystems, process oriented applications and generation and distribution of electric power.
 Models in Modelica are mathematically described by differential, algebraic and discrete equations.

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -6,7 +6,7 @@
 \hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
 \begin{abstract}
 This document defines the Modelica\footnote{%
-Modelica is a registered trademark of the Modelica Association
+\firstuse{Modelica} is a registered trademark of the Modelica Association.
 }
 language, version~\mlsversion, which is developed by the Modelica Association, a non-profit organization with seat in Linköping, Sweden.
 Modelica is a freely available, object-oriented language for modeling of large, complex, and heterogeneous systems.

--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -5,15 +5,6 @@
 % The accepted solution did not seem to work
 \hypersetup{pageanchor=false,bookmarksdepth=2,destlabel=true,bookmarksopenlevel=0}
 \begin{abstract}
-  \ifpdf
-  \else
-  ~\bigskip
-  \begin{center}
-    \includegraphics[width=8cm]{Modelica_Language}
-  \end{center}
-  \bigskip
-  \fi
-
 This document defines the Modelica\footnote{Modelica is a registered
   trademark of the Modelica Association} language, version 3.5, which is
 developed by the Modelica Association, a non-profit organization with

--- a/chapters/copyright.tex
+++ b/chapters/copyright.tex
@@ -1,0 +1,9 @@
+Copyright \textcopyright{} 1998-2020, Modelica Association (\url{https://www.modelica.org})
+
+All rights reserved.
+Reproduction or use of editorial or pictorial content is permitted, i.e., this document can be freely distributed especially electronically, provided the copyright notice and these conditions are retained.
+No patent liability is assumed with respect to the use of information contained herein.
+While every precaution has been taken in the preparation of this document no responsibility for errors or omissions is assumed.
+
+The contributors to this and to previous versions of this document are listed in \cref{modelica-revision-history}.
+All contributors worked voluntarily and without compensation.

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -173,9 +173,9 @@ In this section various terms are defined.
 %   https://github.com/brucemiller/LaTeXML/issues/1292 (marked as fixed as of commit 9f5c893b)
 %\begin{figure}[tb]
 %  \centering
-%  \subfloat[A piecewise-constant variable.]{\includegraphics[width=5cm]{piecewise}\label{fig:piecewise-constant-variable}}
-%  \subfloat[A clock variable.]{\includegraphics[width=5cm]{clock}\label{fig:clock-variable}}
-%  \subfloat[A clocked variable.]{\includegraphics[width=5cm]{clocked}\label{fig:clocked-variable}}
+%  \subfloat[A piecewise-constant variable.]{\includegraphics{piecewise}\label{fig:piecewise-constant-variable}}
+%  \subfloat[A clock variable.]{\includegraphics{clock}\label{fig:clock-variable}}
+%  \subfloat[A clocked variable.]{\includegraphics{clocked}\label{fig:clocked-variable}}
 %  \caption{The different kinds of discrete-time variables.  The \lstinline!hold! extrapolation of the clocked variable is illustrated with dashed green lines.}
 %\end{figure}
 

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -32,15 +32,16 @@ nav > div.ltx_TOC {
 .ltx_page_navbar:before {
   position: fixed;
   z-index: 4;
-  left: 2px;
+  left: 0px;
   top: 0px;
   margin: 0px;
   padding: 0px;
-  font: 16px sans-serif;
+  font-size: 25px;
   color: #DE1D31; /* "Bouncing ball red" */
   height: 30px;
-  width: 16px;
+  width: calc(3rem - 8px);
   background: #F6F6F6;
+  text-align: center;
   content: "☰"; /* Chinese character that looks like hamburger. */
 }
 
@@ -90,8 +91,8 @@ nav > div.ltx_TOC {
   position: fixed;
   z-index: 3;
   top: 0px;
-  height: 3em;
-  padding: 0.5em 1em;
+  height: 2.5rem;
+  padding: 0.5rem 1rem;
   background: #F6F6F6; /* Same as body. */
   color: black; /* Same as side bar. */
   white-space: nowrap;
@@ -99,13 +100,13 @@ nav > div.ltx_TOC {
 }
 
 .ltx_page_content {
-  padding: 1em;
-  margin-top: 3em; /* Header height plus padding below, minus a little bit. */
+  padding: 1rem;
+  margin-top: 2.5rem; /* Header height plus padding below, minus a little bit. */
   background: white;
 }
 
 .ltx_page_footer {
-  padding: 1em;
+  padding: 1rem;
   background: white;
 }
 
@@ -143,11 +144,12 @@ nav > div.ltx_TOC {
     /* Leave just enough space to fit the hamburger plus the right border of the .ltx_page_navbar.
      * Don't define this in em units, since the em is not the same below in .ltx_page_navbar.
      */
-    margin-left: calc(2px + 16px + 8px); /* left + width + border */
+    margin-left: 0px;
   }
   .ltx_page_navbar {
     width: 500px;
-    left: calc(26px - (500px + 8px)); /* Position right extent where .lts_page_main starts, taking .ltx_page_navbar border-right-width into account. */
+    height: 3.5rem;
+    left: calc(3rem - (500px + 8px));
     transition: 0.3s;
   }
   .ltx_TOC {
@@ -155,10 +157,12 @@ nav > div.ltx_TOC {
     height: calc(100% - 20px);
   }
   .ltx_page_header {
-    width: calc(100% - 26px - 2em); /* Subtract 2em for the total horizontal padding on this element. */
+    padding-left: 4rem;
+    width: calc(100% - (4rem + 1rem)); /* Subtract horizontal padding on this element. */
   }
   .ltx_page_navbar:hover {
     left: 0px;
+    height: 100%;
   }
   .ltx_page_navbar:before {
     display: block;

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -46,9 +46,15 @@ nav > div.ltx_TOC {
 }
 
 .ltx_page_navbar a[rel=start] {
-  display: none; /* Hiding the sidebar title, as it is too long to look good, and seem to lack structure for adequate layout. */
-  margin: 1em;
-  font-weight: bold;
+  display: none; /* Don't show sidebar title, as it is too long to look good, and seem to lack structure for adequate layout. */
+}
+
+.ltx_page_header a[rel=prev] {
+  display: none; /* Don't show link to previous chapter. */
+}
+
+.ltx_page_header a[rel=next] {
+  display: none; /* Don't show link to previous chapter. */
 }
 
 .ltx_TOC {
@@ -91,7 +97,7 @@ nav > div.ltx_TOC {
   position: fixed;
   z-index: 3;
   top: 0px;
-  height: 2.5rem;
+  height: 1.5rem;
   padding: 0.5rem 1rem;
   background: #F6F6F6; /* Same as body. */
   color: black; /* Same as side bar. */
@@ -101,7 +107,7 @@ nav > div.ltx_TOC {
 
 .ltx_page_content {
   padding: 1rem;
-  margin-top: 2.5rem; /* Header height plus padding below, minus a little bit. */
+  margin-top: 1.5rem; /* Header height plus padding below, minus a little bit. */
   background: white;
 }
 
@@ -148,7 +154,7 @@ nav > div.ltx_TOC {
   }
   .ltx_page_navbar {
     width: 500px;
-    height: 3.5rem;
+    height: 2.5rem;
     left: calc(3rem - (500px + 8px));
     transition: 0.3s;
   }

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -50,3 +50,7 @@ a:hover { text-decoration: underline; }
   font-weight: bold;
   margin-bottom: 1em;
 }
+
+.ltx_dates {
+  display: none;
+}

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -41,3 +41,12 @@ a:hover { text-decoration: underline; }
 /* Undo the ltx-report.css setting that destroys parskip.sty style paragraphs.
  */
 .ltx_para > .ltx_p:first-child { text-indent: 0; }
+
+/* Treat heading for table of contents on front page as it it were a chapter title,
+ * by settings same style for .ltx_title_chapter in ltx-report.css.
+ */
+.ltx_document .ltx_TOC h6 {
+  font-size: 200%;
+  font-weight: bold;
+  margin-bottom: 1em;
+}

--- a/preamble.tex
+++ b/preamble.tex
@@ -250,7 +250,7 @@
 
 \newenvironment{synopsis}[1][modelica]{%
 \lstset{language=[synopsis]#1}%
-~\vspace*{-\parskip}\par
+~\vspace{-\parskip}\par
 }{%
 }
 \newenvironment{semantics}{%


### PR DESCRIPTION
This PR is a mix of various fixes related to styling of the document title, the document front pages, and the navbar.  Most notable changes (see individual commit messages for a more detailed list):
- The HTML title bar is cleaner.
- When collapsed, the navbar now sits up in the left corner, but substantially wider than before.
- The abstract is back on the front page of the PDF, and copyright stuff goes on a separate page before the table of contents.

@HansOlsson, is it possible to avoid squashing commits when merging?  Squashing makes it much harder for me to safely remove my local branches, as they are not known to be merged by Git.
