### PR TITLE
Break down first items describing ExternalObject

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2488,35 +2488,29 @@ Within Modelica this memory is defined as instance of the predefined class \lsti
   Since the class is partial, it is not possible to define an instance of this class.
   \end{nonnormative}
 \item
-  An external object class shall be directly extended from
-  \lstinline!ExternalObject!, shall have exactly two function definitions, called
-  \lstinline!constructor! and \lstinline!destructor!, and shall not contain other elements.
+  An external object class shall be directly extended from \lstinline!ExternalObject!, shall have exactly two function definitions, called \lstinline!constructor! and \lstinline!destructor!, and shall not contain other elements.
   The functions \lstinline!constructor! and \lstinline!destructor! shall not be replaceable.
+  It is not legal to call the \lstinline!constructor! and \lstinline!destructor! functions explicitly.
 \item
-  The \lstinline!constructor! function is called exactly once before the first use
-  of the object. For each completely constructed object, the destructor
-  is called exactly once, after the last use of the object, even if an
-  error occurs. The \lstinline!constructor! shall have exactly one output argument
-  in which the constructed instance derived from \lstinline!ExternalObject! is
-  returned. The \lstinline!destructor! shall have no output arguments and the only
-  input argument of the destructor shall be of the type derived from
-  \lstinline!ExternalObject!. It is not legal to call explicitly the \lstinline!constructor! and
-  \lstinline!destructor! functions. The constructor shall initialize the object, and
-  must not require any other calls to be made for the initialization to
-  be complete (e.g., from an initial algorithm or initial equation).
+  The \lstinline!constructor! function is called exactly once before the first use of the object.
+  The \lstinline!constructor! shall have exactly one output argument in which the constructed instance derived from \lstinline!ExternalObject! is returned.
   The arguments to the constructor must not -- directly nor indirectly -- depend on the external object being constructed.
-  The destructor shall delete the object, and must not require any other
-  calls to be made for the deletion to be complete (e.g., from a \lstinline!when terminal()! clause). The constructor shall not assume that pointers sent
-  to the external object will remain valid for the life-time of the external object.  An exception is that if the pointer to another external object is
-  given as argument to the constructor, that pointer will remain valid as long as the other external object lives.
+  The constructor shall initialize the object, and must not require any other calls to be made for the initialization to be complete (e.g., from an initial algorithm or initial equation).
+
+  The constructor shall not assume that pointers sent to the external object will remain valid for the life-time of the external object.
+  An exception is that if the pointer to another external object is given as argument to the constructor, that pointer will remain valid as long as the other external object lives.
+\item
+  For each completely constructed object, the \lstinline!destructor! is called exactly once, after the last use of the object, even if an error occurs.
+  The \lstinline!destructor! shall have no output arguments and the only input argument of the destructor shall be of the type derived from \lstinline!ExternalObject!.
+  The destructor shall delete the object, and must not require any other calls to be made for the deletion to be complete (e.g., from a \lstinline!when terminal()! clause).
   \begin{nonnormative}
-  External objects may be a protected component (or part of one) in a function.  The constructor is in that case called at the start of the function call,
-  and the destructor when the function returns, or when recovering from errors in the function.
+  External objects may be a protected component (or part of one) in a function.
+  The constructor is in that case called at the start of the function call, and the destructor when the function returns, or when recovering from errors in the function.
   \end{nonnormative}
   \begin{nonnormative}
-  External objects may be an input (or part of an input) to a function, in that case the destructor is not called (since the external object is active before
-  and after the function call).  Normally this is an external function, but it could be a non-external function as well (e.g.\ calling external functions one
-  or more times).  The function input shall not have a default value using the constructor.
+  External objects may be an input (or part of an input) to a function, in that case the destructor is not called (since the external object is active before and after the function call).
+  Normally this is an external function, but it could be a non-external function as well (e.g.\ calling external functions one or more times).
+  The function input shall not have a default value using the constructor.
   \end{nonnormative}
 \item
   An external object class shall be of the specialized class \lstinline!class!.


### PR DESCRIPTION
This is a separate PR for the text cleanup suggested in #2862.

Having separate items for the constructor and destructor makes the item list easier to organize and digest.
