### PR TITLE
Improve formulation of rational clock.

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -342,17 +342,18 @@ Clock(intervalCounter=$\mathit{intervalCounter}$, resolution=$\mathit{resolution
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \firstuse{Rational interval clock}.
-The first input argument, $\mathit{intervalCounter}$, is a clocked component expression (\cref{def:component-expression}) or a parameter expression of type \lstinline!Integer! with \lstinline!min = 0!.
+The first input argument, $\mathit{intervalCounter}$, is a clocked component expression (\cref{def:component-expression}), or a parameter expression of type \lstinline!Integer! with \lstinline!min = 0!.
 The optional second argument $\mathit{resolution}$ (defaults to 1) is a parameter expression of type \lstinline!Integer! with \lstinline!min = 1! and \lstinline!unit = "Hz"!.
 If $\mathit{intervalCounter}$ is a parameter expression with value zero, the period of the clock is derived by clock inference, see \cref{sub-clock-inferencing}.
+
+If $\mathit{intervalCounter}$ is a parameter expression greater than zero, the clock defines a periodic clock.
+If $\mathit{intervalCounter}$ is a clocked component expression it must greater than zero.
 The result is of base type \lstinline!Clock! that ticks when \lstinline!time! becomes $t_{\mathrm{start}}$, $t_{\mathrm{start}} + \mathit{interval}_{1}$, $t_{\mathrm{start}} + \mathit{interval}_{1} + \mathit{interval}_{2}$, \@\ldots{}
 The clock starts at the start of the simulation $t_{\mathrm{start}}$ or when the controller is switched on.
 At the start of the simulation, \lstinline!previous($\mathit{intervalCounter}$)! = \lstinline!$\mathit{intervalCounter}$.start! and the clocks ticks the first time.
 At the first clock tick $\mathit{intervalCounter}$ must be computed and the second clock tick is then triggered at $\mathit{interval}_{1} = \mathit{intervalCounter}/\mathit{resolution}$.
 At the second clock tick at time $t_{\mathrm{start}} + \mathit{interval}_{1}$, a new value for $\mathit{intervalCounter}$ must be computed and the next clock tick is scheduled at $\mathit{interval}_{2} = \mathit{intervalCounter}/\mathit{resolution}$, and so on.
-If
-interval % This should be "intervalCounter", right?
-is a parameter expression, the clock defines a periodic clock.
+
 
 \begin{nonnormative}
 The given interval and time shift % What given "interval" and "time shift"?

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -342,12 +342,12 @@ Clock(intervalCounter=$\mathit{intervalCounter}$, resolution=$\mathit{resolution
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \firstuse{Rational interval clock}.
-The first input argument, $\mathit{intervalCounter}$, is a clocked component expression (\cref{def:component-expression}), or a parameter expression of type \lstinline!Integer! with \lstinline!min = 0!.
+The first input argument, $\mathit{intervalCounter}$, is a clocked component expression (\cref{def:component-expression}) or a parameter expression of type \lstinline!Integer! with \lstinline!min = 0!.
 The optional second argument $\mathit{resolution}$ (defaults to 1) is a parameter expression of type \lstinline!Integer! with \lstinline!min = 1! and \lstinline!unit = "Hz"!.
 If $\mathit{intervalCounter}$ is a parameter expression with value zero, the period of the clock is derived by clock inference, see \cref{sub-clock-inferencing}.
 
 If $\mathit{intervalCounter}$ is a parameter expression greater than zero, the clock defines a periodic clock.
-If $\mathit{intervalCounter}$ is a clocked component expression it must greater than zero.
+If $\mathit{intervalCounter}$ is a clocked component expression it must be greater than zero.
 The result is of base type \lstinline!Clock! that ticks when \lstinline!time! becomes $t_{\mathrm{start}}$, $t_{\mathrm{start}} + \mathit{interval}_{1}$, $t_{\mathrm{start}} + \mathit{interval}_{1} + \mathit{interval}_{2}$, \@\ldots{}
 The clock starts at the start of the simulation $t_{\mathrm{start}}$ or when the controller is switched on.
 At the start of the simulation, \lstinline!previous($\mathit{intervalCounter}$)! = \lstinline!$\mathit{intervalCounter}$.start! and the clocks ticks the first time.


### PR DESCRIPTION
It might be that we should have a clearer separator for the =0 case.
Closes #2386