### PR TITLE
Fix fortran77

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1744,11 +1744,11 @@ Arguments of simple types are by default mapped as follows for FORTRAN~77:
                                          & \multicolumn{1}{c}{\tablehead{Input}} & \multicolumn{1}{c}{\tablehead{Output}}\\
 \hline
 \hline
-\lstinline!Real! & \lstinline[language=fortran77]!DOUBLE PRECISION! & \lstinline[language=fortran77]!DOUBLE PRECISION!\\
-\lstinline!Integer! & \lstinline[language=fortran77]!INTEGER! & \lstinline[language=fortran77]!INTEGER!\\
-\lstinline!Boolean! & \lstinline[language=fortran77]!LOGICAL! & \lstinline[language=fortran77]!LOGICAL!\\
+\lstinline!Real! & \lstinline[language=FORTRAN77]!DOUBLE PRECISION! & \lstinline[language=FORTRAN77]!DOUBLE PRECISION!\\
+\lstinline!Integer! & \lstinline[language=FORTRAN77]!INTEGER! & \lstinline[language=FORTRAN77]!INTEGER!\\
+\lstinline!Boolean! & \lstinline[language=FORTRAN77]!LOGICAL! & \lstinline[language=FORTRAN77]!LOGICAL!\\
 \lstinline!String! & \emph{Special} & \emph{Not available}\\
-Enumeration type & \lstinline[language=fortran77]!INTEGER! & \lstinline[language=fortran77]!INTEGER!\\
+Enumeration type & \lstinline[language=FORTRAN77]!INTEGER! & \lstinline[language=FORTRAN77]!INTEGER!\\
 \hline
 \end{tabular}
 \end{center}
@@ -1821,13 +1821,13 @@ section.
 \hline
 \hline
 \lstinline!T[$\mathit{dim}_{1}$]! &
-\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$!
+\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$!
 \\
 \lstinline!T[$\mathit{dim}_{1}$, $\mathit{dim}_{2}$]! &
-\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$, INTEGER $\mathit{dim}_{2}$!
+\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$, INTEGER $\mathit{dim}_{2}$!
 \\
 \lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! &
-\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$, $\ldots$, INTEGER $\mathit{dim}_{n}$!
+\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$, $\ldots$, INTEGER $\mathit{dim}_{n}$!
 \\
 \hline
 \end{tabular}
@@ -1859,7 +1859,7 @@ end foo;
 \end{lstlisting}
 the default assumptions correspond to a FORTRAN~77 function
 defined as follows:
-\begin{lstlisting}[language=fortran77]
+\begin{lstlisting}[language=FORTRAN77]
 FUNCTION foo(a, d1, d2, d3)
   DOUBLE PRECISION(d1, d2, d3) a
   INTEGER                      d1
@@ -1891,7 +1891,7 @@ external "FORTRAN 77"
 end foo;
 \end{lstlisting}
 The corresponding FORTRAN~77 subroutine would be declared as follows:
-\begin{lstlisting}[language=fortran77]
+\begin{lstlisting}[language=FORTRAN77]
 SUBROUTINE myfoo(x, y, n, m, u1, i, u2)
   DOUBLE PRECISION(n) x
   DOUBLE PRECISION(n,m) y
@@ -1981,12 +1981,12 @@ Return types are by default mapped as follows for C and FORTRAN~77:
 \multicolumn{1}{c|}{\tablehead{Modelica}} & \multicolumn{1}{c|}{\tablehead{C}} & \multicolumn{1}{c}{\tablehead{FORTRAN~77}}\\
 \hline
 \hline
-\lstinline!Real!    & \lstinline[language=C]!double!      & \lstinline[language=fortran77]!DOUBLE PRECISION!\\
-\lstinline!Integer! & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!INTEGER!\\
-\lstinline!Boolean! & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!LOGICAL!\\
+\lstinline!Real!    & \lstinline[language=C]!double!      & \lstinline[language=FORTRAN77]!DOUBLE PRECISION!\\
+\lstinline!Integer! & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!INTEGER!\\
+\lstinline!Boolean! & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!LOGICAL!\\
 \lstinline!String!  & \lstinline[language=C]!const char*! & \emph{Not allowed}\\
 \lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! & \emph{Not allowed} & \emph{Not allowed} \\
-Enumeration type    & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!INTEGER!\\
+Enumeration type    & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!INTEGER!\\
 Record              & See \cref{records}                  & \emph{Not allowed}\\
 \hline
 \end{tabular}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1744,11 +1744,11 @@ Arguments of simple types are by default mapped as follows for FORTRAN~77:
                                          & \multicolumn{1}{c}{\tablehead{Input}} & \multicolumn{1}{c}{\tablehead{Output}}\\
 \hline
 \hline
-\lstinline!Real! & \lstinline[language=FORTRAN77]!DOUBLE PRECISION! & \lstinline[language=FORTRAN77]!DOUBLE PRECISION!\\
-\lstinline!Integer! & \lstinline[language=FORTRAN77]!INTEGER! & \lstinline[language=FORTRAN77]!INTEGER!\\
-\lstinline!Boolean! & \lstinline[language=FORTRAN77]!LOGICAL! & \lstinline[language=FORTRAN77]!LOGICAL!\\
+\lstinline!Real! & \lstinline[language=fortran77]!DOUBLE PRECISION! & \lstinline[language=fortran77]!DOUBLE PRECISION!\\
+\lstinline!Integer! & \lstinline[language=fortran77]!INTEGER! & \lstinline[language=fortran77]!INTEGER!\\
+\lstinline!Boolean! & \lstinline[language=fortran77]!LOGICAL! & \lstinline[language=fortran77]!LOGICAL!\\
 \lstinline!String! & \emph{Special} & \emph{Not available}\\
