### PR TITLE
Rephrase implied discrete-valued equation rule as non-normative observation

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1457,16 +1457,6 @@ Discrete-time expressions\index{discrete-time expression}\index{expression varia
   Expressions in functions behave as though they were discrete-time expressions.
 \end{itemize}
 
-For an equation \lstinline!expr1 = expr2! where neither expression is of base type
-\lstinline!Real!, both expressions must be discrete-time expressions. For record
-equations the equation is split into basic types before applying this
-test.
-
-\begin{nonnormative}
-This restriction guarantees that \lstinline!noEvent! cannot be applied to \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String!, or \lstinline!enumeration!
-equations outside of a \lstinline!when!-clause, because then one of the two expressions is not discrete-time.
-\end{nonnormative}
-
 Inside an if-expression, \lstinline!if!-clause, \lstinline!while!-statement or \lstinline!for!-clause, that
 is controlled by a non-discrete-time (that is continuous-time, but not
 discrete-time) switching expression and not in the body of a
@@ -1477,6 +1467,20 @@ relations/functions that should generate events.
 \begin{nonnormative}
 The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing
 functions do not become active between events.
+\end{nonnormative}
+
+\begin{nonnormative}
+For a scalar equation \lstinline!expr1 = expr2! where neither expression is of base type \lstinline!Real!, both expressions must be discrete-time expressions.
+
+The rule follows from the observation that a discrete-valued equation does not provide sufficient information to solve for a continuous-valued variable.
+Hence, and according to the perfect matching rule (see \cref{synchronous-data-flow-principle-and-single-assignment-rule}), such an equation must be used to solve for a discrete-valued variable.
+By the interpretation of \eqref{eq:dae-discrete-valued} in \cref{modelica-dae-representation}, it follows that one of \lstinline!expr1! and \lstinline!expr2! must be the variable, and the other expression its solution.
+Since a discrete-valued variable is a discrete-time variable, it follows that its solution on the other side of the equation must have at most discrete-time variability.
+That is, both sides of the equation are discrete-time expressions.
+
+The rule is equally applicable to the scalar components of a non-scalar equation.
+
+For example, this rule shows that (outside of a \lstinline!when!-clause) \lstinline!noEvent! cannot be applied to either side of a \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String!, or \lstinline!enumeration! equation, as this would result in a non-discrete-time expression.
 \end{nonnormative}
 
 \begin{example}


### PR DESCRIPTION
This is an idea inspired by an ongoing conversation in another PR: https://github.com/modelica/ModelicaSpecification/pull/2905#discussion_r603222316

The point is that we shouldn't state a rule as an independent restriction when it can be inferred from other restrictions.  In this case, it is better to explain the rule as a consequence of the other rules.

By not presenting dependent rules as if they were independent, we reduce risk of ending up with contradictions, keep down the number of rules a user actually needs to know about, keep down the number of rules a tool must implement to reject invalid models, and don't leave readers wondering if a rule is really adding something on top of the other rules.
