### PR TITLE
Remove HTML footer links to bibliography and index

### DIFF
--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -62,6 +62,14 @@ nav > div.ltx_TOC {
   display: none; /* Don't show link to previous chapter. */
 }
 
+.ltx_page_footer a[rel=bibliography] {
+  display: none; /* Don't show link to bibliography. */
+}
+
+.ltx_page_footer a[rel=index] {
+  display: none; /* Don't show link to index. */
+}
+
 .ltx_TOC {
   padding-right: 1em;
   overflow-y: auto;

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -139,7 +139,12 @@ nav > div.ltx_TOC {
   z-index: 3;
   top: 0px;
   height: 1.5rem;
-  padding: 0.5rem 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0rem;
+  /* Add right padding corresponding to part being covered by magnifying glass.
+   */
+  padding-right: calc(1.5rem + 2 * 0.5rem + 8px);
   background: #F6F6F6; /* Same as body. */
   color: black; /* Same as side bar. */
   white-space: nowrap;
@@ -177,7 +182,7 @@ nav > div.ltx_TOC {
     height: 100%;
   }
   .ltx_page_header {
-    width: calc(100% - 350px - 2em); /* Subtract 2em for the total horizontal padding on this element. */
+    width: calc(100% - 350px - (1.5rem + 2 * 0.5rem + 8px)); /* Subtract total horizontal padding on this element. */
   }
   .ltx_page_navbar:before {
     display: none;
@@ -204,8 +209,8 @@ nav > div.ltx_TOC {
     height: calc(100% - 20px);
   }
   .ltx_page_header {
-    padding-left: 4rem;
-    width: calc(100% - (4rem + 1rem)); /* Subtract horizontal padding on this element. */
+    padding-left: 3rem;
+    width: calc(100% - 3rem - (1.5rem + 2 * 0.5rem + 8px)); /* Subtract horizontal padding on this element. */
   }
   .ltx_page_navbar:hover {
     left: 0px;

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -66,8 +66,32 @@ nav > div.ltx_TOC {
   display: none; /* Don't show link to bibliography. */
 }
 
+.ltx_page_footer a[rel=index]:before {
+  display: inline-block;
+  content: "";
+  height: 1.5rem; /* Same as .ltx_page_header. */
+  width: 1.5rem;
+  padding: 0.5rem; /* Same as y-direction in .ltx_page_header. */
+  margin: 0px;
+  border-style: solid;
+  border-color: #707A85; /* "Bouncing ball trace gray" */
+  border-width: 0px;
+  border-left-width: 8px;
+  background-image: url("Magnifying_glass_icon.svg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 25px 25px;
+}
+
 .ltx_page_footer a[rel=index] {
-  display: none; /* Don't show link to index. */
+  position: fixed;
+  z-index: 4;
+  top: 0px;
+  right: 0px;
+}
+
+.ltx_page_footer a[rel=index] span {
+  display: none; /* Don't display the "Index" text; we have added a magnifying glass instead. */
 }
 
 .ltx_TOC {

--- a/css/Magnifying_glass_icon.svg
+++ b/css/Magnifying_glass_icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This image is based on the following work released into the public domain: -->
+<!-- - https://commons.wikimedia.org/wiki/File:Magnifying_glass_icon.svg        -->
+<svg xmlns="http://www.w3.org/2000/svg" width="490" height="490">
+<style>
+  <!-- "Bouncing ball red" stroke: -->
+  .bbRedStroke { stroke: #DE1D31 }
+</style>
+<path fill="none" class="bbRedStroke" stroke-width="36" stroke-linecap="round"
+d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110"/>
+</svg>


### PR DESCRIPTION
Addresses one of the items in #2825:
> - [ ] The footer is missing white space between links (looks like: HeadingReferencesIndex)

While I think it is good for the page layout to have a footer, I don't consider any of the links to be of importance.  Hence, rather than trying to improve the styling of the links, I found it better to simply remove them.  The only reason I see for keeping the links to the previous and next chapter is that we don't have much else for populating the footer (except for the LaTeXML build timestamp, which I think is a nice way to give credit to the LaTeXML project on which we rely so heavily).

@HansOlsson: This is another PR where it would be good to have a documented procedure for also targeting the current maintenance branch.
