### PR TITLE
Use colon instead of dash when attaching 'th' to ordinals

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -971,8 +971,8 @@ An indexing operation is assumed to take constant time, i.e., largely independen
 \begin{example}
 Array indexing expressions:
 \begin{lstlisting}[language=modelica]
-a[:, j]      // Vector of the j-th column of a.
-a[j]         // Vector of the j-th row of a. Same as: a[j, :]
+a[:, j]      // Vector of the j:th column of a.
+a[j]         // Vector of the j:th row of a. Same as: a[j, :]
 a[j : k]     // Same as: {a[j], a[j+1], $\ldots$, a[k]}
 a[:, j : k]  // Same as: [a[:, j], a[:, j+1], $\ldots$, a[:, k]]
 \end{lstlisting}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -84,7 +84,7 @@ The general array can have one or more dimensions ($k \geq 1$).
 A component declared with array dimensions, or where the element type is an array type, is called an \firstuse{array variable}\index{array!variable}.
 It is a component whose components are \willintroduce{array elements} (see below).
 For an array variable, the ordering of its components matters:
-The $k$:th element in the sequence of components of an array variable \lstinline!x! is the array element with index \lstinline!k!, denoted \lstinline!x[k]!.
+The $k$th element in the sequence of components of an array variable \lstinline!x! is the array element with index \lstinline!k!, denoted \lstinline!x[k]!.
 % henrikt-ma: The following statement seems like an over-simplification; for Flat Modelica, we've spent some time trying to figure out how to deal with the fact that Modelica arrays are not homogenous in general...
 All elements of an array have the same type.
 An array element may again be an array, i.e., arrays can be nested.
@@ -1033,7 +1033,7 @@ algorithm
 
 \subsection{Indexing with end}\label{indexing-with-end}
 
-The expression \lstinline!end!\indexinline{end} may only appear inside array subscripts, and if used in the $i$:th subscript of an array expression \lstinline!A! it is equivalent to the upper bound of the $i$:th dimension of \lstinline!A!.
+The expression \lstinline!end!\indexinline{end} may only appear inside array subscripts, and if used in the $i$th subscript of an array expression \lstinline!A! it is equivalent to the upper bound of the $i$th dimension of \lstinline!A!.
 If used inside nested array subscripts it refers to the most closely nested array.
 
 \begin{nonnormative}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -971,8 +971,8 @@ An indexing operation is assumed to take constant time, i.e., largely independen
 \begin{example}
 Array indexing expressions:
 \begin{lstlisting}[language=modelica]
-a[:, j]      // Vector of the j:th column of a.
-a[j]         // Vector of the j:th row of a. Same as: a[j, :]
+a[:, j]      // Vector of the j'th column of a.
+a[j]         // Vector of the j'th row of a. Same as: a[j, :]
 a[j : k]     // Same as: {a[j], a[j+1], $\ldots$, a[k]}
 a[:, j : k]  // Same as: [a[:, j], a[:, j+1], $\ldots$, a[:, k]]
 \end{lstlisting}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -2,7 +2,7 @@
 
 An \firstuse{equation}\index{equation} is part of a class definition.
 A scalar equation relates scalar variables, i.e., constrains the values that these variables can take simultaneously.
-When $n$-1 variables of an equation containing $n$ variables are known, the value of the $n$:th variable can be inferred (solved for).
+When $n$-1 variables of an equation containing $n$ variables are known, the value of the $n$th variable can be inferred (solved for).
 In contrast to a statement in an algorithm section, an equation does not define for which of its variable it is to be solved.
 % henrikt-ma: Keeping this sentence from the old glossary only because it mentions the 'instantaneous equations':
 Special cases are: initial equations, instantaneous equations, declaration equations.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1747,10 +1747,8 @@ for Lapack/Blas-routines, and the strings are \textsc{nul}-terminated for
 compatibility with C. Returning strings from FORTRAN~77
 subroutines/functions is currently not supported.
 
-Enumeration types used as arguments are mapped to type int when calling
-an external C function, and to type \lstinline!INTEGER! when calling an external
-FORTRAN function. The $i$:th enumeration literal is mapped to integer
-value $i$, starting at 1.
+Enumeration types used as arguments are mapped to type int when calling an external C function, and to type \lstinline!INTEGER! when calling an external FORTRAN function.
+The $i$th enumeration literal is mapped to integer value $i$, starting at 1.
 
 Return values are mapped to enumeration types analogously: integer value
 1 is mapped to the first enumeration literal, 2 to the second, etc.

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -670,7 +670,7 @@ subSample($u$, factor=$\mathit{factor}$)
 \begin{semantics}
 The clock of \lstinline!y = subSample($u$, $\mathit{factor}$)! is $\mathit{factor}$ times slower than the clock of $u$.
 At every $\mathit{factor}$ ticks of the clock of $u$, the operator returns the value of $u$.
-The first activation of the clock of \lstinline!y! coincides with the first activation of the clock of $u$, and then every activation of the clock of \lstinline!y! coincides with the every $\mathit{factor}$:th activativation of the clock of $u$.
+The first activation of the clock of \lstinline!y! coincides with the first activation of the clock of $u$, and then every activation of the clock of \lstinline!y! coincides with the every $\mathit{factor}$th activativation of the clock of $u$.
 If argument $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
 \end{semantics}
 \end{operatordefinition}

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -668,7 +668,10 @@ Named arguments can make the calls easier to understand.
 subSample($u$, factor=$\mathit{factor}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The clock of \lstinline!y = subSample($u$, $\mathit{factor}$)! is $\mathit{factor}$ times slower than the clock of $u$.  At every $\mathit{factor}$ ticks of the clock of $u$, the operator returns the value of $u$.  The first activation of the clock of \lstinline!y! coincides with the first activation of the clock of $u$, and then every activation of the clock of \lstinline!y! coincides with the every $\mathit{factor}$-th activativation of the clock of $u$.  If argument $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
+The clock of \lstinline!y = subSample($u$, $\mathit{factor}$)! is $\mathit{factor}$ times slower than the clock of $u$.
+At every $\mathit{factor}$ ticks of the clock of $u$, the operator returns the value of $u$.
+The first activation of the clock of \lstinline!y! coincides with the first activation of the clock of $u$, and then every activation of the clock of \lstinline!y! coincides with the every $\mathit{factor}$:th activativation of the clock of $u$.
+If argument $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
 \end{semantics}
 \end{operatordefinition}
 


### PR DESCRIPTION
Fixing issue reported by @HansOlsson in a comment to the recently merged #2789.  Fixing this generally: one more case besides the originally reported listing.
