### PR TITLE
Fix missing \lstinline on 'input' and 'output'

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -129,8 +129,7 @@ Modelica functions have the following restrictions compared to a general
 Modelica \lstinline!class!:
 \begin{itemize}
 \item
-  Each input formal parameter of the function must be prefixed by the
-  keyword input, and each result formal parameter by the keyword output.
+  Each input formal parameter of the function must be prefixed by \lstinline!input!, and each result formal parameter by \lstinline!output!.
   All public variables are formal parameters.
 \item
   Input formal parameters are read-only after being bound to the actual


### PR DESCRIPTION
Saw this in text related to #2730.