### PR TITLE
Restore image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://github.com/modelica/MA-Logos/raw/master/HighRes/Modelica_Language.svg?sanitize=true" width="250px">
+
 # ModelicaSpecification
 This repository contains the Modelica Language Specification, hosted at https://github.com/modelica/ModelicaSpecification. Development is organized within the [Modelica Association Project Language (MAP-LANG)](https://modelica.org/projects).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/modelica/MA-Logos/raw/master/HighRes/Modelica_Language.svg?sanitize=true" width="250px">
+<img src="https://github.com/modelica/MA-Logos/raw/master/HighRes/Modelica_Language.svg?sanitize=true" width="250px"/>
 
 # ModelicaSpecification
 This repository contains the Modelica Language Specification, hosted at https://github.com/modelica/ModelicaSpecification. Development is organized within the [Modelica Association Project Language (MAP-LANG)](https://modelica.org/projects).


### PR DESCRIPTION
As far as I can see this re-introduces the image and still works with Python markdown module.
It works with the Python version I had installed locally (and the previous variant didn't), and it renders correctly on GitHub.

According to https://stackoverflow.com/questions/14860492/how-to-close-img-tag-properly it is also valid html.

So much text for such a small change.