### PR TITLE
Remove forgotten space in '3.6 -dev'

### DIFF
--- a/MLS.tex
+++ b/MLS.tex
@@ -4,7 +4,7 @@
 
 % Define title for use by LaTeXML.
 % An extended title is defined separately in the 'titlepage'.
-\newcommand{\mlsversion}{3.6 -dev}
+\newcommand{\mlsversion}{3.6-dev}
 \newcommand{\mlsdate}{\today}
 \title{Modelica\textsuperscript{\textregistered} Language Specification version~\mlsversion}
 


### PR DESCRIPTION
At least, the previous development version 3.5-dev didn't have this kind of space in the version.