### PR TITLE
Better integration of terms 'instantaneous equation/statement'

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -4,16 +4,9 @@ An \firstuse{equation}\index{equation} is part of a class definition.
 A scalar equation relates scalar variables, i.e., constrains the values that these variables can take simultaneously.
 When $n$-1 variables of an equation containing $n$ variables are known, the value of the $n$:th variable can be inferred (solved for).
 In contrast to a statement in an algorithm section, an equation does not define for which of its variable it is to be solved.
-% henrikt-ma: Keeping this sentence from the old glossary only because it mentions the 'instantaneous equations':
-Special cases are: initial equations, instantaneous equations, declaration equations.
-
-% Including definition of 'instantaneous' from old glossary here, even though the term isn't really used outside the introductory chapter.
-An equation or statement is \firstuse{instantaneous}\index{instantaneous} if it holds only at events, i.e., at single points in time.
-The equations and statements of a when-clause are instantaneous, see \cref{when-equations} and \cref{when-statements}.
 
 \section{Equation Categories}\label{equation-categories}
 
-% henrikt-ma: One would have expected this list to also describe the instantaneous equations.
 Equations in Modelica can be classified into different categories depending on the syntactic context in which they occur:
 \begin{itemize}
 \item
@@ -26,6 +19,10 @@ Equations in Modelica can be classified into different categories depending on t
   \firstuse{Binding equations}\index{binding equation}, which include both declaration equations and element modification for the value of the variable itself.
   These are considered equations when appearing outside functions, and then a component with a binding equation has its value bound to some expression.
   (Binding equations can also appear in functions, see \cref{initialization-and-binding-equations-of-components-in-functions}.)
+\item
+  \willintroduce{Instantaneous} equations\index{instantaneous!equation|hyperpageit}.
+  An equation or statement is \firstuse{instantaneous}\index{instantaneous} if it holds only at events, i.e., at single points in time.
+  The equations and statements of a when-clause are instantaneous, see \cref{when-equations} and \cref{when-statements}.
 \item
   \willintroduce{Initial equations}, which are used to express equations for solving initialization problems (\cref{initialization-initial-equation-and-initial-algorithm}).
 \end{itemize}
@@ -203,7 +200,8 @@ when expression then
 end when ";"
 \end{lstlisting}
 
-The \lstinline!expression! of a when-equation shall be a discrete-time \lstinline!Boolean! scalar or vector expression.  The statements within a when-equation are activated when the scalar expression or any of the elements of the vector expression becomes true.
+The \lstinline!expression! of a when-equation shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
+The equations within a when-equation are known as \firstuse{instantaneous equations}\index{instantaneous!equation}, and are activated only at the instant when the scalar expression or any of the elements of the vector expression becomes true.
 
 \begin{example}
 The order between the equations in a when-equation does not matter, e.g.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -20,10 +20,6 @@ Equations in Modelica can be classified into different categories depending on t
   These are considered equations when appearing outside functions, and then a component with a binding equation has its value bound to some expression.
   (Binding equations can also appear in functions, see \cref{initialization-and-binding-equations-of-components-in-functions}.)
 \item
-  \willintroduce{Instantaneous} equations\index{instantaneous!equation|hyperpageit}.
-  An equation or statement is \firstuse{instantaneous}\index{instantaneous} if it holds only at events, i.e., at single points in time.
-  The equations and statements of a when-clause are instantaneous, see \cref{when-equations} and \cref{when-statements}.
-\item
   \willintroduce{Initial equations}, which are used to express equations for solving initialization problems (\cref{initialization-initial-equation-and-initial-algorithm}).
 \end{itemize}
 
@@ -201,7 +197,7 @@ end when ";"
 \end{lstlisting}
 
 The \lstinline!expression! of a when-equation shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
-The equations within a when-equation are known as \firstuse{instantaneous equations}\index{instantaneous!equation}, and are activated only at the instant when the scalar expression or any of the elements of the vector expression becomes true.
+The equations within a when-equation are activated only at the instant when the scalar expression or any of the elements of the vector expression becomes true.
 
 \begin{example}
 The order between the equations in a when-equation does not matter, e.g.

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -27,7 +27,7 @@ algebraic and discrete equations (= flat hybrid DAE). Note that
 satisfying the semantic restrictions does not guarantee that the model
 can be initialized from the initial conditions and simulated.
 
-Modelica was designed to facilitate symbolic transformations of models, especially by mapping basically every Modelica language construct to continuous or instantaneous equations in the flat Modelica structure.
+Modelica was designed to facilitate symbolic transformations of models, especially by mapping basically every Modelica language construct to equations in the flat Modelica structure.
 Many Modelica models, especially in the associated Modelica Standard Library, are higher index systems, and can only be reasonably simulated if symbolic index reduction is performed, i.e., equations are differentiated and appropriate variables are selected as states, so that the resulting system of equations can be transformed to state space form (at least locally numerically), i.e., a hybrid DAE of index zero.
 In order to allow this structural analysis, a tool may reject simulating a model if parameters cannot be evaluated during translation -- due to calls of external functions or initial equations/initial algorithms for \lstinline!fixed = false! parameters.
 Accepting such models is a quality of implementation issue.
