### PR TITLE
Revert "Add logo to README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="https://github.com/modelica/MA-Logos/raw/master/HighRes/Modelica_Language.svg?sanitize=true" width="250px">
-
 # ModelicaSpecification
 This repository contains the Modelica Language Specification, hosted at https://github.com/modelica/ModelicaSpecification. Development is organized within the [Modelica Association Project Language (MAP-LANG)](https://modelica.org/projects).
 


### PR DESCRIPTION
This reverts commit 7d04c273119887a284411f4dfafe553750108cfb.
(which added the Modelica logo).

Clearly the logo is a good idea, but the problem is that Python CI cannot handle it for specification.modelica.org
After that is corrected the previous commit should be re-applied.