### PR TITLE
BumpCopyright

### DIFF
--- a/chapters/copyright.tex
+++ b/chapters/copyright.tex
@@ -1,4 +1,4 @@
-Copyright \textcopyright{} 1998-2020, Modelica Association (\url{https://www.modelica.org})
+Copyright \textcopyright{} 1998-2021, Modelica Association (\url{https://www.modelica.org})
 
 All rights reserved.
 Reproduction or use of editorial or pictorial content is permitted, i.e., this document can be freely distributed especially electronically, provided the copyright notice and these conditions are retained.


### PR DESCRIPTION
Increase copyright year to 2021.

I don't think it is necessary to do this for maint/3.5 as the text was completed in 2020; and since copyright lasts 50-100 years I don't think it matters much.