### PR TITLE
Add specification document style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of MCPs can be found here: [RationaleMCP](https://github.com/modelica/Mod
 CLA: Contributor's license agreement. (Details to follow.)
 
 How to edit and generate final documents
+* Read the [style guide](styleguide.md).
 * For online editing you can use www.overleaf.com (details to follow)
 * The pdf-documents are generated with pdflatex, which is part of most LaTeX installations, we used http://miktex.org/download
 * The HTML-documents are generated with LaTeXML. That is more complicated to install - and can optionally be skipped:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1091,13 +1091,10 @@ extent along one axis).  The center of the image is positioned at the center of 
 
 \subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
-Any value (coordinates, color, text, etc.) in graphical annotations can
-be dependent on class variables using the \lstinline!DynamicSelect! expression.
-\lstinline!DynamicSelect! has the syntax of a function call with two arguments,
-where the first argument specifies the value of the editing state and
-the second argument the value of the non-editing state. The first
-argument must be a literal expression. The second argument may contain
-references to variables to enable a dynamic behavior.
+Any value (coordinates, color, text, etc.) in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect!.
+\lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the editing state and the second argument the value of the non-editing state.
+The first argument must be a literal expression.
+The second argument may contain references to variables to enable a dynamic behavior.
 
 \begin{example}
 The level of a tank could be animated by a rectangle expanding in vertical direction and its color depending on a variable overflow:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -191,7 +191,7 @@ end Curve;
 
 The mandatory \lstinline!x! and \lstinline!y! expressions are restricted to be component references referring to a scalar variable or \lstinline!time!.
 It is an error if \lstinline!x! or \lstinline!y! does not designate a scalar variable.
