### PR TITLE
Add 'MODELICAPATH' to the index

### DIFF
--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -130,10 +130,8 @@ The following rules apply to import-clauses:
 \end{itemize}
 \section{The Modelica Library Path -- MODELICAPATH}\label{the-modelica-library-path-modelicapath}
 
-The top-level scope implicitly contains a number of classes stored
-externally. If a top-level name is not found at global scope, a Modelica
-translator shall look up additional classes in an ordered list of
-library roots, called \lstinline!MODELICAPATH!.
+The top-level scope implicitly contains a number of classes stored externally.
+If a top-level name is not found at global scope, a Modelica translator shall look up additional classes in an ordered list of library roots, called \lstinline!MODELICAPATH!\indexinline{MODELICAPATH}.
 
 \begin{nonnormative}
 The implementation of \lstinline!MODELICAPATH! is tool dependent.  In order that a user can work in parallel with different Modelica tools, it is advisable to not


### PR DESCRIPTION
Even though I'm not a big fan of `MODELICAPATH` being defined in the specification, it is wrong to not be able to find it in the document index.
