### PR TITLE
Fix issues related to 'declaration equation' in index

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -203,7 +203,7 @@ Conditional declarations of components are described in \cref{conditional-compon
 
 \subsubsection{Declaration Equations}\label{declaration-equations}
 
-An environment that defines the value of a component of built-in type is said to define a \firstuse{declaration equation} associated with the declared component.
+An environment that defines the value of a component of built-in type is said to define a \firstuse{declaration equation}\index{declaration equation}\index{declaration equation|seealso{binding equation}} associated with the declared component.
 % Note: In variability-of-expressions, it's called a "binding equation", not "declaration equation".
 The declaration equation is of the form \lstinline!x = expression! defined by a component declaration, where \lstinline!expression! must not have higher variability than the declared component \lstinline!x! (see \cref{variability-of-expressions}).
 Unlike other equations, a declaration equation can be overridden (replaced or removed) by an element modification.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -19,9 +19,9 @@ Equations in Modelica can be classified into different categories depending on t
 \item
   Normal equality equations occurring in equation sections, including connect-equations and other equation types of special syntactic form (\cref{equations-in-equation-sections}).
 \item
-  Declaration equations, which are part of variable, parameter, or constant declarations (\cref{declaration-equations}).
+  Declaration equations\index{declaration equation|hyperpageit}, which are part of variable, parameter, or constant declarations (\cref{declaration-equations}).
 \item
-  Modification equations, which are commonly used to modify attributes of classes (\cref{modifications}).
+  Modification equations\index{modification equation|hyperpageit}, which are commonly used to modify attributes of classes (\cref{modifications}).
 \item
   \firstuse{Binding equations}\index{binding equation}, which include both declaration equations and element modification for the value of the variable itself.
   These are considered equations when appearing outside functions, and then a component with a binding equation has its value bound to some expression.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -727,7 +727,7 @@ Components in a function can be divided into three groups:
 When a function is called components of a function do not have start-attributes.
 However, a binding equation\index{binding equation!in function} (\lstinline!= expression!) with an expression may be present for a component.
 \begin{nonnormative}
-\firstuse{Declaration assignments}\index{declaration equation (deprecated)} of the form \lstinline!:= expression! are deprecated, but otherwise identical to binding equations.
+\firstuse{Declaration assignments}\index{declaration assignment (deprecated)} of the form \lstinline!:= expression! are deprecated, but otherwise identical to binding equations.
 \end{nonnormative}
 
 A binding equation for a non-input component initializes the


### PR DESCRIPTION
This both fixes an error in the index for 'declaration equation' pointing to the deprecated 'declaration assignment', and further improves the index on the topic of declaration equations.

(I encountered this while answering to #2780.)
