### PR TITLE
Say 'variable value' instead of 'value-attribute'

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1362,7 +1362,7 @@ For a short replaceable class definition only the fields \lstinline!tab!, \lstin
 The annotations \lstinline!tab! and \lstinline!group! define the placement of the component or of variables in a dialog with optional tab and group specification, where the empty string (default) means tool-specific group.
 The idea is that a tool may as default place parameters in the group ``Parameters'' in the tab ``General'', but add e.g., variables with \lstinline!showStartAttribute=true! to another group.
 If \lstinline!enable = false!, the input field may be disabled and no input can be given.
-If \lstinline!showStartAttribute = true! the dialog should allow the user to set the start-value and the \lstinline!fixed! attribute for the variable instead of the variable value.
+If \lstinline!showStartAttribute = true! the dialog should allow the user to set the start-value and the \lstinline!fixed! attribute for the variable instead of the value of the variable.
 
 \begin{nonnormative}
 The \lstinline!showStartAttribute = true! is primarily intended for non-parameter values and avoids introducing

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1359,15 +1359,10 @@ annotation(Dialog(enable = true,
 \end{lstlisting}
 For a short replaceable class definition only the fields \lstinline!tab!, \lstinline!group!, \lstinline!enable! and \lstinline!groupImage! are allowed.
 
-The annotations \lstinline!tab! and \lstinline!group! define the placement of
-the component or of variables in a dialog with optional tab and group
-specification, where the empty string (default) means tool-specific group.
-The idea is that a tool may as default place parameters in the group ``Parameters'' in the tab ``General'',
-but add e.g., variables with \lstinline!showStartAttribute=true! to another group.
-If \lstinline!enable = false!, the input field may
-be disabled and no input can be given. If \lstinline!showStartAttribute = true! the dialog should allow the user to
-% henrikt-ma: What is the "value-attribute"?
-set the start-value and the \lstinline!fixed! attribute for the variable instead of the value-attribute.
+The annotations \lstinline!tab! and \lstinline!group! define the placement of the component or of variables in a dialog with optional tab and group specification, where the empty string (default) means tool-specific group.
+The idea is that a tool may as default place parameters in the group ``Parameters'' in the tab ``General'', but add e.g., variables with \lstinline!showStartAttribute=true! to another group.
+If \lstinline!enable = false!, the input field may be disabled and no input can be given.
+If \lstinline!showStartAttribute = true! the dialog should allow the user to set the start-value and the \lstinline!fixed! attribute for the variable instead of the variable value.
 
 \begin{nonnormative}
 The \lstinline!showStartAttribute = true! is primarily intended for non-parameter values and avoids introducing


### PR DESCRIPTION
While I can see how the term _value-attribute_ can be understood by looking at the definitions of the primitive types, the term isn't used anywhere else, and I think it is better if it is avoided here as well.

Suggestions for other ways of phrasing this are welcome.