### PR TITLE
Make constants available to type definitions

### DIFF
--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -5,7 +5,6 @@ This document describes differences between Flat Modelica and Modelica that aren
 
 The top level structure (see [grammar](grammar.md#Start-rule)) of a Flat Modelica description can have several top level definitions, with a mandatory `model` definition at the end.
 The definitions before the `model` either define types or global constants.
-The _component-clause_ of a global constant must use `constant` as its only _type-prefix_.
 
 ## Unbalanced if-equations
 In Flat Modelica, all branches of an `if`-equation must have the same equation size.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -1,6 +1,11 @@
 # Semantical differences between Flat Modelica and Modelica
 This document describes differences between Flat Modelica and Modelica that aren't clear from the differences in the grammars.
 
+## Top level structure
+
+The top level structure (see [grammar](grammar.md#Start-rule)) of a Flat Modelica description can have several top level definitions, with a mandatory `model` definition at the end.
+The definitions before the `model` define types.
+
 ## Unbalanced if-equations
 In Flat Modelica, all branches of an `if`-equation must have the same equation size.
 Absence of an else branch is equivalent to having an empty else branch with equation size 0.

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -4,7 +4,8 @@ This document describes differences between Flat Modelica and Modelica that aren
 ## Top level structure
 
 The top level structure (see [grammar](grammar.md#Start-rule)) of a Flat Modelica description can have several top level definitions, with a mandatory `model` definition at the end.
-The definitions before the `model` define types.
+The definitions before the `model` either define types or global constants.
+The _component-clause_ of a global constant must use `constant` as its only _type-prefix_.
 
 ## Unbalanced if-equations
 In Flat Modelica, all branches of an `if`-equation must have the same equation size.

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -65,7 +65,9 @@ The _S-CHAR_ accepts Unicode other than " and \\:
 ## Start rule
 > _flat-modelica_ →\
 > &emsp; _VERSION-HEADER_\
-> &emsp; ( _class-definition_ | _component-clause_ )*\
+> &emsp; ( _class-definition_ **;**\
+> &emsp; | _global-constant_ **;**\
+> &emsp; )*\
 > &emsp; **model** _long-class-specifier_ **;**
 
 Here, the _VERSION-HEADER_ is a Flat Modelica variant of the not yet standardized language version header for Modelica proposed in [MCP-0015](https://github.com/modelica/ModelicaSpecification/tree/MCP/0015/RationaleMCP/0015):
@@ -166,6 +168,8 @@ end _F;
 
 ## B24 Component clause
 > _component-clause_ → _type-prefix_ _type-specifier_ _array-subscripts_? _component-list_
+
+> _global-constant_ → **constant** _type-specifier_ _array-subscripts_? _declaration_ _comment_
 
 > _type-prefix_ →\
 > &emsp; ( **flow** | **stream** )?\

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -70,15 +70,25 @@ The _S-CHAR_ accepts Unicode other than " and \\:
 > &emsp; )*\
 > &emsp; **model** _long-class-specifier_ **;**
 
+
+> &emsp;&emsp; **model** _IDENT_ _string-comment_\
+> &emsp;&emsp;&emsp; _composition_\
+> &emsp;&emsp; **end** _IDENT_ **;**\
+> &emsp; **end** _IDENT_ **;**
+
 Here, the _VERSION-HEADER_ is a Flat Modelica variant of the not yet standardized language version header for Modelica proposed in [MCP-0015](https://github.com/modelica/ModelicaSpecification/tree/MCP/0015/RationaleMCP/0015):
 > _VERSION-HEADER_ → `^\U+FEFF?//![ ]flat[ ][0-9]+[.][0-9]+[r.][0-9]+$`
 
 The `\U+FEFF?` at the very beginning is an optional byte order mark.
 
+The four occurrences of _IDENT_ in the _flat-modelica_ rule must be the same identifier.
+
 As an example of the _flat-modelica_ rule, this is a minimal valid Flat Modelica source:
 ```
 //! flat 3.5.0
-model _F
+package _F
+  model _F
+  end _F;
 end _F;
 ```
 

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -65,7 +65,7 @@ The _S-CHAR_ accepts Unicode other than " and \\:
 ## Start rule
 > _flat-modelica_ →\
 > &emsp; _VERSION-HEADER_\
-> &emsp; _class-definition_*\
+> &emsp; ( _class-definition_ | _component-clause_ )*\
 > &emsp; **model** _long-class-specifier_ **;**
 
 Here, the _VERSION-HEADER_ is a Flat Modelica variant of the not yet standardized language version header for Modelica proposed in [MCP-0015](https://github.com/modelica/ModelicaSpecification/tree/MCP/0015/RationaleMCP/0015):


### PR DESCRIPTION
This PR breaks out the part of #2558 concerning the top level structure of a Flat Modelica description.  The problem that needs to be solved is to make definitions of constants available to type definitions.
