### PR TITLE
More systematic use of \lstinline for figure annotations Axis and Curve

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -173,9 +173,10 @@ user, on the other hand, a tool may choose a unit for the variable such that the
 
 If a tool does not recognize the \lstinline!unit!, it is recommended to issue a warning and treat the \lstinline!unit! as if it was empty, as well as ignore any setting for \lstinline!min! and \lstinline!max!.
 
-When an axis label isn't provided, the tool produces a default label.  Providing the empty string as axis label means that no label should be shown.  Variable replacements, as described in
-\cref{variable-replacements}, can be used in the \lstinline!label! of \lstinline!Axis!  The Modelica tool is responsible for showing the unit used for values at the axis tick marks, so the axis
-\lstinline!label! shall not contain the unit.
+When \lstinline!label! isn't provided, the tool produces a default label.
+Providing the empty string as \lstinline!label! means that no label should be shown.
+Variable replacements, as described in \cref{variable-replacements}, can be used in \lstinline!label!.
+The Modelica tool is responsible for showing the unit used for values at the axis tick marks, so the axis \lstinline!label! shall not contain the unit.
 
 \subsubsection{Plot Curves}\label{plot-curves}
 
@@ -192,11 +193,9 @@ The mandatory \lstinline!x! and \lstinline!y! expressions are restricted to be c
 It is an error if \lstinline!x! or \lstinline!y! does not designate a scalar variable.
 When the \lstinline!unit! of an \lstinline!Axis! is non-empty, it is an error if the unit of the corresponding \lstinline!Curve! expression (i.e., a variable's \lstinline!unit!, or second for \lstinline!time!) is incompatible with the axis unit.
 
-When \lstinline!legend! isn't provided, the tool produces a default based on
-\lstinline!x! and/or \lstinline!y!.  Providing the empty string as
-\lstinline!legend! means that the curve shall be omitted from the plot legend.
-Variable replacements, as described in \cref{variable-replacements}, can be
-used in the \lstinline!legend! of \lstinline!Curve!
+When \lstinline!legend! isn't provided, the tool produces a default based on \lstinline!x! and/or \lstinline!y!.
+Providing the empty string as \lstinline!legend! means that the curve shall be omitted from the plot legend.
+Variable replacements, as described in \cref{variable-replacements}, can be used in \lstinline!legend!.
 
 \subsubsection{Escape sequences}\label{text-markup-escape-sequences}
 


### PR DESCRIPTION
Just some minor formatting issues that popped up when working on #3749 and #3750.
