### PR TITLE
Update Jenkins to auto-generate 3.4 branch pages, and not only 3.4 tag pages

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
           buildingTag()
           anyOf {
             branch 'master'
-            branch 'maint/*'                
+            branch 'maint/**'                
           }
         }
       }

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
           buildingTag()
           anyOf {
             branch 'master'
+            branch 'maint/*'                
           }
         }
       }


### PR DESCRIPTION
I assume this will automatically rebuild 3.4 as well.
And then it's only a matter of updating index at specification.modelica.org 