### PR TITLE
Don't treat 'exit' as keyword in listings

### DIFF
--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -41,7 +41,6 @@
     morekeywords=[2]{% blue + bold keywords
         annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
         each,encapsulated,enumeration,else,elseif,elsewhen,end,%
-        exit,% henrikt-ma: What is 'exit' doing here?
         expandable,extends,external,final,flow,for,%
         function,if,in,inner,initial,input,import,loop,model,%
         nondiscrete,% Not a keyword anymore, right?
@@ -87,7 +86,7 @@
     breakatwhitespace=true,
     morekeywords=[2]{%
         letters,annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
-        each,encapsulated,else,elseif,elsewhen,end,exit,expandable,extends,external,final,flow,for,%
+        each,encapsulated,else,elseif,elsewhen,end,expandable,extends,external,final,flow,for,%
         function,if,in,inner,initial,input,import,loop,model,%
         nondiscrete,% Not a keyword anymore, right?
         operator,outer,%


### PR DESCRIPTION
Maybe `exit` was a keyword in the beginning, before revision history was introduced?