@@ -61,18 +61,11 @@ The flat hybrid DAE form consists of:
   section (number of equations = number of different assigned
   variables).
 \item
-  When-clauses where every when-clause is treated as a set of
-  conditionally evaluated equations, also called instantaneous
-  equations, which are functions of the variables occurring in the
-  clause (number of equations = number of different assigned variables).
+  When-clauses where every when-clause is treated as a set of conditionally evaluated equations, which are functions of the variables occurring in the clause (number of equations = number of different assigned variables).
 \end{itemize}
 
-Therefore, a flat hybrid DAE is seen as a set of equations where some of
-the equations are only conditionally evaluated (e.g.\ instantaneous
-equations are only evaluated when the corresponding when-condition
-becomes true). Initial setup of the model is specified using
-start-values and instantaneous equations that hold at the initial time
-only.
+Therefore, a flat hybrid DAE is seen as a set of equations where some of the equations are only conditionally evaluated.
+Initial setup of the model is specified using start-values and equations that hold at the initial time only.
 
 A Modelica class may also contain annotations, i.e.\ formal comments,
 which specify graphical representations of the class (icon and diagram),

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -27,22 +27,12 @@ algebraic and discrete equations (= flat hybrid DAE). Note that
 satisfying the semantic restrictions does not guarantee that the model
 can be initialized from the initial conditions and simulated.
 
-Modelica was designed to facilitate symbolic transformations of models,
-especially by mapping basically every Modelica language construct to
-continuous or instantaneous equations in the flat Modelica structure.
-Many Modelica models, especially in the associated Modelica Standard
-Library, are higher index systems, and can only be reasonably simulated
-if symbolic index reduction is performed, i.e., equations are
-differentiated and appropriate variables are selected as states, so that
-the resulting system of equations can be transformed to state space form
-(at least locally numerically), i.e., a hybrid DAE of index zero. In
-order to allow this structural analysis, a tool may reject simulating a
-model if parameters cannot be evaluated during translation -- due to
-calls of external functions or initial equations/initial algorithms for
-fixed=false parameters. Accepting such models is a quality of
-implementation issue. The Modelica specification does not define how to
-simulate a model. However, it defines a set of equations that the
-simulation result should satisfy as well as possible.
+Modelica was designed to facilitate symbolic transformations of models, especially by mapping basically every Modelica language construct to continuous or instantaneous equations in the flat Modelica structure.
+Many Modelica models, especially in the associated Modelica Standard Library, are higher index systems, and can only be reasonably simulated if symbolic index reduction is performed, i.e., equations are differentiated and appropriate variables are selected as states, so that the resulting system of equations can be transformed to state space form (at least locally numerically), i.e., a hybrid DAE of index zero.
+In order to allow this structural analysis, a tool may reject simulating a model if parameters cannot be evaluated during translation -- due to calls of external functions or initial equations/initial algorithms for \lstinline!fixed = false! parameters.
+Accepting such models is a quality of implementation issue.
+The Modelica specification does not define how to simulate a model.
+However, it defines a set of equations that the simulation result should satisfy as well as possible.
 
 The key issues of the translation (or flattening) are:
 \begin{itemize}

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -65,7 +65,7 @@ The flat hybrid DAE form consists of:
 \end{itemize}
 
 Therefore, a flat hybrid DAE is seen as a set of equations where some of the equations are only conditionally evaluated.
-Initial setup of the model is specified using start-values and equations that hold at the initial time only.
+Initial setup of the model is specified using start-values and equations that hold only during initialization.
 
 A Modelica class may also contain annotations, i.e.\ formal comments,
 which specify graphical representations of the class (icon and diagram),

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -378,7 +378,9 @@ when expression then
   { statement ";" } }
 end when
 \end{lstlisting}
-The \lstinline!expression! of a when-statement shall be a discrete-time \lstinline!Boolean! scalar or vector expression.  The algorithmic statements within a when-statement are activated when the scalar or any one of the elements of the vector-expression becomes true.
+
+The \lstinline!expression! of a when-statement shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
+The statements within a when-statement are known as \emph{instantaneous statements}\index{instantaneous!statement}, and are activated only at the instant when the scalar or any one of the elements of the vector-expression becomes true.
 
 \begin{example}
 Algorithms are activated when \lstinline!x! becomes \textgreater{} 2:

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -380,7 +380,7 @@ end when
 \end{lstlisting}
 
 The \lstinline!expression! of a when-statement shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
-The statements within a when-statement are known as \emph{instantaneous statements}\index{instantaneous!statement}, and are activated only at the instant when the scalar or any one of the elements of the vector-expression becomes true.
+The statements within a when-statement are activated only at the instant when the scalar or any one of the elements of the vector-expression becomes true.
 
 \begin{example}
 Algorithms are activated when \lstinline!x! becomes \textgreater{} 2:


### PR DESCRIPTION
This addresses another comment left behind when introducing the document index.

Since the terms _instantaneous_, _instantaneous equation_, and _instantaneous statement_ are only used in the introductory chapter, one alternative seems to be to not have them introduced at all.  On the other hand, the idea of having these concepts defined isn't strange to me, so I'm just bringing this up as a possibility rather than actually suggesting to remove them.
