### PR TITLE
FixLineBreaks

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -97,10 +97,8 @@ connect(m2.c, m3.c); // m2.c and m3.c are inside connectors
 and in the model for component \lstinline!m3! (\lstinline!c.x! is a sub-connector inside
 \lstinline!c!):
 \begin{lstlisting}[language=modelica]
-connect(c, m4.c); // c is an outside
-connector, m4.c is an inside connector
-connect(c.x, m5.c); // c.x is an outside
-connector, m5.c is an inside connector
+connect(c, m4.c); // c is an outside connector, m4.c is an inside connector
+connect(c.x, m5.c); // c.x is an outside connector, m5.c is an inside connector
 connect(c , d) ; // c is an outside  connector, d  is an outside connector
 \end{lstlisting}
 and in the model for component \lstinline!m6!:
@@ -168,7 +166,7 @@ model Engine
   Sensor sensor;
   Actuator actuator;
 equation
-  connect(bus.speed, sensor.speed); // provides the non-input from sensor.speed
+  connect(bus.speed, sensor.speed); // sensor.speed is the non-input
   connect(bus.speed, actuator.speed);
 end Engine;
 \end{lstlisting}


### PR DESCRIPTION
The previous end of line comments were broken in the source, and thus had inconsistent formatting.
Additionally one line was too long - shortened it.