### PR TITLE
Fix typo in 'bibliograph'

### DIFF
--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -45,7 +45,7 @@ Other issues resolved were:
 \item Overall improvements of the document, made easier by the switch to \LaTeX.
 \begin{itemize}
 \item A real bibliography was added, but excluding papers in this chapter; \href{https://github.com/modelica/ModelicaSpecification/pull/2740}{\#2740}.
-\item Dead links in the bibliograph were removed and DOI used when possible.
+\item Dead links in the bibliography were removed and DOI used when possible.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2502}{\#2502}.
 \item Chapter introductions are now non-normative, \href{https://github.com/modelica/ModelicaSpecification/issues/2366}{\#2366}.
 \item The index was updated to reference the main definition of the term, and the glossary removed to avoid duplicated effort; \href{https://github.com/modelica/ModelicaSpecification/pull/2726}{\#2726}.


### PR DESCRIPTION
Note that I just stumbled upon this one; I haven't run the added items through a spell checker.
