### PR TITLE
Fix typos in revisions notes of v3.5

### DIFF
--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -6,7 +6,7 @@ is not normative. The current version of this document is available from
 \url{https://www.modelica.org/documents}.
 
 \section{Modelica 3.5}\label{modelica-3-5}
-Modelica 3.5 was last edited \mlsdate, and will later be voted to be approved
+Modelica 3.5 was last edited \mlsdate, and will later be voted to be approved.
 The Modelica 3.5 specification was edited by Hans Olsson.
 
 \subsection{Main changes in Modelica 3.5}\label{main-changes-in-modelica-3-5}
@@ -21,7 +21,7 @@ The development of the specification was changed to use \LaTeX for formatting; a
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2692}{\#2692}.
 \item Mandate that Axis.unit is for tick labels, \cref{axis-properties}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2633}{\#2633}.
-\item Define meaing of empty Axis.unit, \cref{axis-properties}.
+\item Define meaning of empty Axis.unit, \cref{axis-properties}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2632}{\#2632}.
 \item Elaborate on inheritance of figures, \cref{annotations-for-figures}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2588}{\#2588}.
@@ -104,7 +104,7 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2417}{\#24
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2403}{\#2403}.
 \end{itemize}
 
-\item Clarified synchonous Modelica, \cref{synchronous-language-elements}
+\item Clarified synchronous Modelica, \cref{synchronous-language-elements}
 \begin{itemize}
 \item Clarified that clock operators are not callable in functions and that functions may not contain Clock-variables and that they do not vectorize, \cref{argument-restrictions-component-expression}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2177}{\#2177} and Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2269}{\#2269}.
@@ -120,7 +120,7 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2512}{\#25
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2651}{\#2651}.
 \item Clarified that clocked signals are extrapolated using hold, not constant \cref{clocks-and-clocked-variables}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2607}{\#2607}.
-\item Clarified that clock constructors can take named arguments and that clock paritioning must be parametric, \cref{clock-constructors};
+\item Clarified that clock constructors can take named arguments and that clock partioning must be parametric, \cref{clock-constructors};
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2394}{\#2394}.
 \item Restricted noClock to not take a Clock as input, \cref{sub-clock-conversion-operators}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2355}{\#2355}.
@@ -294,7 +294,7 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/2742}{\#2742
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2676}{\#2676}.
 \item Made when-descriptions more similar, \cref{restrictions-on-where-a-when-equation-may-occur} and \cref{restrictions-on-equations-within-when-equations}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2635}{\#2635}.
-\item Make assertion level a structural parameteter, \cref{assert}.
+\item Make assertion level a structural parameter, \cref{assert}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2642}{\#2642}.
 \item Deprecate byte order mark, \cref{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2675}{\#2675}.

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -269,7 +269,7 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2639}{\#26
 
 \item Improved stream connector formulation, \cref{derivation-of-stream-equations}
 \begin{itemize}
-\item Updated notation to use have mass-flows as derivatives, \cref{derivation-of-stream-equations}.
+\item Updated notation to use mass-flows as derivatives, \cref{derivation-of-stream-equations}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2644}{\#2644}.
 \item Further clarify inStream simplifications, \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2242}{\#2242}.


### PR DESCRIPTION
I just fixed some typos in the release notes of Modelica 3.5. This should be also merged to master?

Btw, it would be good to use present tense "clarify" and and past tense "clarified", consistently. I did not fix this, because I did not know which option to choose.