### PR TITLE
Stop saying that 'promote' isn't a Modelica function

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -210,14 +210,14 @@ The \lstinline!promote! function listed below is utilized to define other array 
 \tablehead{Expression} & \tablehead{Description} & \tablehead{Details}\\
 \hline
 \hline
-\lstinline!promote($A$, $n$)! & Append dimensions of size 1 (not Modelica) & \Cref{not-modelica-promote} \\
+\lstinline!promote($A$, $n$)! & Append dimensions of size 1 & \Cref{modelica:promote} \\
 \hline
 \end{tabular}
 \end{center}
 
-\begin{operatordefinition*}[promote]\label{not-modelica-promote}\indexinline{promote}
+\begin{operatordefinition}[promote]\indexinline{promote}
 \begin{synopsis}\begin{lstlisting}
-promote($A$, $n$) /* Not available in Modelica. */
+promote($A$, $n$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Fills dimensions of size 1 from the right to array $A$ upto dimension $n$, where $n \geq$ \lstinline!ndims($A$)! is required.
@@ -229,7 +229,7 @@ The argument $n$ must be a constant that can be evaluated during translation, as
 An $n$ that is not a constant that can be evaluated during translation for \lstinline!promote! complicates matrix handling as it can change matrix-equations in subtle ways (e.g.\ changing inner products to matrix multiplication).
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition*}
+\end{operatordefinition}
 
 \begin{nonnormative}
 Some examples of using the functions defined in the following


### PR DESCRIPTION
Fixes #2843.

It's rather embarrassing that we missed this in #2590.