### PR TITLE
Avoid current HTML jump target being hidden behind page header

### DIFF
--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -110,13 +110,24 @@ nav > div.ltx_TOC {
   padding: 0.5rem 1rem;
   background: #F6F6F6; /* Same as body. */
   color: black; /* Same as side bar. */
+  border-bottom-color: #DE1D31; /* "Bouncing ball red" */
+  border-bottom-width: 2px;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
+/* Make current jump target appear below the page header instead of behind it.
+ */
+:target:before {
+  visibility: hidden;
+  content: "X"; /* Hidden, but needs to be non-empty to work in Chrome. */
+  display: block;
+  position: relative;
+  top: calc(-(2.5rem + 2px)); /* Offset by total height of .ltx_page_header. */
+}
+
 .ltx_page_content {
   padding: 1rem;
-  margin-top: 1.5rem; /* Header height plus padding below, minus a little bit. */
   background: white;
 }
 

--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -127,7 +127,10 @@ nav > div.ltx_TOC {
 }
 
 .ltx_page_content {
-  padding: 1rem;
+  padding-top: 2rem;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
   background: white;
 }
 

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -15,8 +15,8 @@ body {
 a       { text-decoration: none; color: inherit; }
 a:hover { text-decoration: underline; }
 
-.ltx_title_chapter {
-  padding-top: 2rem;
+.ltx_titlepage {
+  padding-top: 2rem; /* The big Modelica Language logo doesn't look good too close to page header. */
 }
 
 .ltx_tocentry_subsection { display: none; }

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -15,9 +15,8 @@ body {
 a       { text-decoration: none; color: inherit; }
 a:hover { text-decoration: underline; }
 
-.ltx_page_header {
-  border-bottom-color: #DE1D31; /* "Bouncing ball red" */
-  border-bottom-width: 2px;
+.ltx_title_chapter {
+  padding-top: 2rem;
 }
 
 .ltx_tocentry_subsection { display: none; }


### PR DESCRIPTION
Addresses one of the items in #2825:
> - [ ] When clicking on some heading in the table of contents (left bar), the document jumps to the right spot. But, the selected heading is hidden by the header bar.
