### PR TITLE
Improve navbar on top page

### DIFF
--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -50,6 +50,10 @@ nav > div.ltx_TOC {
   display: none; /* Don't show sidebar title, as it is too long to look good, and seem to lack structure for adequate layout. */
 }
 
+.ltx_page_navbar .ltx_tocentry_document > .ltx_ref_self {
+  display: none; /* Similar to sidebar title, but for the top page. */
+}
+
 .ltx_page_header a[rel=prev] {
   display: none; /* Don't show link to previous chapter. */
 }

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -71,6 +71,10 @@ nav > div.ltx_TOC {
   padding: 0em;
 }
 
+.ltx_tocentry_document > ul.ltx_toclist {
+  padding: 0em;
+}
+
 .ltx_toclist ul {
   padding-left: 1em; /* Indentation of each table of contents level below the top. */
 }


### PR DESCRIPTION
This fixes two issues with the navbar (table of contents, shown as left sidebar) on the top page:
- The document title shouldn't be present in the navbar (only in page header, where it happens to be missing on the top page).
- Entire table of contents has excessive indentation under the document title item.

I suggest that this is also cherry-picked to _maint/3.5_, as it has an impact on the first impression of the document.
