### PR TITLE
Minor cleanup of inline code and math for Derivative annotation

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1359,16 +1359,12 @@ DensityDerivative d_rho2=der (rho2);
 
 \begin{itemize}
 \item
-  \lstinline[language=grammar]!zeroDerivative = inputVar1 { , zeroDerivative = inputVar2 }!
+  \lstinline[language=grammar]!zeroDerivative = $\mathit{inputVar}_{1}$ { , zeroDerivative = $\mathit{inputVar}_{2}$ }!
 \end{itemize}
 
-The derivative function is only valid if \lstinline!inputVar1! (and \lstinline!inputVar2! etc.)
-are independent of the variables the function call is differentiated
-with respect to (i.e.\ that the derivative of \lstinline!inputVar1! is zero). The
-derivative of \lstinline!inputVar1! (and \lstinline!inputVar2! etc.) are excluded from the
-argument list of the derivative-function. If the derivative-function
-also specifies a derivative the common variables should have consistent
-\lstinline!zeroDerivative!.
+The derivative function is only valid if $\mathit{inputVar}_{1}$ (and $\mathit{inputVar}_{2}$ etc.) are independent of the variables the function call is differentiated with respect to (i.e.\ that the derivative of $\mathit{inputVar}_{1}$ is zero).
+The derivative of $\mathit{inputVar}_{1}$ (and $\mathit{inputVar}_{2}$ etc.) are excluded from the argument list of the derivative-function.
+If the derivative-function also specifies a derivative the common variables should have consistent \lstinline!zeroDerivative!.
 
 \begin{nonnormative}
 Assume that function \lstinline!f! takes a matrix and a scalar.
@@ -1432,15 +1428,12 @@ end f_general_der;
 
 \begin{itemize}
 \item
-  \lstinline!noDerivative = inputVar1!
+  \lstinline[language=grammar]!noDerivative = $\mathit{inputVar}_{1}$!
 \end{itemize}
 
-The derivative of inputVar1 is excluded from the argument list of the
-derivative-function. This relies on assumptions on the arguments to the
-function; and the function should document these assumptions (it is not
-always straightforward to verify them). In many cases even the
-undifferentiated function will only behave correctly under these
-assumptions.
+The derivative of $\mathit{inputVar}_{1}$ is excluded from the argument list of the derivative-function.
+This relies on assumptions on the arguments to the function; and the function should document these assumptions (it is not always straightforward to verify them).
+In many cases even the undifferentiated function will only behave correctly under these assumptions.
 
 The inputs excluded using \lstinline!zeroDerivative! or \lstinline!noDerivative! may be of any type (including types not containing reals).
 


### PR DESCRIPTION
Triggered by the _inputVar1_ formatted as normal text.
