### PR TITLE
Fix example in 12.4.6

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -858,7 +858,7 @@ size, and they are traversed in parallel.
 \begin{lstlisting}[language=modelica]
 sin({a, b, c}) = {sin(a), sin(b), sin(c)} // argument is a vector
 sin([a, b, c]) = [sin(a), sin(b), sin(c)] // argument may be a matrix
-atan({a, b, c}, {d, e, f}) = {atan(a, d), atan(b, e), atan(c, f)}
+atan2({a, b, c}, {d, e, f}) = {atan2(a, d), atan2(b, e), atan2(c, f)}
 \end{lstlisting}
 This works even if the function is declared to take an array as
 one of its arguments. If \lstinline!pval! is defined as a function that takes


### PR DESCRIPTION
- Change atan to atan2 in the example, since the number of arguments is wrong otherwise.