-When the \lstinline!unit! of an \lstinline!Axis! is non-empty, it is an error if the unit of the corresponding \lstinline!Curve! expression (i.e., a variable's \lstinline!unit!, or second for \lstinline!time!) is incompatible with the axis unit.
+When the \lstinline!unit! of an \lstinline!Axis! is non-empty, it is an error if the unit of the corresponding \lstinline!x! or \lstinline!y! expression (i.e., a variable's \lstinline!unit!, or second for \lstinline!time!) is incompatible with the axis unit.
 
 When \lstinline!legend! isn't provided, the tool produces a default based on \lstinline!x! and/or \lstinline!y!.
 Providing the empty string as \lstinline!legend! means that the curve shall be omitted from the plot legend.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -577,11 +577,9 @@ An expression:
 function-name "(" expression1 for iterators ")"
 \end{lstlisting}%
 \index{for@\robustinline{for}!reduction expression}
-
-is a reduction-expression. The expressions in the iterators of a
-reduction-expression shall be vector expressions. They are evaluated
-once for each reduction-expression, and are evaluated in the scope
-immediately enclosing the reduction-expression.
+is a \firstuse{reduction expression}\index{reduction expression}.
+The expressions in the iterators of a reduction expression shall be vector expressions.
+They are evaluated once for each reduction expression, and are evaluated in the scope immediately enclosing the reduction expression.
 
 For an iterator:
 \begin{lstlisting}[language=grammar]

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -666,9 +666,7 @@ Real f2[3](unit={"Nm","Nm","Nm"});
 \end{lstlisting}
 \end{example}
 
-If a short class definition inherits from a partial class the new class
-definition will be partial, regardless of whether it is declared with
-the keyword partial or not.
+If a short class definition inherits from a partial class the new class definition will be partial, regardless of whether it is declared with the prefix \lstinline!partial! or not.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -468,7 +468,7 @@ The following rules apply to modifiers:
 \item
   The \lstinline!each!\indexinline{each} keyword on a modifier requires that it is applied in an array declaration/modification, and the modifier is applied individually to each element of the enclosing array (with regard to the position of \lstinline!each!).
   In case of nested modifiers this implies it is applied individually to each element of each element of the enclosing array; see example.
-  If the modified element is a vector and the modifier does not contain the \lstinline!each!-prefix, the modification is split such that the first element in the vector is applied to the first element of the vector of elements, the second to the second element, until the last element of the vector-expression is applied to the last element of the array; it is an error if these sizes do not match.
+  If the modified element is a vector and the modifier does not contain the \lstinline!each! prefix, the modification is split such that the first element in the vector is applied to the first element of the vector of elements, the second to the second element, until the last element of the vector-expression is applied to the last element of the array; it is an error if these sizes do not match.
   Matrices and general arrays of elements are treated by viewing those as vectors of vectors etc.
 \item
   If a nested modifier is split, the split is propagated to all elements of the nested modifier, and if they are modified by the \lstinline!each! keyword the split is inhibited for those elements.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -472,7 +472,7 @@ The following rules apply to modifiers:
   Matrices and general arrays of elements are treated by viewing those as vectors of vectors etc.
 \item
   If a nested modifier is split, the split is propagated to all elements of the nested modifier, and if they are modified by the \lstinline!each! keyword the split is inhibited for those elements.
-  If the nested modifier that is split in this way contains re-declarations that are split it is illegal.
+  If the nested modifier that is split in this way contains re-declarations that are split, it is illegal.
 \end{itemize}
 
 \begin{example}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -471,11 +471,8 @@ The following rules apply to modifiers:
   If the modified element is a vector and the modifier does not contain the \lstinline!each!-prefix, the modification is split such that the first element in the vector is applied to the first element of the vector of elements, the second to the second element, until the last element of the vector-expression is applied to the last element of the array; it is an error if these sizes do not match.
   Matrices and general arrays of elements are treated by viewing those as vectors of vectors etc.
 \item
-  If a nested modifier is split, the split is propagated to all elements
-  of the nested modifier, and if they are modified by the \lstinline!each!-keyword
-  the split is inhibited for those elements. If the nested modifier that
-  is split in this way contains re-declarations that are split it is
-  illegal.
+  If a nested modifier is split, the split is propagated to all elements of the nested modifier, and if they are modified by the \lstinline!each! keyword the split is inhibited for those elements.
+  If the nested modifier that is split in this way contains re-declarations that are split it is illegal.
 \end{itemize}
 
 \begin{example}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -216,8 +216,8 @@ Tools may also store classes in data-base systems, but that is not standardized.
 
 \subsection{Mapping a Package/Class Hierarchy into a Directory Hierarchy (Structured Entity)}\label{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}
 
-A directory shall contain a node, the file \filename{package.mo}. The node shall contain a stored-definition that defines a class \lstinline!A! with a name
-matching the name of the structured entity.
+A directory shall contain a node, the file \filename{package.mo}.
+The node shall contain a \lstinline[language=grammar]!stored-definition! that defines a class \lstinline!A! with a name matching the name of the structured entity.
 
 \begin{nonnormative}
 The node typically contains documentation and graphical information for a package, but may also contain additional elements of the class \lstinline!A!.

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -394,8 +394,6 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2273}{\#22
 \item Clarified illegal modification of outer element, \cref{instance-hierarchy-name-lookup-of-inner-declarations}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/2283}{\#2283}.
 
-
-
 \if0
 \item xxx, \cref{xxx}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/}{\#}.
@@ -403,6 +401,7 @@ Ticket \href{https://github.com/modelica/ModelicaSpecification/issues/}{\#}.
 Ticket \href{https://github.com/modelica/ModelicaSpecification/pull/}{\#}.
 \fi
 \end{itemize}
+
 \section{Modelica 3.4}\label{modelica-3-4}
 Modelica 3.4 was released April 10, 2017. The Modelica 3.4 specification
 was edited by Hans Olsson.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -224,7 +224,10 @@ equation
 
 \subsubsection{Implicit Iteration Ranges}\label{implicit-iteration-ranges}
 
-An iterator \lstinline!IDENT in range-expr! without the \lstinline!in range-expr! requires that the \lstinline!IDENT! appears as the subscript of one or several subscripted expressions, where the expressions are not part of an array in a component of an expandable connector.  The dimension size of the array expression in the indexed position is used to deduce the \lstinline!range-expr! as \lstinline!1:size(array-expression,indexpos)! if the indices are a subtype of \lstinline!Integer!, or as \lstinline!E.e1:E.en! if the indices are of an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!, or as \lstinline!false:true! if the indices are of type \lstinline!Boolean!.  If it is used to subscript several expressions, their ranges must be identical.  The \lstinline!IDENT! may also, inside a reduction-expression, array constructor expression, for-statement, or for-equation, occur freely outside of subscript positions, but only as a reference to the variable \lstinline!IDENT!, and not for deducing ranges.
+An iterator \lstinline!IDENT in range-expr! without the \lstinline!in range-expr! requires that the \lstinline!IDENT! appears as the subscript of one or several subscripted expressions, where the expressions are not part of an array in a component of an expandable connector.
+The dimension size of the array expression in the indexed position is used to deduce the \lstinline!range-expr! as \lstinline!1:size(array-expression,indexpos)! if the indices are a subtype of \lstinline!Integer!, or as \lstinline!E.e1:E.en! if the indices are of an enumeration type \lstinline!E = enumeration(e1, $\ldots$, en)!, or as \lstinline!false:true! if the indices are of type \lstinline!Boolean!.
+If it is used to subscript several expressions, their ranges must be identical.
+The \lstinline!IDENT! may also, inside a reduction expression, array constructor expression, for-statement, or for-equation, occur freely outside of subscript positions, but only as a reference to the variable \lstinline!IDENT!, and not for deducing ranges.
 
 The \lstinline!IDENT! may also be used as a subscript for an array in a component of an expandable connector
 but it is only seen as a reference to the variable \lstinline!IDENT! and cannot be used for deducing ranges.
@@ -276,13 +279,9 @@ equation
 
 \subsubsection{Nested For-Loops and Reduction Expressions with Multiple Iterators}\label{nested-for-loops-and-reduction-expressions-with-multiple-iterators}
 
-The notation with several iterators is a shorthand notation for nested
-for-statements or for-equations (or reduction-expressions). For
-for-statements or for-equations it can be expanded into the usual form
-by replacing each `\lstinline!,!' by ``\lstinline!loop for!'' and adding extra ``\lstinline!end for!''. For
-reduction-expressions it can be expanded into the usual form by
-replacing each `\lstinline!,!' by ``\lstinline!) for!'' and prepending the reduction-expression
-with ``\lstinline!functionName(!''.
+The notation with several iterators is a shorthand notation for nested for-statements or for-equations (or reduction expressions).
+For for-statements or for-equations it can be expanded into the usual form by replacing each `\lstinline!,!' by ``\lstinline!loop for!'' and adding extra ``\lstinline!end for!''.
+For reduction expressions it can be expanded into the usual form by replacing each `\lstinline!,!' by ``\lstinline!) for!'' and prepending the reduction expression with ``\lstinline!functionName(!''.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/preamble.tex
+++ b/preamble.tex
@@ -223,8 +223,6 @@
 % Formatting of table headings.
 \newcommand{\tablehead}[1]{\textit{#1}}
 
-\newcommand{\glossaryitem}[1]{\textbf{#1}}
-
 % Environment for definitions.
 \usepackage{amsthm}
 \newtheoremstyle{mlsdefinition}

--- a/styleguide.md
+++ b/styleguide.md
@@ -15,9 +15,29 @@ The MSL-specific LaTeX macros and environments described in this style guide are
 
 ## Source code formatting
 
+### Trailing spaces and empty lines
+
+There shall be no trailing spaces, and each line (in particular, the last one in the file) shall be terminated by a newline.
+There shall be no empty lines at the beginning or end of a file, and there shall never be more than two empty lines in a row.
+Use one or two empty lines before sectioning commands such as `\section` or `\subsubsection`, except at the start of a file.
+An empty line is recommended also after the non-paragraph sectioning commands.
+
+Be careful about adding empty lines, as they actually are significant in places such as before list environments (`itemize`, etc).
+For example, if the text before a list acts as an introduction, it should be kept tight with the list:
+```
+The following holds for slice operations:
+\begin{itemize}
+\item
+    …
+```
+
+### Hard line breaks within paragraphs
+
 The document is in ongoing transition to _one sentence per line_ source code formatting.
 This means that any modified or new text should have each sentence alone on a single physical line in the source file.
 Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp.
+
+### Indentation
 
 When indenting the contents of a LaTeX environment, an indentation of 2 spaces is used.
 It is recommended to not add indentation before `\item`:

--- a/styleguide.md
+++ b/styleguide.md
@@ -19,7 +19,7 @@ The document is in ongoing transition to _one sentence per line_ source code for
 This means that any modified or new text should have each sentence alone on a single physical line in the source file.
 Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp.
 
-When indenting the contents of a LaTeX environment, an indentation of 2 spaces used.
+When indenting the contents of a LaTeX environment, an indentation of 2 spaces is used.
 It is recommended to not add indentation before `\item`:
 ```
 \begin{itemize}

--- a/styleguide.md
+++ b/styleguide.md
@@ -210,3 +210,13 @@ When a grammar rule is mentioned in the text, the rule shall be formatted with t
 ```
 The node shall contain a \lstinline[language=grammar]!stored-definition! that…
 ```
+
+## English natural language text
+
+This section gives guidelines for how the natural language text in English should be written.
+
+The text is written in American English.
+
+### Contractions
+
+Avoid contractions such as _isn't_ or _won't_; write _is not_ or _will/would not_ instead.

--- a/styleguide.md
+++ b/styleguide.md
@@ -24,7 +24,7 @@ An empty line is recommended also after the non-paragraph sectioning commands.
 
 Be careful about adding empty lines, as they actually are significant in places such as before list environments (`itemize`, etc).
 For example, if the text before a list acts as an introduction, it should be kept tight with the list:
-```
+```tex
 The following holds for slice operations:
 \begin{itemize}
 \item
@@ -41,7 +41,7 @@ Once we have the physical line breaks in the correct places, the diffs of future
 
 When indenting the contents of a LaTeX environment, an indentation of 2 spaces is used.
 It is recommended to not add indentation before `\item`:
-```
+```tex
 \begin{itemize}
 \item
   First are all inputs to the original function, and after all them we will in order append one derivative for each input containing reals.
@@ -53,7 +53,7 @@ It is recommended to not add indentation before `\item`:
 ```
 
 Many environments are used without indenting the contents, including `nonnormative` and `example`:
-```
+```tex
 \begin{nonnormative}
 This means that the most restrictive derivatives should be written first.
 \end{nonnormative}
@@ -167,7 +167,7 @@ For purposes of marking emphasis, see use of `\emph` instead.
 ### Ordinals
 
 Ordinals are written with _th_ in normal font, possibly combined with a math styled expression for the number:
-```
+```tex
 Fixed ordinals: 1st, 2nd, 3rd.
 Symbolic ordinals: $n$th, $(n+1)$th.
 ```
@@ -193,7 +193,7 @@ Use hard line breaks and manual indentation of continued lines to meet this requ
 ### Grammar (extended BNF) listings
 
 Grammar listings use the `language=grammar`, and are written with indentation in steps of 3 spaces:
-```
+```tex
 \begin{lstlisting}[language=grammar]
 stored-definition :
    [ within [ name ] ";" ]
@@ -202,6 +202,6 @@ stored-definition :
 ```
 
 When a grammar rule is mentioned in the text, the rule shall be formatted with the _grammar_ language:
-```
+```tex
 The node shall contain a \lstinline[language=grammar]!stored-definition! that…
 ```

--- a/styleguide.md
+++ b/styleguide.md
@@ -15,7 +15,8 @@ The document is in ongoing transition to _one sentence per line_ source code for
 This means that any modified or new text should have each sentence alone on a single physical line in the source file.
 Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp.
 
-When indenting the contents of a LaTeX environment, an indentation of 2 spaces used.  It is recommended to not add indentation before `\item`:
+When indenting the contents of a LaTeX environment, an indentation of 2 spaces used.
+It is recommended to not add indentation before `\item`:
 ```
 \begin{itemize}
 \item
@@ -34,19 +35,92 @@ This means that the most restrictive derivatives should be written first.
 \end{nonnormative}
 ```
 
-## Special terminology
+## Formatting of language terminology
 
-**TODO**: Sort out the following situation, reported in https://github.com/modelica/ModelicaSpecification/issues/2713:
+### Things with name/keyword in the language
 
-Space | Hyphen | Inline code | Both
---- | --- | --- | ---
-connect equation (9) | connect-equation (32) | `connect` equation (5) | `connect`-equation (2)
-when clause (5) | when-clause (86) | `when` clause (0) | `when`-clause (11)
-if equation (0) | if-equation (8) | `if` equation (0) | `if`-equation (0)
-start value (24) | start-value (15) | `start` value (5) | `start`-value (2)
+As a general rule, when a concept is directly related to a construct in the Modelica language with a certain name/keyword, then the language concept is referred to using a hyphenated combination of the language name/keyword in code style, with a qualifying natural language word written as normal text.
+Examples:
 
+Appearance | LaTeX source
+--- | ---
+`connect`-equation | `\lstinline!connect!-equation`
+`if`-equation | `\lstinline!if!-equation`
+`if`-expression | `\lstinline!if!-expression`
+`when`-clause | `\lstinline!when!-clause`
+`start`-attribute | `\lstinline!start!-attribute`
+
+Note that there's often an associated rule in the Modelica grammar, which should only be used in the text on the rare occasions when it is the actual grammar rule – not the entire language concept – that is being referenced:
+
+Appearance | LaTeX source
+--- | ---
+`if-equation` | `\lstinline[language=grammar]!if-equation!`
+
+Note: The hyphenation may sometimes appear grammatically incorrect, but the consistent use of hyphenation helps readability, and in some contexts the hyphen gives extra safety against reading the language name/keyword as part of the sentence structure.
+For example, compare:
+- If equations are possible to simplify if their condition can be evaluated during translation.
+- `if`-equations are possible to simplify if their condition can be evaluated during translation.
+
+### The keywords themselves
+
+When referencing a keyword itself, hyphenation is not used, and when possible, a better describing word than _keyword_ is used:
+
+Appearance | LaTeX source | Comment
+--- | --- | ---
+the `input` prefix | `\lstinline!prefix! prefix` | For more prefixes, see `class-prefixes`, `base-prefix`, and `type-prefix` in the grammar.
+the `final` modifier | `the \lstinline!final! modifier` |
+the `each` keyword | `the \lstinline!each! keyword` |
+
+Depending on context, one can also swap the order, or drop the describing word completely:
+
+Appearance | LaTeX source
+--- | ---
+the keyword `each` | `the keyword \lstinline!each!`
+declared as `final` | `declared as \lstinline!final!`
+
+### Named functions and operators
+
+When referencing a named function of operator, hyphenation is not used, and it is common to not combine with any describing word:
+
+Appearance | LaTeX source
+--- | ---
+the `smooth` operator | `the \lstinline!smooth! operator`
+where `pre` is not explicitly used | `where \lstinline!pre! is not explicitly used`
+
+### Other things, special cases
+
+Incomplete list of various terminology with special formatting rules:
+
+Appearance | LaTeX source | Comment
+--- | --- | ---
+start value | `start value` | Value of the `start`-attribute (there could be exceptions!)
+base class | `base class` | Similarly: derived class
+base-clock | `base-clock` | Similarly: sub-cock
+
+## Definitions
+
+New terminology is either introduced with a `definition` environment, or as part of the running text.
+When part of the running text, the introduced terminology should be marked with `\firstuse` at the point of the definition.
+(The use of `\firstuse` helps us both produce consistent formatting and keep track of things that should appear in the document index.)
+
+If the new terminology is used before being introduced, the first use should be marked with `\willintroduce` to alert the reader that this is not a term that is expected to be known yet by a first-time reader.
 
 ## Miscellaneous
+
+### Use of `\emph` and italics
+
+To put emphasis on a word or small piece of text, use `\emph`.
+
+Italics is used when new terminology is introduced in the running text instead of the bulkier `definition` environment, see `\firstuse` and `\willintroduce`.
+
+Non-semantical font switching commands for producing italics (`\textit`, `\textsl`, `\itshape`) should pretty much never be used.
+
+Note that the document is full of text set in italics, since this is used for both non-normative text and examples, through the `nonnormative` and `example` environments.
+
+### Use of boldface
+
+Non-semantical font switching commands for producing boldface (`\textbf`, `\bfseries`) may only be used for styling as part of higher level semantic constructs such as the _amsthm.sty_ `\newtheoremstyle` definitions.
+For purposes of marking emphasis, see use of `\emph` instead.
 
 ### Ordinals
 
@@ -55,16 +129,6 @@ Ordinals are written with _th_ in normal font, possibly combined with a math sty
 Fixed ordinals: 1st, 2nd, 3rd.
 Symbolic ordinals: $n$th, $(n+1)$th.
 ```
-
-### Use of `\emph` and italics
-
-**TODO**
-
-
-### Use of boldface
-
-**TODO**
-
 
 ## Code listings
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -6,7 +6,7 @@ This is the style guide for the Modelica Specification document.
 ## Document format and tool chain
 
 The source format of the document is LaTeX, and the source is processed by both pdfLaTeX and LaTeXML.
-It is good to be aware of the LaTeXML implications, but for most contributors and contributions is is considered sufficient to only check that the pdfLaTeX output looks good, the idea being that potential problems should be spotted in the pull request review process.
+It is good to be aware of the LaTeXML implications, but for most contributors and contributions it is considered sufficient to only check that the pdfLaTeX output looks good, the idea being that potential problems should be spotted in the pull request review process.
 
 The MSL-specific LaTeX macros and environments described in this style guide are defined in either of these two files:
 - [preamble.tex](preamble.tex) – Preamble contents for the main document.

--- a/styleguide.md
+++ b/styleguide.md
@@ -188,7 +188,8 @@ equation
 ```
 
 Each line should fit within the width of the page.
-Use hard line breaks and manual indentation of continued lines to meet this requirement.
+Use hard line breaks and manual additional indentation of continued lines to meet this requirement.
+A semicolon in a matrix should either be followed by a line break or by a space.
 
 ### Grammar (extended BNF) listings
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -94,6 +94,7 @@ Incomplete list of various terminology with special formatting rules:
 Appearance | LaTeX source | Comment
 --- | --- | ---
 start value | `start value` | Value of the `start`-attribute (there could be exceptions!)
+reduction expression | `reduction expression` |
 base class | `base class` | Similarly: derived class
 base-clock | `base-clock` | Similarly: sub-cock
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -24,7 +24,7 @@ An empty line is recommended also after the non-paragraph sectioning commands.
 
 Be careful about adding empty lines, as they actually are significant in places such as before list environments (`itemize`, etc).
 For example, if the text before a list acts as an introduction, it should be kept tight with the list:
-```tex
+```
 The following holds for slice operations:
 \begin{itemize}
 \item
@@ -41,7 +41,7 @@ Once we have the physical line breaks in the correct places, the diffs of future
 
 When indenting the contents of a LaTeX environment, an indentation of 2 spaces is used.
 It is recommended to not add indentation before `\item`:
-```tex
+```
 \begin{itemize}
 \item
   First are all inputs to the original function, and after all them we will in order append one derivative for each input containing reals.
@@ -53,7 +53,7 @@ It is recommended to not add indentation before `\item`:
 ```
 
 Many environments are used without indenting the contents, including `nonnormative` and `example`:
-```tex
+```
 \begin{nonnormative}
 This means that the most restrictive derivatives should be written first.
 \end{nonnormative}
@@ -167,7 +167,7 @@ For purposes of marking emphasis, see use of `\emph` instead.
 ### Ordinals
 
 Ordinals are written with _th_ in normal font, possibly combined with a math styled expression for the number:
-```tex
+```
 Fixed ordinals: 1st, 2nd, 3rd.
 Symbolic ordinals: $n$th, $(n+1)$th.
 ```
@@ -193,7 +193,7 @@ Use hard line breaks and manual indentation of continued lines to meet this requ
 ### Grammar (extended BNF) listings
 
 Grammar listings use the `language=grammar`, and are written with indentation in steps of 3 spaces:
-```tex
+```
 \begin{lstlisting}[language=grammar]
 stored-definition :
    [ within [ name ] ";" ]
@@ -202,6 +202,6 @@ stored-definition :
 ```
 
 When a grammar rule is mentioned in the text, the rule shall be formatted with the _grammar_ language:
-```tex
+```
 The node shall contain a \lstinline[language=grammar]!stored-definition! that…
 ```

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,0 +1,100 @@
+# Modelica Specification style guide
+
+This is the style guide for the Modelica Specification document.
+
+
+## Document format and tool chain
+
+The source format of the document is LaTeX, and the source is processed by both pdfLaTeX and LaTeXML.
+It is good to be aware of the LaTeXML implications, but for most contributors and contributions is is considered sufficient to only check that the pdfLaTeX output looks good, the idea being that potential problems should be spotted in the pull request review process.
+
+
+## Source code formatting
+
+The document is in ongoing transition to _one sentence per line_ source code formatting.
+This means that any modified or new text should have each sentence alone on a single physical line in the source file.
+Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp.
+
+When indenting the contents of a LaTeX environment, an indentation of 2 spaces used.  It is recommended to not add indentation before `\item`:
+```
+\begin{itemize}
+\item
+  First are all inputs to the original function, and after all them we will in order append one derivative for each input containing reals.
+  These common inputs must have the same name, type, and declaration order for the function and its derivative.
+\item
+  The outputs are constructed by starting with an empty list and then in order appending one derivative for each output containing reals.
+  The outputs must have the same type and declaration order for the function and its derivative.
+\end{itemize}
+```
+
+Many environments are used without indenting the contents, including `nonnormative` and `example`:
+```
+\begin{nonnormative}
+This means that the most restrictive derivatives should be written first.
+\end{nonnormative}
+```
+
+## Special terminology
+
+**TODO**: Sort out the following situation, reported in https://github.com/modelica/ModelicaSpecification/issues/2713:
+
+Space | Hyphen | Inline code | Both
+--- | --- | --- | ---
+connect equation (9) | connect-equation (32) | `connect` equation (5) | `connect`-equation (2)
+when clause (5) | when-clause (86) | `when` clause (0) | `when`-clause (11)
+if equation (0) | if-equation (8) | `if` equation (0) | `if`-equation (0)
+start value (24) | start-value (15) | `start` value (5) | `start`-value (2)
+
+
+## Miscellaneous
+
+### Ordinals
+
+Ordinals are written with _th_ in normal font, possibly combined with a math styled expression for the number:
+```
+Fixed ordinals: 1st, 2nd, 3rd.
+Symbolic ordinals: $n$th, $(n+1)$th.
+```
+
+### Use of `\emph` and italics
+
+**TODO**
+
+
+### Use of boldface
+
+**TODO**
+
+
+## Code listings
+
+### Modelica listings
+
+Modelica listings are written with indentation in steps of 2 spaces.
+
+A space is typically added on each side of a binary operator, and after comma.
+
+Code snippets may start with an indented line as long as there's some line in the listing with zero indentation, like this:
+```
+  Real x(start = 1.0, fixed = true);
+equation
+  der(x) = -x;
+```
+
+Each line should fit within the width of the page, using hard line breaks and manual indentation of continued lines to meet this requirement.
+
+### Grammar (extended BNF) listings
+
+Grammar listings use the `language=grammar`, and are written with indentation in steps of 3 spaces:
+```
+\begin{lstlisting}[language=grammar]
+stored-definition :
+   [ within [ name ] ";" ]
+   { [ final ] class-definition ";" }
+\end{lstlisting}
+```
+
+When a grammar rule is mentioned in the text, the rule shall be formatted with the _grammar_ language:
+```
+The node shall contain a \lstinline[language=grammar]!stored-definition! that…
+```

--- a/styleguide.md
+++ b/styleguide.md
@@ -78,7 +78,7 @@ Note that there's often an associated rule in the Modelica grammar, which should
 
 Appearance | LaTeX source
 --- | ---
-`if-equation` | `\lstinline[language=grammar]!if-equation!`
+`if-equation` | `\lstinline[language=grammar]!if-equation!`{:.language-tex}
 
 Note: The hyphenation may sometimes appear grammatically incorrect, but the consistent use of hyphenation helps readability, and in some contexts the hyphen gives extra safety against reading the language name/keyword as part of the sentence structure.
 For example, compare:

--- a/styleguide.md
+++ b/styleguide.md
@@ -8,6 +8,10 @@ This is the style guide for the Modelica Specification document.
 The source format of the document is LaTeX, and the source is processed by both pdfLaTeX and LaTeXML.
 It is good to be aware of the LaTeXML implications, but for most contributors and contributions is is considered sufficient to only check that the pdfLaTeX output looks good, the idea being that potential problems should be spotted in the pull request review process.
 
+The MSL-specific LaTeX macros and environments described in this style guide are defined in either of these two files:
+- [preamble.tex](preamble.tex) – Preamble contents for the main document.
+- [mlsshared.sty](mlsshared.sty) – Extracted parts of the styling to be shared with other documents that should follow the same style, such as many of the figures.
+
 
 ## Source code formatting
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -35,6 +35,10 @@ The following holds for slice operations:
 
 The document is in ongoing transition to _one sentence per line_ source code formatting.
 This means that any modified or new text should have each sentence alone on a single physical line in the source file.
+
+When a sentence doesn't fit in one screen line, one may take that as a reminder that long sentences can reduce readability of the specification document, and consider breaking the long sentence into shorter ones.
+Just keep in mind that the purpose of doing this shall be to improve readability of the specification text, not improve readability of the _one sentence per line_ formatted source code.
+
 Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp, and merge conflicts much more easily resolved.
 
 ### Indentation

--- a/styleguide.md
+++ b/styleguide.md
@@ -96,7 +96,6 @@ Different constructs with _expression_ and _call_:
 Appearance | LaTeX source | Comment
 --- | --- | ---
 `if`-expression | `\lstinline!if!-expression` | Generic language concept
-`Curve`-expression | `\lstinline!Curve!-expression` | Currently with space in the document!
 `Real` expression | `\lstinline!Real! expression` | An expression of type `Real`
 `y` expression | `\lstinline!y! expression` | Expression for something named `y`
 `convertElement` call | `\lstinline!convertElement! call` | A call expression with callee `convertElement`

--- a/styleguide.md
+++ b/styleguide.md
@@ -61,6 +61,21 @@ For example, compare:
 - If equations are possible to simplify if their condition can be evaluated during translation.
 - `if`-equations are possible to simplify if their condition can be evaluated during translation.
 
+### Expressions
+
+Different constructs with _expression_ and _call_:
+
+Appearance | LaTeX source | Comment
+--- | --- | ---
+`if`-expression | `\lstinline!if!-expression` | Generic language concept
+`DynamicSelect`-expression | `\lstinline!DynamicSelect!-expression` | Currently with space in the document!
+`Curve`-expression | `\lstinline!Curve!-expression` | Currently with space in the document!
+`Real` expression | `\lstinline!Real! expression` | An expression of type `Real`
+`y` expression | `\lstinline!y! expression` | Expression for something named `y`
+`convertElement` call | `\lstinline!convertElement! call` | A call expression with callee `convertElement`
+
+Note: There is no need for hyphenation of "`convertElement` call" since we don't say "`Real` call" for a call expression of type `Real` (we have "`Real` expression" for this purpose).
+
 ### The keywords themselves
 
 When referencing a keyword itself, hyphenation is not used, and when possible, a better describing word than _keyword_ is used:

--- a/styleguide.md
+++ b/styleguide.md
@@ -167,7 +167,8 @@ equation
   der(x) = -x;
 ```
 
-Each line should fit within the width of the page, using hard line breaks and manual indentation of continued lines to meet this requirement.
+Each line should fit within the width of the page.
+Use hard line breaks and manual indentation of continued lines to meet this requirement.
 
 ### Grammar (extended BNF) listings
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -117,7 +117,9 @@ base-clock | `base-clock` | Similarly: sub-cock
 
 New terminology is either introduced with a `definition` environment, or as part of the running text.
 When part of the running text, the introduced terminology should be marked with `\firstuse` at the point of the definition.
-(The use of `\firstuse` helps us both produce consistent formatting and keep track of things that should appear in the document index.)
+As a general rule, `\firstuse` should appear in combination with `\index` for adding the term to the document index.
+(The use of `\firstuse` instead of just `\emph` helps us both produce consistent formatting and makes it easier to spot cases where the additional use of `\index` has been forgotten.
+The reason that `\firstuse` doesn't also do the job calling `\index` is that the form of the term presented to `\firstuse` isn't always in the base form expected in the document index, that there can be a need for special styling tricks in the `\index` argument, etc.)
 
 If the new terminology is used before being introduced, the first use should be marked with `\willintroduce` to alert the reader that this is not a term that is expected to be known yet by a first-time reader.
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -96,11 +96,14 @@ Different constructs with _expression_ and _call_:
 Appearance | LaTeX source | Comment
 --- | --- | ---
 `if`-expression | `\lstinline!if!-expression` | Generic language concept
-`DynamicSelect`-expression | `\lstinline!DynamicSelect!-expression` | Currently with space in the document!
 `Curve`-expression | `\lstinline!Curve!-expression` | Currently with space in the document!
 `Real` expression | `\lstinline!Real! expression` | An expression of type `Real`
 `y` expression | `\lstinline!y! expression` | Expression for something named `y`
 `convertElement` call | `\lstinline!convertElement! call` | A call expression with callee `convertElement`
+
+In particular, avoid other constructs with _expression_ than the variants above.
+For other needs, try to find a formulation not based on _expression_ to avoid misinterpretations according to the variants above.
+For example, instead of saying "… can be dependent on class variables using the `DynamicSelect` expression", just say "… can be dependent on class variables using `DynamicSelect`".
 
 Note: There is no need for hyphenation of "`convertElement` call" since we don't say "`Real` call" for a call expression of type `Real` (we have "`Real` expression" for this purpose).
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -155,7 +155,7 @@ To put emphasis on a word or small piece of text, use `\emph`.
 
 Italics is used when new terminology is introduced in the running text instead of the bulkier `definition` environment, see `\firstuse` and `\willintroduce`.
 
-Non-semantical font switching commands for producing italics (`\textit`, `\textsl`, `\itshape`) should pretty much never be used.
+Refrain from using non-semantical font switching commands for producing italics (`\textit`, `\textsl`, `\itshape`).
 
 Note that the document is full of text set in italics, since this is used for both non-normative text and examples, through the `nonnormative` and `example` environments.
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -78,7 +78,7 @@ Note that there's often an associated rule in the Modelica grammar, which should
 
 Appearance | LaTeX source
 --- | ---
-`if-equation` | `\lstinline[language=grammar]!if-equation!`{:.language-tex}
+`if-equation` | `\lstinline[language=grammar]!if-equation!`
 
 Note: The hyphenation may sometimes appear grammatically incorrect, but the consistent use of hyphenation helps readability, and in some contexts the hyphen gives extra safety against reading the language name/keyword as part of the sentence structure.
 For example, compare:

--- a/styleguide.md
+++ b/styleguide.md
@@ -125,7 +125,7 @@ As a general rule, `\firstuse` should appear in combination with `\index` for ad
 (The use of `\firstuse` instead of just `\emph` helps us both produce consistent formatting and makes it easier to spot cases where the additional use of `\index` has been forgotten.
 The reason that `\firstuse` doesn't also do the job calling `\index` is that the form of the term presented to `\firstuse` isn't always in the base form expected in the document index, that there can be a need for special styling tricks in the `\index` argument, etc.)
 
-If the new terminology is used before being introduced, the first use should be marked with `\willintroduce` to alert the reader that this is not a term that is expected to be known yet by a first-time reader.
+If the new terminology is used before being introduced, it should be marked with `\willintroduce` (instead of `\firstuse`) to alert the reader that this is not a term that is expected to be known yet by a first-time reader.
 
 ## Miscellaneous
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -35,7 +35,7 @@ The following holds for slice operations:
 
 The document is in ongoing transition to _one sentence per line_ source code formatting.
 This means that any modified or new text should have each sentence alone on a single physical line in the source file.
-Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp.
+Once we have the physical line breaks in the correct places, the diffs of future changes will become clean and easy to grasp, and merge conflicts much more easily resolved.
 
 ### Indentation
 

--- a/styleguide.md
+++ b/styleguide.md
@@ -153,7 +153,7 @@ If the new terminology is used before being introduced, it should be marked with
 
 To put emphasis on a word or small piece of text, use `\emph`.
 
-Italics is used when new terminology is introduced in the running text instead of the bulkier `definition` environment, see `\firstuse` and `\willintroduce`.
+Italics is used via the semantic macros `\firstuse` and `\willintroduce` when new terminology is introduced in the running text instead of the bulkier `definition` environment.
 
 Refrain from using non-semantical font switching commands for producing italics (`\textit`, `\textsl`, `\itshape`).
 


### PR DESCRIPTION
Preparing a style guide for the specification document, according to [phone meeting decision](https://github.com/modelica/ModelicaSpecification/issues/2713#issuecomment-780635709).

This is a prerequisite for fixing #2713: once we have a style guide to follow, we'll have to set up another PR for actually applying the style guide to fix #2713.

Setting up PR in _Draft_ state, so that others can give early feedback.  Please note that I still haven't even started on the part directly related to #2713.
