### PR TITLE
Clarify that Figure.caption and identifiers have an empty default;

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -106,14 +106,12 @@ title should be shown. The plot title is not to be confused with the plot
 described in \cref{variable-replacements}, can be used in the
 \lstinline!title! of \lstinline!Figure! and \lstinline!Plot!.
 
-The \lstinline!identifier! in \lstinline!Figure! and \lstinline!Plot! is an optional \lstinline!String! identifier, and is intended to identify the
-\lstinline!Figure! and \lstinline!Plot! for programmatic access.  The \lstinline!figures! annotation is inherited in the sense that each class has
-a collection of figures comprised by the contents of the \lstinline!figures! annotation in the class itself, as well as the \lstinline!figures! annotations
-from any base classes. A \lstinline!Figure! must be uniquely identified by its \lstinline!identifier! and a class having it in its collection.  This
-means that a \lstinline!Figure! \lstinline!identifier! must be unique among all \lstinline!Figure! annotations within the same \lstinline!figures!
-annotation as well as among all \lstinline!figures! annotations from inherited classes.  A \lstinline!Plot! \lstinline!identifier! on the other hand
-is only required to be unique among the \lstinline!plots! in the the same \lstinline!Figure! annotation.
-If the identifier is an empty string it cannot be used for programmatic access and is exempt from the uniqueness requirement.
+The \lstinline!identifier! in \lstinline!Figure! and \lstinline!Plot! is a \lstinline!String! identifier, and is intended to identify the \lstinline!Figure! and \lstinline!Plot! for programmatic access.
+The \lstinline!figures! annotation is inherited in the sense that each class has a collection of figures comprised by the contents of the \lstinline!figures! annotation in the class itself, as well as the \lstinline!figures! annotations from any base classes.
+A \lstinline!Figure! must be uniquely identified by its \lstinline!identifier! and a class having it in its collection.
+This means that a \lstinline!Figure! \lstinline!identifier! must be unique among all \lstinline!Figure! annotations within the same \lstinline!figures! annotation as well as among all \lstinline!figures! annotations from inherited classes.
+A \lstinline!Plot! \lstinline!identifier! on the other hand is only required to be unique among the \lstinline!plots! in the the same \lstinline!Figure! annotation.
+If the identifier is an empty string it cannot be used for programmatic access and is exempt from the uniqueness requirements.
 
 \begin{nonnormative}
 For \lstinline!Figure!, this makes it possible to reference the plot from a

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -111,7 +111,7 @@ The \lstinline!figures! annotation is inherited in the sense that each class has
 A \lstinline!Figure! must be uniquely identified by its \lstinline!identifier! and a class having it in its collection.
 This means that a \lstinline!Figure! \lstinline!identifier! must be unique among all \lstinline!Figure! annotations within the same \lstinline!figures! annotation as well as among all \lstinline!figures! annotations from inherited classes.
 A \lstinline!Plot! \lstinline!identifier! on the other hand is only required to be unique among the \lstinline!plots! in the the same \lstinline!Figure! annotation.
-If the identifier is an empty string it cannot be used for programmatic access and is exempt from the uniqueness requirements.
+If an \lstinline!identifier! is an empty string it cannot be used for programmatic access and is exempt from the uniqueness requirements.
 
 \begin{nonnormative}
 For \lstinline!Figure!, this makes it possible to reference the plot from a

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -75,11 +75,11 @@ Inside the \lstinline!Documentation! annotation, each element of the \lstinline!
 \begin{lstlisting}[language=modelica]
 record Figure
   String title = "" "Title meant for display";
-  String identifier "Identifier meant for programmatic access";
+  String identifier = "" "Identifier meant for programmatic access";
   String group = "" "Name of plot group";
   Boolean preferred = false "Automatically display figure after simulation";
   Plot[:] plots "Plots";
-  String caption "Figure caption";
+  String caption = "" "Figure caption";
 end Figure;
 \end{lstlisting}
 
@@ -87,7 +87,7 @@ A \fmtannotationindex{Figure} is a graphical container that can contain several 
 \begin{lstlisting}[language=modelica]
 record Plot
   String title "Title meant for display";
-  String identifier "Identifier meant for programmatic access";
+  String identifier = "" "Identifier meant for programmatic access";
   Curve[:] curves "Plot curves";
   Axis x "X axis properties";
   Axis y "Y axis properties";
@@ -109,10 +109,11 @@ described in \cref{variable-replacements}, can be used in the
 The \lstinline!identifier! in \lstinline!Figure! and \lstinline!Plot! is an optional \lstinline!String! identifier, and is intended to identify the
 \lstinline!Figure! and \lstinline!Plot! for programmatic access.  The \lstinline!figures! annotation is inherited in the sense that each class has
 a collection of figures comprised by the contents of the \lstinline!figures! annotation in the class itself, as well as the \lstinline!figures! annotations
-from any base classes.  A \lstinline!Figure! must be uniquely identified by its \lstinline!identifier! and a class having it in its collection.  This
+from any base classes. A \lstinline!Figure! must be uniquely identified by its \lstinline!identifier! and a class having it in its collection.  This
 means that a \lstinline!Figure! \lstinline!identifier! must be unique among all \lstinline!Figure! annotations within the same \lstinline!figures!
 annotation as well as among all \lstinline!figures! annotations from inherited classes.  A \lstinline!Plot! \lstinline!identifier! on the other hand
 is only required to be unique among the \lstinline!plots! in the the same \lstinline!Figure! annotation.
+If the identifier is an empty string it cannot be used for programmatic access and is exempt from the uniqueness requirement.
 
 \begin{nonnormative}
 For \lstinline!Figure!, this makes it possible to reference the plot from a


### PR DESCRIPTION
and special rules for empty identifiers.
Note that Plot.caption is not the empty string as default as there is a more complicated explanation.
Closes #2851