### PR TITLE
Use comments instead of text escape in array indexing listing

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -969,15 +969,21 @@ An indexing operation is assumed to take constant time, i.e., largely independen
 \end{nonnormative}
 
 \begin{example}
-% henrikt-ma: This listing needs to be cleaned up from confusing punctuation.
-\begin{lstlisting}[language=modelica, escapechar=!]
-a[:, j] !\emph{is a vector of the j-th column of a,}!
-a[j] !\emph{is a vector of the j-th row of a:}! a[j, :]
-a[j : k] is {[a[j], a[j+1], ... , a[k]}
-a[:,j : k] is [a[:,j], a[:,j+1], ... , a[:,k]],
-v[2:2:8] = v[ {2,4,6,8} ] .
-v[{j,k}] := {2,3}; // Same as v[j] := 2; v[k] := 3;
-v[{1,1}] := {2,3}; // Same as v[1] := 3;
+Array indexing expressions:
+\begin{lstlisting}[language=modelica]
+a[:, j]      // Vector of the j-th column of a.
+a[j]         // Vector of the j-th row of a. Same as: a[j, :]
+a[j : k]     // Same as: {[a[j], a[j+1], $\ldots$, a[k]}
+a[:, j : k]  // Same as: [a[:, j], a[:, j+1], $\ldots$, a[:, k]]
+\end{lstlisting}
+The range vector operator is just a special case of a vector expression:
+\begin{lstlisting}[language=modelica]
+v[2 : 2 : 8] // Same as: v[{2, 4, 6, 8}]
+\end{lstlisting}
+Array indexing in assignment statements:
+\begin{lstlisting}[language=modelica]
+v[{j, k}] := {2, 3}; // Same as: v[j] := 2; v[k] := 3;
+v[{1, 1}] := {2, 3}; // Same as: v[1] := 3;
 \end{lstlisting}
 If \lstinline!x! is a vector, \lstinline!x[1]! is a scalar, but the slice \lstinline!x[1:5]! is a vector
 (a vector-valued or colon index expression causes a vector to be returned).

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -973,7 +973,7 @@ Array indexing expressions:
 \begin{lstlisting}[language=modelica]
 a[:, j]      // Vector of the j-th column of a.
 a[j]         // Vector of the j-th row of a. Same as: a[j, :]
-a[j : k]     // Same as: {[a[j], a[j+1], $\ldots$, a[k]}
+a[j : k]     // Same as: {a[j], a[j+1], $\ldots$, a[k]}
 a[:, j : k]  // Same as: [a[:, j], a[:, j+1], $\ldots$, a[:, k]]
 \end{lstlisting}
 The range vector operator is just a special case of a vector expression:


### PR DESCRIPTION
This makes the example more aligned with other examples, and thereby easier to read and understand.