### PR TITLE
Clean up ellipsis and angle brackets in listings

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -122,7 +122,7 @@ the \lstinline!Figure! contains more than one \lstinline!Plot!.
 \end{nonnormative}
 
 % henrikt-ma 2020-06: Once there is Modelica URI support for referring to a figure in the collection of a class, it will be easier to explain
-% the following statement...
+% the following statement.
 Even though a \lstinline!Figure! annotation can be shared through inheritance between classes in a class hierarchy, note that each simulated class provides
 its own data to be displayed in the figure.
 
@@ -835,7 +835,7 @@ end A;
 
 model B
   extends C annotation(DiagramMap(primitivesVisible = false));
-  ...
+  $\ldots$
 end B;
 \end{lstlisting}
 In this example the diagram of \lstinline!A! contains the graphical primitives
@@ -1268,7 +1268,7 @@ component, the literal string message may be used as part of a diagnostic messag
 \begin{example}
 \begin{lstlisting}[language=modelica]
 model World
-  ...
+  $\ldots$
   annotation(defaultComponentName = "world",
   defaultComponentPrefixes = "inner replaceable",
   missingInnerMessage = "The World object is missing");
@@ -1335,7 +1335,7 @@ cannot be assigned, the message is displayed.  This annotation is used to provid
 \begin{example}
 \begin{lstlisting}[language=modelica]
 connector Frame "Frame of a mechanical system"
