### PR TITLE
Add keywords to generated PDF.

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -96,6 +96,7 @@
 \else
 \usepackage[pdfusetitle,backref=page]{hyperref} % Need backref, since we can't use biblatex.
 \fi
+\hypersetup{pdfkeywords={Modelica, modeling, object-oriented, multi-domain}}
 % The bookmarks are used as table-of-contents in Acrobat
 % The default (magenta for urls and red for internal links) isn't nice
 \hypersetup{bookmarksnumbered=true, hidelinks, urlcolor=blue, linkcolor=blue}


### PR DESCRIPTION
Investigating pdfinfo did after all give some insights.
I don't know if they currently have any effect for LaTeXML - but no harm I guess.

It might be that we should add more keywords, and I don't see this as critical for 3.5.