### PR TITLE
Restore non-strict inequality for dimension of equalityConstraint

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -813,7 +813,7 @@ record Record
   end equalityConstraint;
 end Record;
 \end{lstlisting}
-The array dimension $n$ of \lstinline!residue! shall be a constant \lstinline!Integer! expression that can be evaluated during translation, with $n > 0$.
+The array dimension $n$ of \lstinline!residue! shall be a constant \lstinline!Integer! expression that can be evaluated during translation, with $n \geq 0$.
 The \lstinline!equalityConstraint! expresses the equality between the two type instances \lstinline!T1! and \lstinline!T2! or the record instances \lstinline!R1! and \lstinline!R2!, respectively, as the $n$ non-redundant equation residuals returned in \lstinline!residue!.
 That is, the set of $n$ non-redundant equations stating that \lstinline!R1 = R2! is given by the equation (\lstinline!0! represents a vector of zeros of appropriate size):
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
Addressing review comment by Elena in already merged PR: https://github.com/modelica/ModelicaSpecification/pull/2898#discussion_r604278037

Comment in original PR by @eshmoylova:
> Sorry, I am too late with my review.  I see the restriction of 'n > 0' was added. There is at least one Modelica library [that sets it to 0](https://github.com/lbl-srg/modelica-buildings/blob/bddfd49d63a9c056073551b1267591be680e4852/Buildings/Electrical/PhaseSystems/PartialPhaseSystem.mo#L30) @mwetter do you want to comment why it is necessary to have it as 0. The change was merged already. Should we open a separate issue for that?

Comment in original PR by @beutlich:
> It's also in MSL: [Modelica.Electrical.QuasiStatic.Types.Reference](https://github.com/modelica/ModelicaStandardLibrary/blob/f30a6ea93530d97db634ca8a1490a755376c20d8/Modelica/Electrical/QuasiStatic/Types/Reference.mo) @AHaumer