### PR TITLE
Less subtle syntax highlighting of class 3 keywords 

### DIFF
--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -12,7 +12,7 @@
 
 \definecolor{keywordcolor1} {rgb}{0.07, 0.46, 0.00}
 \definecolor{keywordcolor3} {rgb}{0.00, 0.20, 0.47}
-\definecolor{commentcolor}  {rgb}{0.58, 0.13  0.57}
+\definecolor{commentcolor}  {rgb}{0.58, 0.13, 0.57}
 
 % It would be nice to have comments set in normal variable-width font without any sort of
 % column alignment by the listsings.sty package, just like the comments look in the LaTeXML build.

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -13,6 +13,7 @@
 \definecolor{keywordcolor1} {rgb}{0.07, 0.46, 0.00}
 \definecolor{keywordcolor3} {rgb}{0.00, 0.20, 0.47}
 \definecolor{commentcolor}  {rgb}{0.58, 0.13, 0.57}
+\definecolor{stringcolor}   {rgb}{0.15, 0.15, 0.15}
 
 % It would be nice to have comments set in normal variable-width font without any sort of
 % column alignment by the listsings.sty package, just like the comments look in the LaTeXML build.
@@ -159,7 +160,7 @@
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
   keywordstyle=[3]\color{keywordcolor3},
-  stringstyle=\color{black},     % string literal style
+  stringstyle=\color{stringcolor},
   language=[short]modelica,     % Language that will be used by default, in particluar by plain \lstinline.
   showstringspaces=false,
   frame=lrtb,

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -10,9 +10,9 @@
 \usepackage{color}
 \usepackage[table]{xcolor}
 
-\definecolor{keywordcolor1} {rgb}{0.00, 0.20, 0.47}
-\definecolor{keywordcolor3} {rgb}{0.33, 0.24, 0.03}
-\definecolor{commentcolor}  {rgb}{0.07, 0.46, 0.00}
+\definecolor{keywordcolor1} {rgb}{0.07, 0.46, 0.00}
+\definecolor{keywordcolor3} {rgb}{0.00, 0.20, 0.47}
+\definecolor{commentcolor}  {rgb}{0.58, 0.13  0.57}
 
 % It would be nice to have comments set in normal variable-width font without any sort of
 % column alignment by the listsings.sty package, just like the comments look in the LaTeXML build.

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -37,8 +37,8 @@
     basicstyle=\upshape\smallifpdf\ttfamily, % Font size for displayed code listings.
     alsoletter={},
 %   otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
-    morekeywords=[1]{}, % blue Keywords
-    morekeywords=[2]{% blue + bold keywords
+    morekeywords=[1]{},
+    morekeywords=[2]{%
         annotation,assert,block,break,class,connector,constant,constrainedby,discrete,%
         each,encapsulated,enumeration,else,elseif,elsewhen,end,%
         expandable,extends,external,final,flow,for,%


### PR DESCRIPTION
I'm sorry to bring up the question about syntax colors in listings once more, but having spent some time with the new color of class 3 keywords (`der`, `Real`, etc), I find the brown too subtle.  It doesn't pop out too much when used in inline listings (like the old red color did), which is an improvement, but it has become too similar – at least to my eyes – to the un-highlighted black.  If anything, it just looks de-highlighted:
![syntax-colors-current](https://user-images.githubusercontent.com/25294143/103250035-40f79980-4972-11eb-97f1-090c0d4009f3.png)

I find the problem being exaggerated when viewing at low magnification, like when reading on my phone.

Maybe this isn't a big deal, but I feel responsible to bring it up because I was driving the change from the old popping-out-red to the current de-highlighted-brown.

To improve the situation, I've come to the conclusion that the green color serves better as a keyword color than as comment color, as green doesn't pop out too much to be used in inline listings.  Comments, on the other hand, are rarely seen in inline listings, and can therefore use colors that would pop out too much when used in inline listings.  I chose a color called _plum_ which I found to both give good contrast and clear separation from non-comment code.

With both blue and green tones working well in inline listings, I find that blue is more similar to black, and that it therefore makes most sense to apply this to keyword class 3, meaning that green would be used for the actual keywords.

With this reasoning, the excerpt above turns into this:
![syntax-colors-new](https://user-images.githubusercontent.com/25294143/103250384-d8112100-4973-11eb-8dbf-b951087f1407.png)

This PR is opened in _Draft_ state both to indicate that the proposed colors are something I expect to raise reactions that will require adjustments, but also because I'd like to also include updated figures before merging.
