### PR TITLE
Remove outdated link to doc.modelica.org

### DIFF
--- a/chapters/library.tex
+++ b/chapters/library.tex
@@ -6,9 +6,8 @@ available, ready to use, and sharable between applications. For this
 reason, the Modelica Association develops and maintains a growing
 \emph{Modelica Standard Library} called \lstinline!package Modelica!. For an
 overview of the current version see
-\url{http://doc.modelica.org/help/Modelica_UsersGuide.html} or
-\url{http://doc.modelica.org/om/Modelica.UsersGuide.html}. This is a
-free library that can be used without essential restrictions, e.g., in
+\url{https://github.com/modelica/ModelicaStandardLibrary}.
+This is a free library that can be used without essential restrictions, e.g., in
 commercial Modelica simulation environments. The Modelica Standard
 Library is tool-neutral, and relies on a small library,
 ModelicaServices, that each conformant tool must implement to handle


### PR DESCRIPTION
~~Only link to OM generated help of MSL v4.0.0.~~

Alternatively (and avoiding the version dependency in the specification) we can update http://doc.modelica.org/om/Modelica.UsersGuide.html to redirect to https://doc.modelica.org/Modelica%204.0.0/Resources/helpOM/Modelica.html.