-  ...
+  $\ldots$
   flow Modelica.Units.SI.Force f[3]
   annotation(unassignedMessage =
       "All Forces cannot be uniquely calculated. The reason could be that the
@@ -1456,7 +1456,7 @@ model DialogDemo
   parameter Real r4 "Real parameter in Tab 1 and Group 2"
      annotation(Dialog(tab="Tab 1", group="Group 2"));
   StepIn stepIn[nInports];
-  ...
+  $\ldots$
 end DialogDemo;
 \end{lstlisting}
 When clicking on an instance of model \lstinline!DialogDemo!, a menu pops up
@@ -1490,7 +1490,7 @@ model Step
   // nIn cannot be set in the parameter dialog (but maybe shown)
   parameter Integer nIn=0 annotation(Dialog(connectorSizing=true));
   StepIn inPorts[nIn];
-  ...
+  $\ldots$
 end Step;
 \end{lstlisting}
 If the parameter is used as dimension size of a vector of
@@ -1625,7 +1625,7 @@ In a top-level class, the version number and the dependency to earlier versions 
   Defines that user models using the \lstinline!VERSION-NUMBER! can be upgraded to the \lstinline!CURRENT-VERSION-NUMBER! of the current class without any changes.
 \item
   \lstinline!conversion(from(version = Versions, [to=VERSION-NUMBER,] Convert))!\\
-  where \emph{Versions} is \lstinline!VERSION-NUMBER! \textbar{} \lstinline!{VERSION-NUMBER,VERSION-NUMBER, ...}! and \lstinline!Convert! is \lstinline!script="..."! \textbar{} \lstinline!change={conversionRule(), ..., conversionRule()}!\\*[.5ex]
+  where \emph{Versions} is \lstinline!VERSION-NUMBER! \textbar{} \lstinline!{VERSION-NUMBER, VERSION-NUMBER, $\ldots$}! and \lstinline!Convert! is \lstinline!script="$\ldots$"! \textbar{} \lstinline!change={conversionRule(), $\ldots$, conversionRule()}!\\*[.5ex]
   Defines that user models using the \lstinline!VERSION-NUMBER! or any of the given \lstinline!VERSION-NUMBER! can be upgraded to the given \lstinline!VERSION-NUMBER! (if the to-tag is missing this is the \lstinline!CURRENT-VERSION-NUMBER!) of the current class by applying the given conversion rules.
   The script consists of an unordered sequence of \lstinline!conversionRule();! (and optionally Modelica comments).
   The \lstinline!conversionRule! functions are defined in \cref{conversion-rules}.
@@ -1643,7 +1643,7 @@ The annotations \lstinline!uses! and \lstinline!conversion! may contain several 
 \begin{example}
 \begin{lstlisting}[language=modelica]
 package Modelica
-  ...
+  $\ldots$
   annotation(version="3.1",
   conversion(noneFromVersion="3.1 Beta 1",
   noneFromVersion="3.1 Beta 2",
@@ -1654,13 +1654,13 @@ package Modelica
 end Modelica;
 
 model A
-  ...
+  $\ldots$
   annotation(version="1.0",
   uses(Modelica(version="1.5")));
 end A;
 
 model B
-  ...
+  $\ldots$
   annotation(uses(Modelica(version="3.1 Beta 1")));
 end B;
 \end{lstlisting}
@@ -1942,7 +1942,7 @@ String revisionId    "Revision identifier of the version management system used
 \begin{example}
 \begin{lstlisting}[language=modelica,mathescape=false]
 package Modelica
-  ...
+  $\ldots$
   annotation(version = "3.0.1",
   versionDate = "2008-04-10",
   versionBuild = 4,
@@ -2159,7 +2159,7 @@ In this section annotations within the \lstinline!Protection! annotation are
 defined to restrict the usage of the encrypted package:
 \begin{lstlisting}[language=modelica]
 record Protection
-  ...
+  $\ldots$
   String features[:] = fill("", 0) "Required license features";
   record License
     String libraryKey;
@@ -2248,7 +2248,7 @@ package can also decrypt it.
 // File MyLibrary\package.mo
 package MyLibrary
   annotation(Protection(License(libraryKey="15783-A39323-498222-444ckk4ll",
-  licenseFile="MyLibraryAuthorization_Tool.mo_lic), ...));
+  licenseFile="MyLibraryAuthorization_Tool.mo_lic), $\ldots$));
 end MyLibrary;
 
 // File MyLibrary\MyLibraryAuthorization_Tool.mo\

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -85,7 +85,7 @@ A component declared with array dimensions, or where the element type is an arra
 It is a component whose components are \willintroduce{array elements} (see below).
 For an array variable, the ordering of its components matters:
 The $k$th element in the sequence of components of an array variable \lstinline!x! is the array element with index \lstinline!k!, denoted \lstinline!x[k]!.
-% henrikt-ma: The following statement seems like an over-simplification; for Flat Modelica, we've spent some time trying to figure out how to deal with the fact that Modelica arrays are not homogenous in general...
+% henrikt-ma: The following statement seems like an over-simplification; for Flat Modelica, we've spent some time trying to figure out how to deal with the fact that Modelica arrays are not homogenous in general.
 All elements of an array have the same type.
 An array element may again be an array, i.e., arrays can be nested.
 An array element is hence referenced using $n$ indices in general, where $n$ is the number of dimensions of the array.
@@ -103,7 +103,8 @@ declaration form~2 is the traditional way of array declarations in
 languages such as Fortran, C, C++.
 
 \begin{lstlisting}[language=modelica]
-Real[:] v1, v2 // vectors v1 and v2 have unknown sizes. The actual sizes may be different.
+Real[:] v1, v2 // Vectors v1 and v2 have unknown sizes.
+               // The actual sizes may be different.
 \end{lstlisting}
 It is possible to mix the two declaration forms although it might be confusing.
 \begin{lstlisting}[language=modelica]
@@ -621,11 +622,11 @@ see \cref{types-as-iteration-ranges}.
 \begin{example}
 % No frame since the math would break it.
 \begin{lstlisting}[language=modelica, frame=none]
-sum(i for  i in 1:10) // Gives $\sum_{i=1}^{10}i=$1+2+...+10=55
+sum(i for i in 1:10) // Gives $\sum_{i=1}^{10}i$ = 1 + 2 + $\ldots$ + 10 = 55
 // Read it as: compute the sum of i for i in the range 1 to 10.
-sum(i^2 for  i in {1,3,7,6}) // Gives $\sum_{i\in \begin{Bmatrix}1&3&7&6\end{Bmatrix}}i^2=$1+9+49+36=95
-{product(j for j in 1:i) for i in 0:4} // Gives {1,1,2,6,24}
-max(i^2 for  i in {3,7,6}) // Gives 49
+sum(i^2 for i in {1,3,7,6}) // Gives $\sum_{i\in \{1,\, 3,\, 7,\, 6\}}i^2$ = 1 + 9 + 49 + 36 = 95
+{product(j for j in 1:i) for i in 0:4} // Gives {1, 1, 2, 6, 24}
+max(i^2 for i in {3,7,6}) // Gives 49
 \end{lstlisting}
 \end{example}
 
@@ -781,10 +782,10 @@ array of the result.
 \begin{example}
 \begin{lstlisting}[language=modelica]
 array(i for i in 1:10)
-// Gives the vector 1:10={1,2,3,...,10}
+// Gives the vector 1:10 = {1, 2, 3, $\ldots$, 10}
 
 {r for r in 1.0 : 1.5 : 5.5}
-// Gives the vector 1.0:1.5:5.5={1.0, 2.5, 4.0, 5.5}
+// Gives the vector 1.0:1.5:5.5 = {1.0, 2.5, 4.0, 5.5}
 
 {i^2 for i in {1,3,7,6}}
 // Gives the vector {1, 9, 49, 36}
@@ -800,8 +801,8 @@ a '\lstinline!{!'.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-Real toeplitz[:,:]={i-j for i in 1:n, j in 1:n};
-Real toeplitz2[:,:]={{i-j for i in 1:n} for j in 1:n};
+Real toeplitz[:,:] = {i-j for i in 1:n, j in 1:n};
+Real toeplitz2[:,:] = {{i-j for i in 1:n} for j in 1:n};
 \end{lstlisting}
 \end{example}
 
@@ -1366,7 +1367,7 @@ equation
     // size(tf[1].x1[:]) = size(tf[2].x1[:]) = $\ldots$ = size(tf[m].x1[:])
   y3 = sum(tf.x1[1:2]); // Legal.
     // Since x1 has at least 2 elements in all tf, and
-    // size(tf[1].x1[1:2]) = size(tf[2].x1[1:2]) = $\ldots$ = size(tf[m].x1[1:2]) = {2}
+    // size(tf[1].x1[1:2]) = $\ldots$ = size(tf[m].x1[1:2]) = {2}
 \end{lstlisting}
 In this example the different \lstinline!x1! vectors have different lengths,
 but it is still possible to perform some operations on them.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -252,11 +252,11 @@ The prefixes \lstinline!input!\indexinline{input} and \lstinline!output!\indexin
 \begin{lstlisting}[language=modelica]
 block FirstOrder
   input Real u;
-  ...
+  $\ldots$
 end FirstOrder;
 model UseFirstOrder
   FirstOrder firstOrder(u=time); // binding equation for u
-  ...
+  $\ldots$
 end UseFirstOrder;
 \end{lstlisting}
 \end{example}
@@ -398,7 +398,7 @@ Example:
 \begin{lstlisting}[language=modelica]
 model Inertia
   parameter Boolean state = true;
-  ...
+  $\ldots$
 equation
   J*a = t1 - t2;
   if state then // code which is removed during symbolic
@@ -477,7 +477,7 @@ A component declaration can have a \lstinline!condition-attribute!: \lstinline!i
   // Illegal modifier on component3 since component1.J is conditional
   // Even if we can see that component1 always exist if component3 exist
 equation
-  connect(component1..., ...) "Connection to conditional component 1";
+  connect(component1$\ldots$, $\ldots$) "Connection to conditional component 1";
   connect(component2.n, motor.n) "Connection to conditional component 2";
   connect(component3.n, motor.n) "Connection to conditional component 3";
   component1.u=0; // Illegal
@@ -533,11 +533,11 @@ followed by a number of equations in an equation section.
 class ClassName
   Declaration1
   Declaration2
-  ...
+  $\ldots$
 equation
   equation1
   equation2
-  ...
+  $\ldots$
 end ClassName;
 \end{lstlisting}
 \end{example}
@@ -617,7 +617,7 @@ Demonstrating the difference in scopes:
 \begin{lstlisting}[language=modelica]
 model Resistor
   parameter Real R;
-  ...
+  $\ldots$
 end Resistor;
 model A
   parameter Real R;
@@ -631,8 +631,8 @@ model A
   encapsulated model Load2=.Resistor(R=2); // Ok
   encapsulated model LoadR=.Resistor(R=R); // Illegal
   Load a,b,c;
-  ConstantSource ...;
-  ...
+  ConstantSource $\ldots$;
+  $\ldots$
 end A;
 \end{lstlisting}
 \end{example}
@@ -1533,7 +1533,7 @@ end Mixing2;
 
 For each enumeration:
 \begin{lstlisting}[language=modelica]
-type E=enumeration(e1, e2, ..., en);
+type E = enumeration(e1, e2, $\ldots$, en);
 \end{lstlisting}
 
 a new simple type is conceptually defined as
@@ -1546,9 +1546,9 @@ type E // Note: Defined with Modelica syntax although predefined
   parameter EnumType start = e1;       // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
-  constant EnumType e1=...;
-  ...
-  constant EnumType en=...;
+  constant EnumType e1 = $\ldots$;
+  $\ldots$
+  constant EnumType en = $\ldots$;
 equation
   assert(value >= min and value <= max, "Variable value out of limit");
 end E;
@@ -1562,10 +1562,7 @@ level, it is not possible to use the enumeration attribute names
 
 \subsubsection{Type Conversion of Enumeration Values to String or Integer}\label{type-conversion-of-enumeration-values-to-string-or-integer}
 
-The type conversion function \lstinline!Integer(<expression of enumeration type>)! returns the ordinal number of the
-enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated,
-where \lstinline!Integer(E.e1) = 1!, \lstinline!Integer(E.en) = n!, for an enumeration type
-\lstinline!E = enumeration(e1, ..., en)!.
+The type conversion function \lstinline!Integer($\mbox{\emph{\textless{}expression of enumeration type\textgreater{}}}$)! returns the ordinal number of the enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated, where $\text{\lstinline!Integer(E.e1)!} = 1$, $\text{\lstinline!Integer(E.en)!} = n$, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
 
 \lstinline!String(E.enumvalue)! gives the \lstinline!String! representation of the enumeration value.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1562,7 +1562,7 @@ level, it is not possible to use the enumeration attribute names
 
 \subsubsection{Type Conversion of Enumeration Values to String or Integer}\label{type-conversion-of-enumeration-values-to-string-or-integer}
 
-The type conversion function \lstinline!Integer($\mbox{\emph{\textless{}expression of enumeration type\textgreater{}}}$)! returns the ordinal number of the enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated, where $\text{\lstinline!Integer(E.e1)!} = 1$, $\text{\lstinline!Integer(E.en)!} = n$, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
+The type conversion function \lstinline!Integer($\langle\mbox{\emph{expression of enumeration type}}\rangle$)! returns the ordinal number of the enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated, where $\text{\lstinline!Integer(E.e1)!} = 1$, $\text{\lstinline!Integer(E.en)!} = n$, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
 
 \lstinline!String(E.enumvalue)! gives the \lstinline!String! representation of the enumeration value.
 
@@ -1579,10 +1579,7 @@ the same name and in the same scope as the enumeration type is
 implicitly defined. This function can be used in an expression to
 convert an integer value to the corresponding (as described in \cref{type-conversion-of-enumeration-values-to-string-or-integer}) enumeration value.
 
-For an enumeration type named \lstinline!EnumTypeName!, the expression
-\lstinline!EnumTypeName(<Integer expression>)! returns the
-enumeration value \lstinline!EnumTypeName.e! such that \lstinline!Integer(EnumTypeName.e)! is
-equal to the original integer expression.
+For an enumeration type named \lstinline!EnumTypeName!, the expression \lstinline!EnumTypeName($\langle\mbox{\emph{Integer expression}}\rangle$)! returns the enumeration value \lstinline!EnumTypeName.e! such that \lstinline!Integer(EnumTypeName.e)! is equal to the original integer expression.
 
 Attempting to convert an integer argument that does not correspond to a
 value of the enumeration type is an error.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -875,7 +875,8 @@ Defines a \firstuse{required spanning-tree edge}\index{required spanning-tree ed
 This function can be used at all places where a \lstinline!connect! statement is allowed.
 
 \begin{nonnormative}
-E.g., it is not allowed to use this function in a when-clause.  This definition shall be used if in a model with connectors \lstinline!A! and \lstinline!B! the overdetermined records \lstinline!A.R! and \lstinline!B.R! are algebraically coupled in the model, e.g., due to \lstinline!B.R = f(A.R!, \textless{}other unknowns\textgreater{}).
+E.g., it is not allowed to use this function in a when-clause.
+This definition shall be used if in a model with connectors \lstinline!A! and \lstinline!B! the overdetermined records \lstinline!A.R! and \lstinline!B.R! are algebraically coupled in the model, e.g., due to \lstinline!B.R = f(A.R, $\langle\mbox{\emph{other unknowns}}\rangle$)!.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -20,7 +20,7 @@ A \emph{connector} is an instance of a \lstinline!connector!\indexinline{connect
 The connect-equation construct takes two references to connectors, each of which is either of the following forms:
 \begin{itemize}
 \item
-  $c_1.c_2...c_n$,
+  $c_1.c_2\ldots{}c_n$,
   where $c_1$ is a connector of the class,
   $n$\textgreatereq 1 and $c_{i+1}$ is a connector element of
   $c_i$ for \lstinline!i=1:(n-1)!.
@@ -320,7 +320,7 @@ import Modelica.Blocks.Interfaces.RealInput;
 // Plant Side
 model SparkPlug
   RealInput spark_advance;
-  ...
+  $\ldots$
 end SparkPlug;
 
 expandable connector EngineBus
@@ -334,7 +334,7 @@ end CylinderBus;
 model Cylinder
   CylinderBus cylinder_bus;
   SparkPlug spark_plug;
-  ...
+  $\ldots$
 equation
   connect(spark_plug.spark_advance,
   cylinder_bus.spark_advance);
@@ -796,7 +796,7 @@ type Type // overdetermined type
     input Type T2;
     output Real residue[ <n> ];
   algorithm
-    residue := ...
+    residue := $\ldots$;
   end equalityConstraint;
 end Type;
 
@@ -807,7 +807,7 @@ record Record
     input Record R2;
     output Real residue[ <n> ];
   algorithm
-    residue := ...
+    residue := $\ldots$;
   end equalityConstraint;
 end Record;
 \end{lstlisting}

--- a/chapters/derivationofstream.tex
+++ b/chapters/derivationofstream.tex
@@ -147,7 +147,7 @@ components in a connection set, this means the following.
 In the general case of a connection set with \emph{n} components,
 similar considerations lead to the following.
 \begin{equation*}
-\text{\lstinline!inStream!}(h_{\mathrm{outflow},i})=\frac{\sum_{j=1,...,n;j\neq i}\operatorname{max}(-\tilde{m}_j,0)h_{\mathrm{outflow},j}}{\sum_{j=1,...,n;j\neq i}\operatorname{max}(-\tilde{m}_j,0)}
+\text{\lstinline!inStream!}(h_{\mathrm{outflow},i})=\frac{\sum_{j=1,\dotsc,n;j\neq i}\operatorname{max}(-\tilde{m}_j,0)h_{\mathrm{outflow},j}}{\sum_{j=1,\dotsc,n;j\neq i}\operatorname{max}(-\tilde{m}_j,0)}
 \end{equation*}
 
 \section{Special cases covered by inStream definition}\label{special-cases-covered-by-the-instream-operator-definition}
@@ -216,7 +216,7 @@ however it does not lead to simplifications):
 \begin{lstlisting}[language=modelica]
 model m2
   Fluidport c(m_flow(min=0));
-  ...
+  $\ldots$
 end m2;
 \end{lstlisting}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -122,7 +122,7 @@ The \lstinline!expression! of a for-equation shall be a vector expression, where
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-for i in 1 : 10 loop           // i takes the values 1, 2, 3, ..., 10
+for i in 1 : 10 loop           // i takes the values 1, 2, 3, $\ldots$, 10
 for r in 1.0 : 1.5 : 5.5 loop  // r takes the values 1.0, 2.5, 4.0, 5.5
 for i in {1, 3, 6, 7} loop     // i takes the values 1, 3, 6, 7
 for i in TwoEnums loop         // i takes the values TwoEnums.one, TwoEnums.two

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -13,22 +13,21 @@ This makes the syntax of function definitions quite close to Modelica class defi
 The structure of a typical function declaration is sketched by
 the following schematic function example:
 \begin{lstlisting}[language=modelica,escapechar=!]
-function  !\emph{functionname}!
+function $\mathit{functionname}$
   input  TypeI1 in1;
   input  TypeI2 in2;
-  input  TypeI3 in3 = !\emph{default\_expr1}! "Comment" annotation($\ldots$);
-  ...
+  input  TypeI3 in3 = $\mathit{defaultExpr}_{1}$ "Comment" annotation($\ldots$);
+  $\ldots$
   output TypeO1 out1;
-  output TypeO2 out2 =  !\emph{default\_expr2}!;
-  ...
+  output TypeO2 out2 = $\mathit{defaultExpr}_{2}$;
+  $\ldots$
 protected
   !\emph{\textless{}local variables\textgreater{}}!
-  ...
+  $\ldots$
 algorithm
-  ...
-    !\emph{\textless{}statements\textgreater{}}!
-  ...
-end !\emph{functionname}!;
+  !\emph{\textless{}statements\textgreater{}}!
+  $\ldots$
+end $\mathit{functionname}$;
 \end{lstlisting}
 \end{nonnormative}
 
@@ -41,9 +40,9 @@ Explicit default values are shown for the third input parameter and the second o
 
 \begin{nonnormative}
 All internal parts of a function are optional; i.e., the following is also a legal function:
-\begin{lstlisting}[language=modelica,escapechar=!]
-function !\emph{functionname}!
-end !\emph{functionname}!;
+\begin{lstlisting}[language=modelica]
+function $\mathit{functionname}$
+end $\mathit{functionname}$;
 \end{lstlisting}
 \end{nonnormative}
 
@@ -63,16 +62,16 @@ Mixing declarations in this way is not recommended, however, since it makes the 
 \end{nonnormative}
 
 \begin{example}
-\begin{lstlisting}[language=modelica,escapechar=!]
-function !\emph{\textless{}functionname\textgreater{}}!
+\begin{lstlisting}[language=modelica]
+function $\mathit{functionname}$
   output TypeO1 out1; // Intermixed declarations of inputs and outputs
   input TypeI1 in1; // not recommended since code becomes hard to read
   input TypeI2 in2;
-  ...
+  $\ldots$
   output TypeO2 out2;
   input TypeI3 in3;
-  ...
-end !\emph{\textless{}functionname\textgreater{}}!;
+  $\ldots$
+end $\mathit{functionname}$;
 \end{lstlisting}
 \end{example}
 
@@ -438,7 +437,7 @@ function RealToString
   input Real precision = 6 "number of significantdigits";
   input Real length = 0 "minimum length of field";
   output String string "number as string";
-  ...
+  $\ldots$
 end RealToString;
 \end{lstlisting}
 Then the following applications are equivalent:
@@ -539,7 +538,7 @@ function declaration. A function partial application is specified by the
 giving named formal parameter associations for the formal parameters to
 be bound, e.g.:
 \begin{lstlisting}[language=modelica]
-function func_name(..., formal_parameter_name = expr, ...)
+function func_name($\ldots$, formal_parameter_name = expr, $\ldots$)
 \end{lstlisting}
 
 \begin{nonnormative}
@@ -687,8 +686,9 @@ function eigen "calculate eigenvalues and optionally eigenvectors"
   output Real leftEigenVectors [size(A,1),size(A,1)];
 algorithm
   // The output variables are computed separately (and not, e.g., by one
-  // call of a Fortran function) in order that an optimizing compiler can remove
-  // unnecessary computations, if one or more output arguments are missing
+  // call of a Fortran function) in order that an optimizing compiler can
+  // remove unnecessary computations, if one or more output arguments are
+  // missing
   //   compute eigenvalues
   //   compute right eigenvectors using the computed eigenvalues
   //   compute left eigenvectors using the computed eigenvalues
@@ -797,9 +797,9 @@ function collectPositive
   input Real x[:];
   output Real xpos[:];
 algorithm
-  for i in 1:size(x,1) loop
-    if x[i]>0 then
-      xpos:=cat(1,xpos,x[i:i]);
+  for i in 1 : size(x, 1) loop
+    if x[i] > 0 then
+      xpos := cat(1, xpos, x[i:i]);
     end if;
   end for;
 end collectPositive;
@@ -985,9 +985,9 @@ package Motors
 
   model Motor "Motor model" // using the generic MotorData
     MotorData data;
-    ...
+    $\ldots$
   equation
-    ...
+    $\ldots$
   end Motor;
 
   record MotorI123 = MotorData( // data of a specific motor
@@ -1005,10 +1005,10 @@ end Motors
 model Robot
   import Motors.*;
   Motor motor1(data = MotorI123()); // just refer to data sheet
-  Motor motor2(data = MotorI123(inertia=0.0012));
+  Motor motor2(data = MotorI123(inertia = 0.0012));
   // data can still be modified (if no final declaration in record)
   Motor motor3(data = MotorI145());
-  ...
+  $\ldots$
 end Robot;
 \end{lstlisting}
 
@@ -1042,11 +1042,12 @@ end Demo;
 The following record constructor functions are implicitly defined
 (the name of the output, given in italic below, is not defined; it
 should be chosen to not cause any conflict):
+% henrikt-ma: TODO: Fix too long lines.
 \begin{lstlisting}[language=modelica,escapechar=!]
 package Demo;
   function Record1
     input Real r0 = 0;
-    output Record1 !\emph{result}!(r0 = r0);
+    output Record1 $\mathit{result}$(r0 = r0);
   end Record1;
 
   function Record2
@@ -1060,7 +1061,7 @@ package Demo;
     input Real r5 = 5.0;
     input Real r6[n1];
     input Real r7[n2];
-    output Record2 !\emph{result}!(r0=r0,c2=c2,n1=n1,n2=n2,r1=r1,r2=r2,r4=r4,r5=r5,r6=r6,r7=r7);
+    output Record2 $\mathit{result}$(r0=r0,c2=c2,n1=n1,n2=n2,r1=r1,r2=r2,r4=r4,r5=r5,r6=r6,r7=r7);
   protected
     final constant Real c1 = 2.0; // referenced from r2
     final parameter Real r3 = Modelica.Math.cos(r2);
@@ -1068,6 +1069,7 @@ package Demo;
 end Demo;
 \end{lstlisting}
 and can be applied in the following way
+% henrikt-ma: TODO: Fix too long lines.
 \begin{lstlisting}[language=modelica]
 Demo.Record2 r1 = Demo.Record2(r0=1, c2=2, n1=2, n2=3, r1=1, r2=2,r4=5, r5=5, r6={1,2}, r7={1,2,3});
 Demo.Record2 r2 = Demo.Record2(1,2,2,3,1,2,5,5,{1,2},{1,2,3});
@@ -1128,7 +1130,7 @@ model Model2
   Model1 sub1;
   protected
   Integer i1;
-  ...
+  $\ldots$
 end Model2;
 
 record MyFlange
@@ -1151,7 +1153,7 @@ model Model
   Model2 s2[2];
   MyRecord2 rec1 = MyRecord2(s1);
   MyRecord2 rec2[2] = MyRecord2(s2);
-  ...
+  $\ldots$
 end Model;
 // Model is conceptually mapped to
 model ModelExpanded
@@ -1166,7 +1168,7 @@ model ModelExpanded
   MyRecord2(r1=s2[2].r1, i2=s2[2].i2,
   sub1 = MyRecord1(b1=s2[2].sub1.b1,
   flange = MyFlange(tau=s2[2].sub1.flange.tau)};
-  ...
+  $\ldots$
 end ModelExpanded;
 \end{lstlisting}
 \end{example}
@@ -1183,7 +1185,7 @@ function definition, see \cref{partial-derivatives-of-functions}.
 A function declaration can have an annotation \fmtannotationindex{derivative} specifying the derivative function or preferably, for a function written in Modelica, use the \lstinline!smoothOrder! annotation to indicate that the tool can construct the derivative function automatically, \cref{annotations-for-code-generation}.
 The \lstinline!derivative! annotation can influence simulation time and accuracy and can be applied to both functions written in Modelica and to external functions.
 A \lstinline!derivative! annotation can state that it is only valid under certain restrictions on the input arguments.
-These restrictions are defined using the following optional attributes: \lstinline!order! (only a restriction if \lstinline!order>1!, the default for \lstinline!order! is 1), \lstinline!noDerivative!, and \lstinline!zeroDerivative!.
+These restrictions are defined using the following optional attributes: \lstinline!order! (only a restriction if $\text{\lstinline!order!} > 1$, the default for \lstinline!order! is 1), \lstinline!noDerivative!, and \lstinline!zeroDerivative!.
 The given derivative-function can only be used to compute the derivative of a function call if these restrictions are satisfied.
 There may be multiple restrictions on the derivative, in which case they must all be satisfied. The restrictions also imply that some derivatives of some inputs are excluded from the call of the derivative (since they are not necessary).
 A function may supply multiple derivative functions subject to different restrictions, the first one that can be used (i.e.\ satisfying the restrictions) will be used for each call.
@@ -1219,17 +1221,13 @@ follows:
   and its derivative.
 \end{itemize}
 
-If the Modelica function call is a nth derivative (n\textgreater{}=1),
-i.e.\ this function call has been derived from an (n-1)th derivative by
-differentiation inside the tool, an \lstinline!annotation(order=n+1)=...!,
-specifies the (n+1)th derivative, and the (n+1)th derivative call is
-constructed as follows:
+If the Modelica function call is a $n$th derivative ($n \geq 1$), i.e.\ this function call has been derived from an $(n-1)$th derivative by differentiation inside the tool, an \lstinline!annotation(derivative(order=$n+1$) = $\ldots$)!, specifies the $(n+1)$th derivative, and the $(n+1)$th derivative call is constructed as follows:
 \begin{itemize}
 \item
   The input arguments are appended with the (n+1)th derivative, which
-  are constructed in order from the nth \lstinline!order! derivatives.
+  are constructed in order from the $n$th \lstinline!order! derivatives.
 \item
-  The output arguments are similar to the output argument for the nth
+  The output arguments are similar to the output argument for the $n$th
   derivative, but each output is one higher in derivative order. The
   outputs must have the same type and declaration order for the function
   and its derivative.
@@ -1247,38 +1245,38 @@ tests to verify that they are the same).
 Given the declarations
 \begin{lstlisting}[language=modelica]
 function foo0
-  ...
+  $\ldots$
   input Real x;
   input Boolean linear;
-  input ...;
+  input $\ldots$;
   output Real y;
-  ...
+  $\ldots$
   annotation(derivative=foo1);
 end foo0;
 
 function foo1
-  ...
+  $\ldots$
   input Real x;
   input Boolean linear;
-  input ...;
+  input $\ldots$;
   input Real der_x;
-  ...
+  $\ldots$
   output Real der_y;
-  ...
+  $\ldots$
   annotation(derivative(order=2)=foo2);
 end foo1;
 
 function foo2
-  ...
+  $\ldots$
   input Real x;
   input Boolean linear;
-  input ...;
+  input $\ldots$;
   input Real der_x;
-  ...;
+  $\ldots$;
   input Real der_2_x;
-  ...
+  $\ldots$
   output Real der_2_y;
-  ...
+  $\ldots$
 \end{lstlisting}
 the equation
 \begin{align*}
@@ -1318,7 +1316,7 @@ function density
   input ThermodynamicState state "Thermodynamic state";
   output Density d "Density";
 algorithm
-  ...
+  $\ldots$
   annotation(derivative=density_der);
 end density;
 
@@ -1327,7 +1325,7 @@ function density_der
   input ThermodynamicState_der state_der;
   output DensityDerivative d "Density derivative";
 algorithm
-  ...
+  $\ldots$
 end density_der;
 
 function setState_ph
@@ -1336,7 +1334,7 @@ function setState_ph
   input Integer phase = 0;
   output ThermodynamicState state;
 algorithm
-  ...
+  $\ldots$
   annotation(derivative = setState_ph_der);
 end setState_ph;
 
@@ -1348,13 +1346,13 @@ function setState_ph_der
   input SpecificEnthalpyDerivative h_der;
   output ThermodynamicState_der state_der;
 algorithm
-  ...
+  $\ldots$
 end setState_ph_der;
 
-ThermodynamicState state1 = setState_ph(p=..., h=..., phase=...);
+ThermodynamicState state1 = setState_ph(p=$\ldots$, h=$\ldots$, phase=$\ldots$);
 Density rho1=density(state1);
 DensityDerivative d_rho1=der (rho1);
-Density rho2=density(setState_ph(p=..., h=..., phase=...));
+Density rho2=density(setState_ph(p=$\ldots$, h=$\ldots$, phase=$\ldots$));
 DensityDerivative d_rho2=der (rho2);
 \end{lstlisting}
 \end{example}
@@ -1389,7 +1387,7 @@ function f "Simple table lookup"
   input Real offset;
   output Real z;
 algorithm
-  ...
+  $\ldots$
   annotation(derivative(zeroDerivative=y, zeroDerivative=offset)= f_der,
              derivative=f_general_der);
 end f;
@@ -1401,7 +1399,7 @@ function f_der "Derivative of simple table lookup"
   input Real x_der;
   output Real z_der;
 algorithm
-  ...
+  $\ldots$
   annotation(derivative(zeroDerivative=y, zeroDerivative=offset, order=2) = f_der2);
 end f_der;
 
@@ -1413,7 +1411,7 @@ function f_der2 "Second derivative of simple table lookup"
   input Real x_der2;
   output Real z_der2;
 algorithm
-  ...
+  $\ldots$
 end f_der2;
 
 function f_general_der "Derivative of table lookup taking
@@ -1426,7 +1424,7 @@ into account varying tables"
   input Real offset_der;
   output Real z_der;
 algorithm
-  ...
+  $\ldots$
   //annotation(derivative(order=2) = f_general_der2);
 end f_general_der;
 \end{lstlisting}
@@ -1463,7 +1461,7 @@ function f
   input Real y;
   output Real z;
 algorithm
-  ...
+  $\ldots$
   annotation(derivative(noDerivative = y) = f_der);
 end f;
 
@@ -1473,7 +1471,7 @@ function f_der
   input Real x_der;
   output Real z_der;
 algorithm
-  ...
+  $\ldots$
 end f_der;
 \end{lstlisting}
 This is useful if \lstinline!g! represents the major computational
@@ -1499,7 +1497,7 @@ function Gibbs
   input Real p, T;
   output Real g;
 algorithm
-  ...
+  $\ldots$
 end Gibbs;
 function Gibbs_T = der(Gibbs, T);
 function specificEnthalpy
@@ -1551,7 +1549,7 @@ function h_pTX
   input Real X[:] "mass fractions";
   output Real h "specific enthalpy";
 algorithm
-  ...
+  $\ldots$
   annotation(inverse(T = T_phX(p,h,X)));
 end h_pTX;
 
@@ -1561,7 +1559,7 @@ function T_phX
   input Real X[:] "mass fractions";
   output Real T "temperature";
 algorithm
-  ...
+  $\ldots$
 end T_phX;
 \end{lstlisting}
 \end{example}
@@ -1578,7 +1576,7 @@ function inv_sine
   output Real angle;
   // Finds sine(angle) = x with angle closest to angleOrig.
 algorithm
-  ...
+  $\ldots$
   annotation(inverse(x = sine(angle)));
 end inv_sine;
 
@@ -1641,7 +1639,7 @@ Components in the public part of an external function declaration shall be decla
 This is just as for any other function.  The components in the protected part allow local variables for temporary storage to be declared.
 \end{nonnormative}
 
-The \lstinline[language=grammar]!language-specification! must currently be one of \lstinline!"builtin"! (deprecated), \lstinline!"C"!, \lstinline!"C..."! (for one of the specific C standards like C89, C99, and C11 -- specifying
+The \lstinline[language=grammar]!language-specification! must currently be one of \lstinline!"builtin"! (deprecated), \lstinline!"C"!, \lstinline!"C$\ldots$"! (for one of the specific C standards like C89, C99, and C11 -- specifying
 that it relies on the C standard library of that version) or \lstinline!"FORTRAN 77"!.
 Unless the external language is specified, it is assumed to be \lstinline!"C"!.
 
@@ -1849,7 +1847,7 @@ FUNCTION foo(a, d1, d2, d3)
   INTEGER                      d2
   INTEGER                      d3
   DOUBLE PRECISION             foo
-  ...
+  $\ldots$
 END
 \end{lstlisting}
 \end{example}
@@ -1883,7 +1881,7 @@ SUBROUTINE myfoo(x, y, n, m, u1, i, u2)
   DOUBLE PRECISION(n) u1
   INTEGER i
   DOUBLE PRECISION(m) u2
-  ...
+  $\ldots$
 END
 \end{lstlisting}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -12,7 +12,7 @@ This makes the syntax of function definitions quite close to Modelica class defi
 \begin{nonnormative}
 The structure of a typical function declaration is sketched by
 the following schematic function example:
-\begin{lstlisting}[language=modelica,escapechar=!]
+\begin{lstlisting}[language=modelica]
 function $\mathit{functionname}$
   input  TypeI1 in1;
   input  TypeI2 in2;
@@ -22,10 +22,10 @@ function $\mathit{functionname}$
   output TypeO2 out2 = $\mathit{defaultExpr}_{2}$;
   $\ldots$
 protected
-  !\emph{\textless{}local variables\textgreater{}}!
+  $\langle\mbox{\emph{local variables}}\rangle$
   $\ldots$
 algorithm
-  !\emph{\textless{}statements\textgreater{}}!
+  $\langle\mbox{\emph{statements}}\rangle$
   $\ldots$
 end $\mathit{functionname}$;
 \end{lstlisting}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -209,11 +209,11 @@ E.g.\ a package can only be base class for packages.  All other kinds of classes
 \begin{example}
 \begin{lstlisting}[language=modelica]
 record RecordA
-  ...
+  $\ldots$
 end RecordA;
 
 package PackageA
-  ...
+  $\ldots$
 end PackageA;
 
 package PackageB
@@ -235,8 +235,7 @@ end ModelB;
 The class name used after \lstinline!extends! for base-classes and for constraining classes must use a class reference considered transitively non-replaceable, see definition in \cref{transitively-non-replaceable}.  For a replaceable component declaration without constraining clause the class must use a class reference considered transitively non-replaceable.
 
 \begin{nonnormative}
-The requirement to use a transitively non-replaceable name excludes the long form of redeclare, i.e.\ \lstinline!redeclare model extends M...! where
-\lstinline!M! must be an inherited replaceable class.
+The requirement to use a transitively non-replaceable name excludes the long form of redeclare, i.e.\ \lstinline!redeclare model extends M $\ldots$! where \lstinline!M! must be an inherited replaceable class.
 \end{nonnormative}
 
 \begin{nonnormative}
@@ -539,7 +538,7 @@ type Angle =
 model TransferFunction
   parameter Real b[:] = {1} "numerator coefficient vector";
   parameter Real a[:] = {1, 1} "denominator coefficient vector";
-  ...
+  $\ldots$
 end TransferFunction;
 
 model PI "PI controller"
@@ -681,9 +680,9 @@ class-definition :
    [ encapsulated ] class-prefixes
    class-specifier
 
-class-specifier : long-class-specifier | ...
+class-specifier : long-class-specifier | $\ldots$
 
-long-class-specifier : ...
+long-class-specifier : $\ldots$
     | extends IDENT [ class-modification ] description-string
       composition end IDENT
 \end{lstlisting}
@@ -707,14 +706,14 @@ Example to extend from existing packages:
 \begin{lstlisting}[language=modelica]
 package PowerTrain // library from someone else
   replaceable package GearBoxes
-    ...
+    $\ldots$
   end GearBoxes;
 end PowerTrain;
 
 package MyPowerTrain
   extends PowerTrain; // use all classes from PowerTrain
   redeclare package extends GearBoxes // add classes to sublibrary
-    ...
+    $\ldots$
   end GearBoxes;
 end MyPowerTrain;
 \end{lstlisting}
@@ -725,12 +724,13 @@ partial package PartialMedium "Generic medium interface"
   constant Integer nX "number of substances";
   replaceable partial model BaseProperties
     Real X[nX];
-    ...
+    $\ldots$
   end BaseProperties;
 
   replaceable partial function dynamicViscosity
     input Real p;
-    output Real eta;...
+    output Real eta;
+    $\ldots$
   end dynamicViscosity;
 end PartialMedium;
 
@@ -743,7 +743,7 @@ package MoistAir "Special type of medium"
     // note, nX = 2 (!)
   equation
     X = {0, 1};
-    ...
+    $\ldots$
   end BaseProperties;
 
   redeclare function extends dynamicViscosity
@@ -852,7 +852,7 @@ in subsequent redeclarations:
 \begin{lstlisting}[language=modelica]
 model ElectricalSource
   replaceable SineSource source constrainedby MO(final n=5);
-  ...
+  $\ldots$
 end ElectricalSource;
 
 model TrapezoidalSource
@@ -866,7 +866,7 @@ automatically applied in subsequent redeclarations:
 \begin{lstlisting}[language=modelica]
 model Circuit
   replaceable model NonlinearResistor = Resistor(R=100);
-  ...
+  $\ldots$
 end Circuit;
 
 model Circuit2
@@ -1013,19 +1013,19 @@ The behavior when \lstinline!choicesAllMatching! is not specified; ideally it sh
 \begin{lstlisting}[language=modelica]
 replaceable model MyResistor = Resistor
   annotation(choices(
-               choice(redeclare model MyResistor=lib2.Resistor(a={2}) "..."),
-               choice(redeclare model MyResistor=lib2.Resistor2 "...")));
+               choice(redeclare model MyResistor=lib2.Resistor(a={2}) "$\ldots$"),
+               choice(redeclare model MyResistor=lib2.Resistor2 "$\ldots$")));
 
 replaceable Resistor Load(R = 2) constrainedby TwoPin
   annotation(choices(
-               choice(redeclare lib2.Resistor Load(a={2}) "..."),
-               choice(redeclare Capacitor Load(L=3) "...")));
+               choice(redeclare lib2.Resistor Load(a={2}) "$\ldots$"),
+               choice(redeclare Capacitor Load(L=3) "$\ldots$")));
 
 replaceable FrictionFunction a(func = exp) constrainedby Friction
   annotation(choices(
-               choice(redeclare ConstantFriction a(c=1) "..."),
-               choice(redeclare TableFriction a(table="...") "..."),
-               choice(redeclare FunctionFriction a(func=exp) "...")));
+               choice(redeclare ConstantFriction a(c=1) "$\ldots$"),
+               choice(redeclare TableFriction a(table="$\ldots$") "$\ldots$"),
+               choice(redeclare FunctionFriction a(func=exp) "$\ldots$")));
 
 replaceable package Medium = Modelica.Media.Water.ConstantPropertyLiquidWater
   constrainedby Modelica.Media.Interfaces.PartialMedium

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -108,13 +108,8 @@ An instance \lstinline!r!: \lstinline!R r;!
 
 An instance \lstinline!r2!: \lstinline!R2 r2;!
 
-The type \lstinline!R! of \lstinline!r! can be viewed as the set of all
-record values having the attributes defined by the interface of
-\lstinline!R!, e.g.\ the infinite set \lstinline!{R(b=false,x=1.2)!, \lstinline!R(b=false, x=3.4)!,
-\lstinline!R(b=true, x=1.2)!, \lstinline!R(b=true, x=1.2, y=2)!,
-\lstinline!R(b=true, x=1.2, a=2),...)!. The statement that \lstinline!r! has the type (or
-interface) \lstinline!R! means that the value of \lstinline!r! s to this
-infinite set.
+The type \lstinline!R! of \lstinline!r! can be viewed as the set of all record values having the attributes defined by the interface of \lstinline!R!, e.g.\ the infinite set \{\lstinline!R(b=false, x=1.2)!, \lstinline!R(b=false, x=3.4)!, \lstinline!R(b=true, x=1.2)!, \lstinline!R(b=true, x=1.2, y=2)!, \lstinline!R(b=true, x=1.2, a=2)!, $\ldots$\}.
+The statement that \lstinline!r! has the type (or interface) \lstinline!R! means that the value of \lstinline!r! s to this infinite set.
 
 The type \lstinline!R2! is a subtype of \lstinline!R! since its instances
 fulfill the additional property of having the component \lstinline!Real y;!
@@ -467,13 +462,13 @@ end TwoFlanges;
 
 partial model FrictionElement
   extends TwoFlanges;
-  ...
+  $\ldots$
 end FrictionElement;
 
 model Clutch "compatible - but not plug-compatible with FrictionElement"
   Modelica.Blocks.Interfaces.RealInput pressure;
   extends FrictionElement;
-  ...
+  $\ldots$
 end Clutch;
 
 model DriveLineBase
@@ -577,7 +572,7 @@ model PlanetSimulation
   function sunGravity = PointMassGravity (m=2e30);
   Body planet1(redeclare function gravity = sunGravity);
   Body planet2(redeclare function gravity = PointMassGravity (m=2e30));
-  ...
+  $\ldots$
 end PlanetSimulation;
 \end{lstlisting}
 

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -44,7 +44,7 @@ Modelica comments do not nest, i.e., /* */ cannot be embedded within /*
 /* Commented out - erroneous comment, invalid nesting of comments!
   /* This is an interesting model */
   model interesting
-  ...
+    $\ldots$
   end interesting;
 */
 \end{lstlisting}
@@ -55,9 +55,9 @@ occur at the end of a declaration, equation, or statement or at the
 beginning of a class definition. For example:
 \begin{lstlisting}[language=modelica]
 model TempResistor "Temperature dependent resistor"
-  ...
+  $\ldots$
   parameter Real R "Resistance for reference temp.";
-  ...
+  $\ldots$
 end TempResistor;
 \end{lstlisting}
 
@@ -77,12 +77,12 @@ The single quotes are part of the identifier, i.e., \lstinline!'x'! and \lstinli
 The redundant escapes (\lstinline!'\?'! and \lstinline!'\"'!) are the same as the corresponding non-escaped variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica source code.
 A full BNF definition of the Modelica syntax and lexical units is available in \cref{modelica-concrete-syntax}.
 
-\begin{lstlisting}[language=grammar,mathescape=false]
+\begin{lstlisting}[language=grammar]
 IDENT   = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
-NONDIGIT = "_" | letters "a" ... "z" | letters "A" ... "Z"
+NONDIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
 DIGIT    = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")" | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" | "{" | "}"  | "|" | "~" | " " | """
+Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")" | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" | "{" | "}"  | "|" | "~" | " " | """
 S-ESCAPE = "\'" | "\"" | "\?" | "\\" | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 \end{lstlisting}
 

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -21,13 +21,9 @@ several places; for details see \cref{lexical-conventions}.
 
 \section{Comments}\label{comments}
 
-There are two kinds of comments in Modelica which are not lexical units
-in the language and therefore are treated as white-space by a Modelica
-translator. The white-space characters are space, tabulator, and line
-separators (carriage return and line feed); and white-space cannot occur
-inside tokens, e.g., \textless{}= must be written as two characters
-without space or comments between them.  The following comment variants are
-available:
+There are two kinds of comments in Modelica which are not lexical units in the language and therefore are treated as white-space by a Modelica translator.
+The white-space characters are space, tabulator, and line separators (carriage return and line feed); and white-space cannot occur inside tokens, e.g., \lstinline!<=! must be written as two characters without space or comments between them.
+The following comment variants are available:
 %TODO-FORMAT should be a table instead of lstlisting?
 \begin{lstlisting}[language=modelica]
 // comment & Characters from // to the end of the line are ignored.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -431,7 +431,8 @@ Square root of $v$ if $v \geq 0$, otherwise an error occurs.  Argument $v$ needs
 Integer($e$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Ordinal number of the expression $e$ of enumeration type that evaluates to the enumeration value \lstinline!E.enumvalue!, where \lstinline!Integer(E.e1) = 1!, \lstinline!Integer(E.en) = n!, for an enumeration type \lstinline!E = enumeration(e1, ..., en)!.  See also \cref{type-conversion-of-enumeration-values-to-string-or-integer}.
+Ordinal number of the expression $e$ of enumeration type that evaluates to the enumeration value \lstinline!E.enumvalue!, where \lstinline!Integer(E.e1) = 1!, \lstinline!Integer(E.en) = n!, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
+See also \cref{type-conversion-of-enumeration-values-to-string-or-integer}.
 \end{semantics}
 \end{operatordefinition*}
 
@@ -940,7 +941,7 @@ equation
   assert(cardinality(p) > 0 and cardinality(n) > 0,
          "Connectors p and n of Resistor must be connected");
   // Equations of resistor
-  ...
+  $\ldots$
 end Resistor;
 \end{lstlisting}
 \end{nonnormative}
@@ -1016,7 +1017,7 @@ starting with a ``flat'' diode characteristic and then move with
 \lstinline!homotopy! to the desired ``steep'' characteristic:
 \begin{lstlisting}[language=modelica]
 model IdealDiode
-  ...
+  $\ldots$
   parameter Real Goff = 1e-5;
 protected
   Real Goff_flat = max(0.01, Goff);
@@ -1026,7 +1027,7 @@ equation
   Goff2 = homotopy(actual=Goff, simplified=Goff_flat);
   u = s*(if off then 1 else Ron2) + Vknee;
   i = s*(if off then Goff2 else 1 ) + Goff2*Vknee;
-  ...
+  $\ldots$
 end IdealDiode;
 \end{lstlisting}
 \end{example}
@@ -1054,16 +1055,16 @@ are used here in order to further improve the readability.
 \begin{lstlisting}[language=modelica]
 model PressureLoss
   import Modelica.Units.SI;
-  ...
+  $\ldots$
   parameter SI.MassFlowRate m_flow_nominal "Nominal mass flow rate";
   parameter SI.Pressure dp_nominal "Nominal pressure drop";
   SI.Density rho "Upstream density";
   SI.DynamicViscosity lambda "Upstream viscosity";
 equation
-  ...
+  $\ldots$
   m_flow = homotopy(actual = turbulentFlow_dp(dp, rho, lambda),
   simplified = dp/dp_nominal*m_flow_nominal);
-  ...
+  $\ldots$
 end PressureLoss;
 \end{lstlisting}
 \end{example}
@@ -1109,16 +1110,16 @@ The equations
 y = semiLinear(x, sa, s1);
 y = semiLinear(x, s1, s2);
 y = semiLinear(x, s2, s3);
-...
+$\ldots$
 y = semiLinear(x, sN, sb);
-...
+$\ldots$
 \end{lstlisting}
 may be replaced by
 \begin{lstlisting}[language=modelica]
 s1 = if x >= 0 then sa else sb
 s2 = s1;
 s3 = s2;
-...
+$\ldots$
 $s_N = s_{N-1}$;
 y = semiLinear(x, sa, sb);
 \end{lstlisting}
@@ -1170,11 +1171,11 @@ function is called.
 package MyLib
   model Vehicle
     Engine engine;
-    ...
+    $\ldots$
   end Vehicle;
   model Engine
     Controller controller;
-    ...
+    $\ldots$
   end Engine;
   model Controller
   equation

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -65,13 +65,13 @@ optional arguments, i.e.\ functions of the form
 \begin{lstlisting}[language=modelica]
 function f
   input $A_1$ $u_1$;
-  ...
+  $\ldots$
   input $A_{m}$ $u_{m}$ := $A_{m}$;
-  ...
+  $\ldots$
   input $A_{n}$ $u_{n}$;
   output B y;
 algorithm
-  ...
+  $\ldots$
 end f;
 \end{lstlisting}
 The vector P indicates whether argument m of f has a default value (\lstinline!true! for default value, \lstinline!false! otherwise).  A call

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -276,7 +276,7 @@ declaration of \lstinline!Rotational! could be given as below:
 \begin{lstlisting}[language=modelica]
 within Modelica.Mechanics;
 package Rotational // Modelica.Mechanics.Rotational
-  ...
+  $\ldots$
 \end{lstlisting}
 \end{example}
 

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -2190,8 +2190,7 @@ The following main changes in Modelica 3.0 are \emph{backwards compatible}:
 \item
   New element-wise operators: \lstinline!.+!, \lstinline!.-!, \lstinline!.*!, \lstinline!./!, \lstinline!.^!.
 \item
-  A third argument \lstinline!AssertionLevel! to built-in function \lstinline!assert(!...\lstinline!)! in
-  order that warnings can optionally be defined.
+  A third argument \lstinline!AssertionLevel! to built-in function \lstinline!assert($\ldots$)! in order that warnings can optionally be defined.
 \item
   New annotations \crefnameref{vendor-specific-annotations}:\\
   In this section it is precisely defined how vendor-specific

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1444,8 +1444,7 @@ particular:
   Improved the definition of \lstinline!reinit!.
 \item
   \cref{discrete-time-expressions} Discrete-Time Expressions\\
-  Improved definition of ordered relations
-  (\textgreater{},\textless{},\textgreater{}=,\textless{}=).
+  Improved definition of ordered relations (\lstinline!>!, \lstinline!<!, \lstinline!>=!, \lstinline!<=!).
 \item
   \cref{conditional-component-declaration} Conditional Component Declaration\\
   Clarified redeclaration of a component.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -28,8 +28,8 @@ For example, this means that a declaration can refer to a name inherited through
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-class C1 ... end C1;
-class C2 ... end C2;
+class C1 $\ldots$ end C1;
+class C2 $\ldots$ end C2;
 class C3
   Real x=3;
   C1 y;
@@ -223,13 +223,13 @@ Simple Example:
 \begin{lstlisting}[language=modelica]
 class A
   outer Real T0;
-  ...
+  $\ldots$
 end A;
 class B
   inner Real T0=1;
   A a1, a2; // B.T0, B.a1.T0 and B.a2.T0 will have the same value
   A a3(T0=4); // Illegal as T0 is an outer variable.
-  ...
+  $\ldots$
 end B;
 \end{lstlisting}
 More complicated example:
@@ -308,12 +308,12 @@ end A;
 function B // B is a subtype of A
   extends A;
 algorithm
-  ...
+  $\ldots$
 end B;
 
 class D
   outer function fc = A;
-  ...
+  $\ldots$
 equation
   y = fc(u);
 end D;

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -413,7 +413,7 @@ different mutually exclusive states needs to be merged.
 In each state, the outer output variables are solved for and for each
 such variable a single definition is formed:
 \begin{lstlisting}[language=modelica,escapechar=!]
-v := if activeState(state!\textsubscript{1}!) then expre!\textsubscript{1}! elseif activeState(state!\textsubscript{2}!) then expre!\textsubscript{2}! elseif ... else last(v)
+v := if activeState(state!\textsubscript{1}!) then expre!\textsubscript{1}! elseif activeState(state!\textsubscript{2}!) then expre!\textsubscript{2}! elseif $\ldots$ else last(v)
 \end{lstlisting}
 
 \lstinline!last! is special internal semantic operator returning its
@@ -433,7 +433,7 @@ The causal connection semantics of Modelica for non-state machines are generaliz
 It is possible to connect outputs each coming from different states of state machines together -- and connect this with other causal connectors.
 These outputs are combined seen as one source of the signal, and give the following constraint equations,
 \begin{lstlisting}[language=modelica,escapechar=!]
-u!\textsubscript{1}! = u!\textsubscript{2}! = ... = y!\textsubscript{1}! = y!\textsubscript{2}! = ...
+u!\textsubscript{1}! = u!\textsubscript{2}! = $\ldots$ = y!\textsubscript{1}! = y!\textsubscript{2}! = $\ldots$
 \end{lstlisting}
 with \lstinline!y!\textsubscript{i} being outputs from different states of the state-machine and \lstinline!u!\textsubscript{i} being other causal variables.
 The semantics is defined similarly to \cref{merging-variable-definitions}:
@@ -447,7 +447,7 @@ v = if activeState(state!\textsubscript{1}!) then
       last(v);
 u!\textsubscript{1}! = v
 u!\textsubscript{2}! = v
-...
+$\ldots$
 \end{lstlisting}
 
 \subsection{Example}\label{example}

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -139,12 +139,9 @@ Assignment to array variables with subscripts is described in \cref{array-indexi
 
 \subsubsection{Assignments from Called Functions with Multiple Results}\label{assignments-from-called-functions-with-multiple-results}
 
-There is a special form of assignment statement that is used only when
-the right-hand side contains a call to a function with multiple results.
-The left-hand side contains a parenthesized, comma-separated list of
-variables receiving the results from the function call. A function with
-\emph{n} results needs \emph{m\textless{}=n} receiving variables on the
-left-hand side, and the variables are assigned from left to right.
+There is a special form of assignment statement that is used only when the right-hand side contains a call to a function with multiple results.
+The left-hand side contains a parenthesized, comma-separated list of variables receiving the results from the function call.
+A function with $n$ results needs $m \leq n$ receiving variables on the left-hand side, and the variables are assigned from left to right.
 
 \begin{lstlisting}[language=modelica]
 (out1, out2, out3) := function_name(in1, in2, in3, in4);

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -208,7 +208,7 @@ The rules for for-statements are the same as for for-expressions in \cref{explic
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-for i in 1 : 10 loop // i takes the values 1, 2, 3, ..., 10
+for i in 1 : 10 loop // i takes the values 1, 2, 3, $\ldots$, 10
 for r in 1.0 : 1.5 : 5.5 loop // r takes the values 1.0, 2.5, 4.0, 5.5
 for i in {1, 3, 6, 7} loop // i takes the values 1, 3, 6, 7
 for i in TwoEnums loop // i takes the values TwoEnums.one, TwoEnums.two
@@ -240,11 +240,11 @@ but it is only seen as a reference to the variable \lstinline!IDENT! and cannot 
   Real xsquared2[size(x, 1)];
   Real xsquared3[size(x, 1)];
 equation
-  for i loop // Same as: for i in 1 : size(x, 1) loop ...
+  for i loop // Same as: for i in 1 : size(x, 1) loop $\ldots$
     xsquared2[i] = x[i]^2;
   end for;
 algorithm
-  for i loop // Same as: for i in 1 : size(x, 1) loop ...
+  for i loop // Same as: for i in 1 : size(x, 1) loop $\ldots$
     xsquared3[i] := x[i]^2;
   end for;
 \end{lstlisting}
@@ -292,8 +292,8 @@ with ``\lstinline!functionName(!''.
   Real x[4,3];
 algorithm
   for j, i in 1:2 loop
-    // The loop-variable j takes the values 1,2,3,4 (due to use)
-    // The loop-variable i takes the values 1,2 (given range)
+    // The loop variable j takes the values 1, 2, 3, 4 (due to use)
+    // The loop variable i takes the values 1, 2 (given range)
     x[j,i] := j+i;
   end for;
 \end{lstlisting}
@@ -465,32 +465,28 @@ there are no additional restrictions within when-statements:
 A when-statement:
 \begin{lstlisting}[language=modelica]
 algorithm
-  when {x>1, ..., y>p} then
-    ...
-    elsewhen x > y.start then
-    ...
+  when {x > 1, $\ldots$, y > p} then
+    $\ldots$
+  elsewhen x > y.start then
+    $\ldots$
   end when;
 \end{lstlisting}
 is similar to the following special if-statement, where \lstinline!Boolean b1[N];! and \lstinline!Boolean b2;! are necessary because \lstinline!edge! can
 only be applied to variables
 \begin{lstlisting}[language=modelica]
-  Boolean b1[N](start={x.start>1, ...,
-  y.start>p});
-  Boolean b2(start=x.start>y.start);
+  Boolean b1[N](start = {x.start > 1, $\ldots$, y.start > p});
+  Boolean b2(start = x.start > y.start);
 algorithm
-  b1:={x>1, ..., y>p};
-  b2:=x>y.start;
-  if edge(b1[1]) or edge(b1[2]) or ...
-    edge(b1[N]) then
-    ...
-    elseif edge(b2) then
-    ...
+  b1: = {x > 1, $\ldots$, y > p};
+  b2: = x > y.start;
+  if edge(b1[1]) or edge(b1[2]) or $\ldots$ or edge(b1[N]) then
+    $\ldots$
+  elseif edge(b2) then
+    $\ldots$
   end if;
 \end{lstlisting}
-with \lstinline!edge(A)= A and not pre(A)! and the additional guarantee, that the
-statements within this special if-statement are only evaluated at event
-instants. The difference compared to the when-statements is that e.g.\ \lstinline!pre! may only be used on continuous-time real variables inside the body
-of a when-clause and not inside these if-statements.
+with \lstinline!edge(A) = A and not pre(A)! and the additional guarantee, that the statements within this special if-statement are only evaluated at event instants.
+The difference compared to the when-statements is that e.g.\ \lstinline!pre! may only be used on continuous-time real variables inside the body of a when-clause and not inside these if-statements.
 
 \subsection{Special Statements}\label{special-statements}
 

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -83,25 +83,25 @@ variable \lstinline!m_flow! in connector \lstinline!c!.
 
 \begin{lstlisting}[language=modelica]
 connector FluidPort
-  ...
+  $\ldots$
   flow Real m_flow "Flow of matter; m_flow > 0 if flow into component";
   stream Real h_outflow "Specific variable in component if m_flow < 0"
 end FluidPort
 
 model FluidSystem
-  ...
-  FluidComponent $m_1$, $m_2$, ..., $m_N$;
-  FluidPort $c_1$, $c_2$, ..., $c_M$;
+  $\ldots$
+  FluidComponent $m_1$, $m_2$, $\ldots$, $m_N$;
+  FluidPort $c_1$, $c_2$, $\ldots$, $c_M$;
 equation
   connect($m_1$.c, $m_2$.c);
   connect($m_1$.c, $m_3$.c);
-  ...
+  $\ldots$
   connect($m_1$.c, $m_N$.c);
   connect($m_1$.c, $c_1$);
   connect($m_1$.c, $c_2$);
-  ...
+  $\ldots$
   connect($m_1$.c, $c_M$);
-  ...
+  $\ldots$
 end FluidSystem;
 \end{lstlisting}
 \begin{figure}[H]

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -247,7 +247,7 @@ following term is used.
 
 \begin{definition}[Component expression]\label{def:component-expression}\index{component!expression (argument restriction)}
 A component expression is a \lstinline[language=grammar]!component-reference! which is a valid expression, i.e., not referring to models or blocks with equations.
-% "an element of records" below looks strange...
+% "an element of records" below looks strange:
 In detail, it is an instance of a (a) base type, (b) derived type, (c) record, (d) an array of such an instance (a-c), (e) one or more elements of such an array (d) defined by index expressions which are parameter expressions (see below), or (f) an element of records.
 \begin{nonnormative}
 The essential features are that one or several values are associated with the instance, that start values can be defined on these values, and that no equations are associated with the instance.
@@ -369,12 +369,12 @@ can be modified by using the \lstinline!subSample!, \lstinline!superSample!, \ls
   Real y2(start = 0);
 equation
   when Clock(2, 1000) then
-    // periodic clock that ticks at 0, 0.002, 0.004, ...
+    // periodic clock that ticks at 0, 0.002, 0.004, $\ldots$
     y1 = previous(y1) + 1;
   end when;
 
   when Clock(nextInterval, 1000) then
-    // interval clock that ticks at 0, 0.003, 0.007, 0.012, ...
+    // interval clock that ticks at 0, 0.003, 0.007, 0.012, $\ldots$
     nextInterval = previous(nextInterval) + 1;
     y2 = previous(y2) + 1;
   end when;
@@ -715,13 +715,12 @@ shiftSample($u$, $k$, $\mathit{resolution}$) =
 Note, due to the restriction of \lstinline!superSample! on event clocks, \lstinline!shiftSample! can only shift the number of ticks of the event clock, but cannot introduce new ticks.  Example:
 \begin{lstlisting}[language=modelica]
 // Rational interval clock
-Clock u  = Clock(3, 10);            // ticks: 0, 3/10, 6/10, ..
-Clock y1 = shiftSample(u, 1, 3);    // ticks: 1/10, 4/10,
-$\ldots$
+Clock u  = Clock(3, 10);            // ticks: 0, 3/10, 6/10, $\ldots$
+Clock y1 = shiftSample(u, 1, 3);    // ticks: 1/10, 4/10, $\ldots$
 // Event clock
 Clock u = Clock(sin(2 * pi * time) > 0, startInterval = 0.0);
-                                    // ticks: 0.0, 1.0, 2.0, 3.0, ...
-Clock y1 = shiftSample(u, 2);       // ticks: 2.0, 3.0, ...
+                                    // ticks: 0.0, 1.0, 2.0, 3.0, $\ldots$
+Clock y1 = shiftSample(u, 2);       // ticks: 2.0, 3.0, $\ldots$
 Clock y2 = shiftSample(u, 2, 3);    // error (resolution must be 1)
 \end{lstlisting}
 \end{nonnormative}
@@ -743,21 +742,17 @@ If $u$ is a clocked component expression, the operator returns the start value o
 \begin{example}
 \begin{lstlisting}[language=modelica]
 // Rational interval clock 1
-
-Clock u  = Clock(3, 10);          // ticks: 0, 3/10, 6/10, ..
-Clock y1 = shiftSample(u, 3);     // ticks: 9/10, 12/10, ..
-Clock y2 = backSample(y1, 2);     // ticks: 3/10, 6/10,
-$\ldots$
+Clock u  = Clock(3, 10);          // ticks: 0, 3/10, 6/10, $\ldots$
+Clock y1 = shiftSample(u, 3);     // ticks: 9/10, 12/10, $\ldots$
+Clock y2 = backSample(y1, 2);     // ticks: 3/10, 6/10, $\ldots$
 Clock y3 = backSample(y1, 4);     // error (ticks before u)
-Clock y4 = shiftSample(u, 2, 3);  // ticks: 2/10, 5/10,
-$\ldots$
-Clock y5 = backSample(y4, 1, 3);  // ticks: 1/10, 4/10,
-$\ldots$
+Clock y4 = shiftSample(u, 2, 3);  // ticks: 2/10, 5/10, $\ldots$
+Clock y5 = backSample(y4, 1, 3);  // ticks: 1/10, 4/10, $\ldots$
 // Event clock
 Clock u = Clock(sin(2 * pi * time) > 0, startInterval = xx)
-                                  // ticks: 0, 1.0, 2.0, 3.0, ....
-Clock y1 = shiftSample(u, 3);     // ticks: 3.0, 4.0, ...
-Clock y2 = backSample(y1, 2);     // ticks: 1.0, 2.0, ...
+                                  // ticks: 0, 1.0, 2.0, 3.0, $\ldots$
+Clock y1 = shiftSample(u, 3);     // ticks: 3.0, 4.0, $\ldots$
+Clock y2 = backSample(y1, 2);     // ticks: 1.0, 2.0, $\ldots$
 \end{lstlisting}
 \end{example}
 \end{semantics}
@@ -819,16 +814,15 @@ Note that it is not legal to compute the derivative of the \lstinline!sample!, \
 In addition to the previously discussed conditional when-clause, a
 \emph{clocked} when-clause is introduced:
 \begin{lstlisting}[language=modelica,escapechar=!]
-when !\emph{clock-expression}! then
-  !\emph{clocked-equation}!
-  ...
+when $\mathit{clockExpression}$ then
+  !\emph{\textless{}clocked equations\textgreater{}}!
+  $\ldots$
 end when;
 \end{lstlisting}
 
 The clocked when-clause cannot be nested and does not have any \lstinline!elsewhen! part.  It cannot be used inside an algorithm.  General equations are allowed in a clocked when-clause.
 
-For a clocked when-clause, all equations inside the when-clause are
-clocked with the same clock given by the \emph{clock-expression}.
+For a clocked when-clause, all equations inside the when-clause are clocked with the same clock given by the $\mathit{clockExpression}$.
 
 \section{Clock Partitioning}\label{clock-partitioning}
 

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -811,8 +811,7 @@ Note that it is not legal to compute the derivative of the \lstinline!sample!, \
 
 \section{Clocked When-Clause}\label{clocked-when-clause}
 
-In addition to the previously discussed conditional when-clause, a
-\emph{clocked} when-clause is introduced:
+In addition to the previously discussed conditional when-clause, a \emph{clocked} when-clause\index{clocked!when-clause}\index{when-clause!clocked} is introduced:
 \begin{lstlisting}[language=modelica,escapechar=!]
 when $\mathit{clockExpression}$ then
   !\emph{\textless{}clocked equations\textgreater{}}!

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -812,9 +812,9 @@ Note that it is not legal to compute the derivative of the \lstinline!sample!, \
 \section{Clocked When-Clause}\label{clocked-when-clause}
 
 In addition to the previously discussed conditional when-clause, a \emph{clocked} when-clause\index{clocked!when-clause}\index{when-clause!clocked} is introduced:
-\begin{lstlisting}[language=modelica,escapechar=!]
+\begin{lstlisting}[language=modelica]
 when $\mathit{clockExpression}$ then
-  !\emph{\textless{}clocked equations\textgreater{}}!
+  $\langle\mbox{\emph{clocked equations}}\rangle$
   $\ldots$
 end when;
 \end{lstlisting}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -12,13 +12,13 @@ The following syntactic meta symbols are used (extended BNF):
 The following lexical units are defined (the ones in boldface are the
 ones used in the grammar, the rest are just internal to the definition
 of other lexical units):
-\begin{lstlisting}[language=grammar,mathescape=false]
+\begin{lstlisting}[language=grammar]
 IDENT = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
-NONDIGIT = "_" | letters "a" to "z" | letters "A" to "Z"
+NONDIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
 STRING = """ { S-CHAR | S-ESCAPE } """
 S-CHAR = see below
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$" | "%" | "&" | "(" | ")"
+Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")"
    | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
    | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
 S-ESCAPE = "\'" | "\"" | "\?" | "\\"

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -60,9 +60,8 @@ Note:
   other strings have to contain only the sub-set of Unicode characters
   identical with the 7-bit US-ASCII character set.
   \begin{nonnormative}
-  As a consequence, operators like `\textgreater{}' or `\textless{}', and external functions only operate on ASCII strings and not on Unicode-strings.
-  Within a description-string the tags \lstinline!<HTML>! and \lstinline!</HTML>! or \lstinline!<html>! and \lstinline!</html>! define optionally begin
-  and end of content that is HTML encoded.
+  As a consequence, operators like `\lstinline!>!' or `\lstinline!<!', and external functions only operate on ASCII strings and not on Unicode-strings.
+  Within a description-string the tags \lstinline!<HTML>! and \lstinline!</HTML>! or \lstinline!<html>! and \lstinline!</html>! define optionally begin and end of content that is HTML encoded.
   \end{nonnormative}
 \item
   Boldface denotes keywords of the Modelica language. Keywords are

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -143,7 +143,7 @@
         include,pragma,undef,warning}
 }[keywords,comments,strings,directives]
 
-% Note: \lstinline!...! used for inline Modelica using [short]modelica
+% Note: \lstinline!…! used for inline Modelica using [short]modelica
 
 \lstset{%
   backgroundcolor=\color{white},   % choose the background color

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -143,8 +143,6 @@
         include,pragma,undef,warning}
 }[keywords,comments,strings,directives]
 
-% Note: \lstinline!…! used for inline Modelica using [short]modelica
-
 \lstset{%
   backgroundcolor=\color{white},   % choose the background color
   mathescape=true,

--- a/preamble.tex
+++ b/preamble.tex
@@ -47,7 +47,7 @@
 
 \RequirePackage[margin=1em, labelfont=bf,
                 singlelinecheck=true, font=sl,
-                compatibility=false% Unsupported feature that suppresses the incompatibility checks...
+                compatibility=false% Unsupported feature that suppresses the incompatibility checks.
                 ]{caption}
 \captionsetup[figure]{position=bottom}
 \captionsetup[table]{position=top}
@@ -88,7 +88,7 @@
 \fi
 \makeindex
 
-% Providing command that other authors seem to take for granted...
+% Providing command that other authors seem to take for granted.
 \newcommand*\seealso[2]{\emph{\alsoname} #1}
 
 \ifpdf


### PR DESCRIPTION
This is a listings-focused cleanup of:
- Consistent typesetting of ellipsis (…).
- Consistent formatting of bracketed describing text (⟨_clocked equations_⟩).
- Breaking some lines that were too long.

Additionally, one off-topic change:
- Adding _clocked when-clause_ to the document index.

I don't find this important for the 3.5 release, I just happened to come across these when all I was really planning was to add the clocked when-clause to the document index.
