### PR TITLE
Fix line breaks in inside/outside connector example

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -87,25 +87,21 @@ This is done before resolving \lstinline!outer! elements to corresponding \lstin
   \end{center}
   \caption{Example for inside and outside connectors.}
 \end{figure}
-The figure visualizes the following \lstinline!connect! equations to
-the connector \lstinline!c! in the models \lstinline!m!$i$. Consider the
-following \lstinline!connect! equations found in the model for component \lstinline!m0!:
+The figure visualizes the following \lstinline!connect! equations to the connector \lstinline!c! in the models \lstinline!m!$i$.
+Consider the following \lstinline!connect! equations found in the model for component \lstinline!m0!:
 \begin{lstlisting}[language=modelica]
 connect(m1.c, m3.c); // m1.c and m3.c are inside connectors
 connect(m2.c, m3.c); // m2.c and m3.c are inside connectors
 \end{lstlisting}
-and in the model for component \lstinline!m3! (\lstinline!c.x! is a sub-connector inside
-\lstinline!c!):
+and in the model for component \lstinline!m3! (\lstinline!c.x! is a sub-connector inside \lstinline!c!):
 \begin{lstlisting}[language=modelica]
-connect(c, m4.c); // c is an outside
-connector, m4.c is an inside connector
-connect(c.x, m5.c); // c.x is an outside
-connector, m5.c is an inside connector
-connect(c , d) ; // c is an outside  connector, d  is an outside connector
+connect(c, m4.c);   // c is an outside connector, m4.c is an inside connector
+connect(c.x, m5.c); // c.x is an outside connector, m5.c is an inside connector
+connect(c, d) ;     // c is an outside connector, d is an outside connector
 \end{lstlisting}
 and in the model for component \lstinline!m6!:
 \begin{lstlisting}[language=modelica]
-connect(d, m7.c); // d is an outside connector, m7.c is an inside connector
+connect(d, m7.c);   // d is an outside connector, m7.c is an inside connector
 \end{lstlisting}
 \end{example}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -637,11 +637,9 @@ Two different errors caused by non-discrete-time expressions:
 when noEvent(x1 > 1) or x2 > 10 then // When-condition must be discrete-time
   close = true;
 end when;
-above1 = noEvent(x1 > 1);            // above1 is discrete-time variable
+above1 = noEvent(x1 > 1);            // Boolean equation must be discrete-time
 \end{lstlisting}
-The when-condition error is a direct violation of the requirement that the when-condition must be discrete-time.
-The error in the equation with \lstinline!above1! is only indirect; since \lstinline!above1! requires a discrete-time solution, it cannot be solved from this equation.
-Consequently, this equation cannot be solved for any variable, a structural singularity condition that will be reported in tool-specific ways.
+The when-condition rule is stated in \cref{when-equations}, and the rule for a non-\lstinline!Real! equation is stated in \cref{discrete-time-expressions}.
 \end{example}
 
 Modelica is based on the synchronous data flow principle (\cref{synchronous-data-flow-principle-and-single-assignment-rule}).

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -640,7 +640,7 @@ end when;
 above1 = noEvent(x1 > 1);            // above1 is discrete-time variable
 \end{lstlisting}
 The when-condition error is a direct violation of the requirement that the when-condition must be discrete-time.
-The error in the equation with \lstinline!above1! is only indirect; since \lstinline!above1! requires a dicsrete-time solution, it cannot be solved from this equation.
+The error in the equation with \lstinline!above1! is only indirect; since \lstinline!above1! requires a discrete-time solution, it cannot be solved from this equation.
 Consequently, this equation cannot be solved for any variable, a structural singularity condition that will be reported in tool-specific ways.
 \end{example}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -632,12 +632,16 @@ Using state events in when-clauses is unnecessary because the body of a when-cla
 \end{nonnormative}
 
 \begin{example}
+Two different errors caused by non-discrete-time expressions:
 \begin{lstlisting}[language=modelica]
-Limit1 = noEvent(x1 > 1);  // Error since Limit1 is a discrete-time variable
-when noEvent(x1>1) or x2>10 then // error, when-conditions is not a discrete-time expression
-  Close = true;
+when noEvent(x1 > 1) or x2 > 10 then // When-condition must be discrete-time
+  close = true;
 end when;
+above1 = noEvent(x1 > 1);            // above1 is discrete-time variable
 \end{lstlisting}
+The when-condition error is a direct violation of the requirement that the when-condition must be discrete-time.
+The error in the equation with \lstinline!above1! is only indirect; since \lstinline!above1! requires a dicsrete-time solution, it cannot be solved from this equation.
+Consequently, this equation cannot be solved for any variable, a structural singularity condition that will be reported in tool-specific ways.
 \end{example}
 
 Modelica is based on the synchronous data flow principle (\cref{synchronous-data-flow-principle-and-single-assignment-rule}).


### PR DESCRIPTION
Most importantly, this fixes the badly broken lines in the middle listing.