### PR TITLE
Clarify acyclic rule for non-fixed parameters

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -283,6 +283,8 @@ Thus it is not possible to introduce equations for parameters by cyclic dependen
 
 \begin{nonnormative}
 There is no exception for parameters with \lstinline!fixed = false!, despite the fact that such parameters are generally allowed to be initialized from systems of dependent equations.
+% Saying "binding equation" below even though it's called a "declaration equation", for consistency with the normative paragraph above.
+However, a parameter with \lstinline!fixed = false! can use an initial equation instead of a binding equation, allowing for cyclic dependencies.
 \end{nonnormative}
 
 \begin{example}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -281,6 +281,10 @@ end UseFirstOrder;
 The unexpanded binding equations for parameters and constants in the translated model must be acyclic after flattening; except that cycles are allowed if the cycles disappear when evaluating parameters having annotation \lstinline!Evaluate = true! that are not part of the cycle.
 Thus it is not possible to introduce equations for parameters by cyclic dependencies.
 
+\begin{nonnormative}
+There is no exception for parameters with \lstinline!fixed = false!, despite the fact that such parameters are generally allowed to be initialized from systems of dependent equations.
+\end{nonnormative}
+
 \begin{example}
 \begin{lstlisting}[language=modelica]
 constant Real p = 2 * q;

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -278,7 +278,8 @@ end UseFirstOrder;
 
 \subsection{Acyclic Bindings of Constants and Parameters}\label{acyclic-bindings-of-constants-and-parameters}
 
-The unexpanded binding equations for parameters and constants in the translated model must be acyclic after flattening; except that cycles are allowed if the cycles disappear when evaluating parameters having annotation \lstinline!Evaluate=true! that are not part of the cycle. Thus it is not possible to introduce equations for parameters by cyclic dependencies.
+The unexpanded binding equations for parameters and constants in the translated model must be acyclic after flattening; except that cycles are allowed if the cycles disappear when evaluating parameters having annotation \lstinline!Evaluate = true! that are not part of the cycle.
+Thus it is not possible to introduce equations for parameters by cyclic dependencies.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -302,7 +303,7 @@ parameter Real r = 2 * sin(r); // Illegal, since r = 2 * sin(r) is cyclic
 
 partial model PartialLumpedVolume
   parameter Boolean use_T_start = true "= true, use T_start, otherwise h_start"
-    annotation(Dialog(tab = "Initialization"), Evaluate=true);
+    annotation(Dialog(tab = "Initialization"), Evaluate = true);
   parameter Medium.Temperature T_start=if use_T_start then system.T_start else
       Medium.temperature_phX(p_start,h_start,X_start)
     annotation(Dialog(tab = "Initialization", enable = use_T_start));


### PR DESCRIPTION
I'd like this to be clarified one way or another.  The current way appears to be just a clarification, while the other alternative – to say that declaration equations are excluded from the rule for non-fixed parameters – would seem more like an actual change.

When a declaration equation of a non-fixed parameter breaks the rule, I think it will always be possible to add the equations under `initial equation` instead, so there is an easy workaround for any models that work break due to this clarification.
