### PR TITLE
Revert "Use angle brackets for '<describing text>' in listings"

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1562,7 +1562,7 @@ level, it is not possible to use the enumeration attribute names
 
 \subsubsection{Type Conversion of Enumeration Values to String or Integer}\label{type-conversion-of-enumeration-values-to-string-or-integer}
 
-The type conversion function \lstinline!Integer($\langle\mbox{\emph{expression of enumeration type}}\rangle$)! returns the ordinal number of the enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated, where $\text{\lstinline!Integer(E.e1)!} = 1$, $\text{\lstinline!Integer(E.en)!} = n$, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
+The type conversion function \lstinline!Integer($\mbox{\emph{\textless{}expression of enumeration type\textgreater{}}}$)! returns the ordinal number of the enumeration value \lstinline!E.enumvalue!, to which the expression is evaluated, where $\text{\lstinline!Integer(E.e1)!} = 1$, $\text{\lstinline!Integer(E.en)!} = n$, for an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!.
 
 \lstinline!String(E.enumvalue)! gives the \lstinline!String! representation of the enumeration value.
 
@@ -1579,7 +1579,10 @@ the same name and in the same scope as the enumeration type is
 implicitly defined. This function can be used in an expression to
 convert an integer value to the corresponding (as described in \cref{type-conversion-of-enumeration-values-to-string-or-integer}) enumeration value.
 
-For an enumeration type named \lstinline!EnumTypeName!, the expression \lstinline!EnumTypeName($\langle\mbox{\emph{Integer expression}}\rangle$)! returns the enumeration value \lstinline!EnumTypeName.e! such that \lstinline!Integer(EnumTypeName.e)! is equal to the original integer expression.
+For an enumeration type named \lstinline!EnumTypeName!, the expression
+\lstinline!EnumTypeName(<Integer expression>)! returns the
+enumeration value \lstinline!EnumTypeName.e! such that \lstinline!Integer(EnumTypeName.e)! is
+equal to the original integer expression.
 
 Attempting to convert an integer argument that does not correspond to a
 value of the enumeration type is an error.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -875,8 +875,7 @@ Defines a \firstuse{required spanning-tree edge}\index{required spanning-tree ed
 This function can be used at all places where a \lstinline!connect! statement is allowed.
 
 \begin{nonnormative}
-E.g., it is not allowed to use this function in a when-clause.
-This definition shall be used if in a model with connectors \lstinline!A! and \lstinline!B! the overdetermined records \lstinline!A.R! and \lstinline!B.R! are algebraically coupled in the model, e.g., due to \lstinline!B.R = f(A.R, $\langle\mbox{\emph{other unknowns}}\rangle$)!.
+E.g., it is not allowed to use this function in a when-clause.  This definition shall be used if in a model with connectors \lstinline!A! and \lstinline!B! the overdetermined records \lstinline!A.R! and \lstinline!B.R! are algebraically coupled in the model, e.g., due to \lstinline!B.R = f(A.R!, \textless{}other unknowns\textgreater{}).
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -12,7 +12,7 @@ This makes the syntax of function definitions quite close to Modelica class defi
 \begin{nonnormative}
 The structure of a typical function declaration is sketched by
 the following schematic function example:
-\begin{lstlisting}[language=modelica]
+\begin{lstlisting}[language=modelica,escapechar=!]
 function $\mathit{functionname}$
   input  TypeI1 in1;
   input  TypeI2 in2;
@@ -22,10 +22,10 @@ function $\mathit{functionname}$
   output TypeO2 out2 = $\mathit{defaultExpr}_{2}$;
   $\ldots$
 protected
-  $\langle\mbox{\emph{local variables}}\rangle$
+  !\emph{\textless{}local variables\textgreater{}}!
   $\ldots$
 algorithm
-  $\langle\mbox{\emph{statements}}\rangle$
+  !\emph{\textless{}statements\textgreater{}}!
   $\ldots$
 end $\mathit{functionname}$;
 \end{lstlisting}

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -812,9 +812,9 @@ Note that it is not legal to compute the derivative of the \lstinline!sample!, \
 \section{Clocked When-Clause}\label{clocked-when-clause}
 
 In addition to the previously discussed conditional when-clause, a \emph{clocked} when-clause\index{clocked!when-clause}\index{when-clause!clocked} is introduced:
-\begin{lstlisting}[language=modelica]
+\begin{lstlisting}[language=modelica,escapechar=!]
 when $\mathit{clockExpression}$ then
-  $\langle\mbox{\emph{clocked equations}}\rangle$
+  !\emph{\textless{}clocked equations\textgreater{}}!
   $\ldots$
 end when;
 \end{lstlisting}


### PR DESCRIPTION
This reverts commit 219c56aa0b887e211dbdd8269cd32e877a33b82e.

Only some files are reverted.
Closes #2867