### PR TITLE
Remove default for Dialog.group in the right place

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1351,7 +1351,7 @@ A component declaration or a short replaceable class definition may have the fol
 \begin{lstlisting}[language=modelica]
 annotation(Dialog(enable = true,
                   tab = "General",
-                  group = "",
+                  group = "Parameters",
                   showStartAttribute = false,
                   colorSelector = false,
                   groupImage = "modelica://MyLib/Resources/Images/load.png",
@@ -1418,7 +1418,7 @@ Annotation \fmtannotationindex{Dialog} is defined as:
 \begin{lstlisting}[language=modelica]
 record Dialog
   parameter String tab = "General";
-  parameter String group = "Parameters";
+  parameter String group = "";
   parameter Boolean enable = true;
   parameter Boolean showStartAttribute = false;
   parameter Boolean colorSelector = false;


### PR DESCRIPTION
When #2476 was first closed, the string `"Parameters"` was replaced by the empty string in the first example of a `Dialog` annotation, rather in the place where the defaults of the annotation are actually defined.  This moves the fix into the right place.  See #2819 for a more thorough take on this for future versions.

(Making use of a temporary branch in the central repo, counting on it soon being removed automatically when this PR gets merged – I see no reason why it shouldn't.  I can also see that it could make sense to apply this change to _master_ while waiting for #2476, but I leave it to others to tell if this is considered necessary.)