### PR TITLE
Align duplicated parts of lexing rules

### DIFF
--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -73,13 +73,17 @@ The single quotes are part of the identifier, i.e., \lstinline!'x'! and \lstinli
 The redundant escapes (\lstinline!'\?'! and \lstinline!'\"'!) are the same as the corresponding non-escaped variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica source code.
 A full BNF definition of the Modelica syntax and lexical units is available in \cref{modelica-concrete-syntax}.
 
+% For easy maintenance, the lexing rules below should be a substring of the full lexing rules in \cref{lexical-conventions}.
 \begin{lstlisting}[language=grammar]
-IDENT   = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
+IDENT = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
 NONDIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
-DIGIT    = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
-Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")" | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "=" | "?" | "@" | "[" | "]" | "^" | "{" | "}"  | "|" | "~" | " " | """
-S-ESCAPE = "\'" | "\"" | "\?" | "\\" | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
+DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")"
+   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
+   | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
+S-ESCAPE = "\'" | "\"" | "\?" | "\\"
+   | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
 \end{lstlisting}
 
 \subsection{Names}\label{names}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -12,18 +12,19 @@ The following syntactic meta symbols are used (extended BNF):
 The following lexical units are defined (the ones in boldface are the
 ones used in the grammar, the rest are just internal to the definition
 of other lexical units):
+% Beware that the first lines of the lexing rules below are duplicated in \cref{identifiers}, and must be kept in sync.
 \begin{lstlisting}[language=grammar]
 IDENT = NONDIGIT { DIGIT | NONDIGIT } | Q-IDENT
 Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
 NONDIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
-STRING = """ { S-CHAR | S-ESCAPE } """
-S-CHAR = see below
+DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 Q-CHAR = NONDIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")"
    | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
    | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
 S-ESCAPE = "\'" | "\"" | "\?" | "\\"
    | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
-DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+STRING = """ { S-CHAR | S-ESCAPE } """
+S-CHAR = see below
 UNSIGNED-INTEGER = DIGIT { DIGIT }
 UNSIGNED-REAL =
    UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]


### PR DESCRIPTION
This isn't the first time we have issues with these being out of sync.  Hopefully, maintenance will become easier now with the duplicated part being a substring of the full lexing rules.

Addresses one of the items in #2825:
> - [ ] Text does not adapt to width of browser window. I only found this for for Chapter 2 in one column mode on Desktop. Strange.

@HansOlsson: This is another PR where it would be good to have a documented procedure for also targeting the current maintenance branch.
