### PR TITLE
Remove comment with definition of 'partial flattening' from old glossary

### DIFF
--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -491,12 +491,6 @@ flat equation system) using the same lookup.
 
 A \firstuse{partially instantiated}\index{partially instantiated} class or component is an element that is ready to be instantiated; a partially instantiated element (i.e.\ class or component) is comprised of a reference to the original element (from the class tree) and the modifiers for that element (including a possible redeclaration).
 
-% henrikt-ma: The old glossary defined 'partial flattening' as follows -- does it belong here?
-%First find the names of declared local classes and components.
-%Modifiers, if present, are merged to the local elements and redeclarations are performed.
-%Then base-classes are looked up, flattened and inserted into the class.
-%See also flattening, which additionally flattens local elements and performs modifications.
-
 The possible redeclaration of the element itself takes effect.
 
 The class of a partially instantiated component is found in the instance


### PR DESCRIPTION
Fixes #2787.