### PR TITLE
Array declarations can't have zero dimensions

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -61,7 +61,11 @@ An array indexed by \lstinline!Boolean! or enumeration type can only be used in 
 
 % IMPROVETOP
 \begin{table}[H]
-\caption{General forms of declaration of arrays.  The notation \lstinline!EB! stands for an enumeration type or \lstinline!Boolean!.  The general array array can have zero or more dimensions ($k \geq 0$).}
+\caption{%
+General forms of declaration of arrays.
+The notation \lstinline!EB! stands for an enumeration type or \lstinline!Boolean!.
+The general array array can have one or more dimensions ($k \geq 1$).
+}
 \begin{center}
 \begin{tabular}{l l c l l}
 \hline


### PR DESCRIPTION
I don't know when the statement that there can be zero or more dimension in a general array component declaration, but the grammar still seems to think that there shall be at least one:
```
array-subscripts :
   "[" subscript { "," subscript } "]"
```