-Enumeration type & \lstinline[language=FORTRAN77]!INTEGER! & \lstinline[language=FORTRAN77]!INTEGER!\\
+Enumeration type & \lstinline[language=fortran77]!INTEGER! & \lstinline[language=fortran77]!INTEGER!\\
 \hline
 \end{tabular}
 \end{center}
@@ -1821,13 +1821,13 @@ section.
 \hline
 \hline
 \lstinline!T[$\mathit{dim}_{1}$]! &
-\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$!
+\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$!
 \\
 \lstinline!T[$\mathit{dim}_{1}$, $\mathit{dim}_{2}$]! &
-\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$, INTEGER $\mathit{dim}_{2}$!
+\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$, INTEGER $\mathit{dim}_{2}$!
 \\
 \lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! &
-\lstinline[language=FORTRAN77]!T', INTEGER $\mathit{dim}_{1}$, $\ldots$, INTEGER $\mathit{dim}_{n}$!
+\lstinline[language=fortran77]!T', INTEGER $\mathit{dim}_{1}$, $\ldots$, INTEGER $\mathit{dim}_{n}$!
 \\
 \hline
 \end{tabular}
@@ -1981,12 +1981,12 @@ Return types are by default mapped as follows for C and FORTRAN~77:
 \multicolumn{1}{c|}{\tablehead{Modelica}} & \multicolumn{1}{c|}{\tablehead{C}} & \multicolumn{1}{c}{\tablehead{FORTRAN~77}}\\
 \hline
 \hline
-\lstinline!Real!    & \lstinline[language=C]!double!      & \lstinline[language=FORTRAN77]!DOUBLE PRECISION!\\
-\lstinline!Integer! & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!INTEGER!\\
-\lstinline!Boolean! & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!LOGICAL!\\
+\lstinline!Real!    & \lstinline[language=C]!double!      & \lstinline[language=fortran77]!DOUBLE PRECISION!\\
+\lstinline!Integer! & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!INTEGER!\\
+\lstinline!Boolean! & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!LOGICAL!\\
 \lstinline!String!  & \lstinline[language=C]!const char*! & \emph{Not allowed}\\
 \lstinline!T[$\mathit{dim}_{1}$, $\ldots$, $\mathit{dim}_{n}$]! & \emph{Not allowed} & \emph{Not allowed} \\
-Enumeration type    & \lstinline[language=C]!int!         & \lstinline[language=FORTRAN77]!INTEGER!\\
+Enumeration type    & \lstinline[language=C]!int!         & \lstinline[language=fortran77]!INTEGER!\\
 Record              & See \cref{records}                  & \emph{Not allowed}\\
 \hline
 \end{tabular}

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -56,6 +56,7 @@
         terminal,noEvent,smooth,sample,pre,edge,change,reinit,%
         previous,hold,subSample,superSample,shiftSample,backSample,noClock,firstTick,interval,%
         Real,Integer,Boolean,String},%
+    sensitive=true, % just in case
     comment=[l]{//}, % comment lines
     morecomment=[s]{/*}{*/}, % comment blocs
     morestring=[b]{'},
@@ -92,8 +93,8 @@
     morekeywords=[1]{|}
 }[keywords,comments,strings]
 
-% Duplicate this definition here to avoid issue - and name it "fortran77" to avoid problem in LatexML
-\lstdefinelanguage{fortran77}{%
+% Duplicate this definition here to avoid issue
+\lstdefinelanguage{FORTRAN77}{%
     basicstyle=\upshape\smallifpdf\ttfamily, % size of fonts used for the code
     morekeywords={%
         ASSIGN,BACKSPACE,CALL,CHARACTER,%
@@ -114,7 +115,7 @@
         LOG10,SIN,COS,TAN,ASIN,ACOS,ATAN,ATAN2,SINH,COSH,TANH,LGE,LLE,LLT,%
         LEN,INDEX},
     morekeywords=[4]{AND,EQ,EQV,FALSE,GE,GT,OR,LE,LT,NE,NEQV,NOT,TRUE},%
-    sensitive=f, % not Fortran-77 standard, but allowed in Fortran-95 %%
+    sensitive=true,
     morecomment=[f]*,
     morecomment=[f]C,
     morecomment=[f]c,
@@ -130,7 +131,7 @@
         short,signed,sizeof,static,struct,switch,typedef,union,unsigned,%
         void,volatile,while},
     % henrikt-ma: How about adding some highlighting of 'size_t' as a recognized name?
-    sensitive,
+    sensitive=true,
     morecomment=[s]{/*}{*/},
     morecomment=[l]//, % nonstandard
     morestring=[b]",


### PR DESCRIPTION
Working around an issue in LaTeXML

The basic issue is that "INTEGER" has the wrong color for Fortran77 if you look at https://specification.modelica.org/master/functions.html#simple-types

And it seems to work now. My assumption is that there is some cross-language talk for case insensitive keywords.