### PR TITLE
Cleanup of "Matching Function"

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -806,7 +806,7 @@ solver.
 \lstinline!spatialDistribution! allows the infinite-dimensional problem below to be solved efficiently with good accuracy
 \begin{align*}
 \frac{\partial z(y,t)}{\partial t}+v(t)\frac{\partial z(y,t)}{\partial y} &= 0.0\\
-z(0.0, t) &= \mathrm{in}_0(t) \text{ if $v\ge 0$}\\
+z(0.0, t) &= \mathrm{in}_0(t) \text{ if $v\geq 0$}\\
 z(1.0, t) &= \mathrm{in}_1(t) \text{ if $v<0$}
 \end{align*}
 where $z(y, t)$ is the transported quantity, $y$ is the

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -80,14 +80,11 @@ with distinct names $b_{j}$ is a valid match for the function f, provided (treat
 
 \begin{itemize}
 \item
-  $A_{i}$ = typeOf($A_{i}$) for 1 $\le$ i $\le$ k,
+  $A_{i}$ = typeOf($A_{i}$) for $1 \leq i \leq k$,
 \item
-  the names $b_{j}$ = $u_{Qj}$, Qj \textgreater{}
-  k, $A_{Qj}$ = typeOf($w_{i}$) for 1 $\le$ j $\le$ p, and
+  the names $b_{j}$ = $u_{\mathit{Qj}}$, $\mathit{Qj} > k$, $A_{\mathit{Qj}}$ = typeOf($w_{i}$) for $1 \leq j \leq p$, and
 \item
-  if the union of \{i: 1 $\le$ i $\le$ k \}, \{Qj: 1 $\le$ j $\le$ p\}, and \{m:
-  $P_{m}$ \lstinline!true! and 1 $\le$ m $\le$ n \} is the set \{i: 1 $\le$
-  i $\le$ n\}.
+  if the union of $\{i: 1 \leq i \leq k \}$, $\{\mathit{Qj}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ is \lstinline!true! and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
 \end{itemize}
 
 \begin{nonnormative}
@@ -146,8 +143,7 @@ generating flow-equations for connect-equations and zero elements for matrix mul
 
 \section{Overloaded String Conversions}\label{overloaded-string-conversions}
 
-Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!,
-$k \ge 1$ where $A_1$ is an element of class \lstinline!A!.
+Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!, $k \geq 1$ where $A_1$ is an element of class \lstinline!A!.
 
 \begin{enumerate}
 \item

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -58,10 +58,7 @@ only a short hand notation for function calls.
 
 \section{Matching Function}\label{matching-function}
 
-All functions defined inside the \lstinline!operator! class must return one
-output (based on the restriction above), and may include functions with
-optional arguments, i.e.\ functions of the form
-
+All functions defined inside the \lstinline!operator! class must return one output (based on the restriction above), and may include functions with optional arguments, i.e.\ functions of the form
 \begin{lstlisting}[language=modelica]
 function f
   input $A_1$ $u_1$;
@@ -74,17 +71,16 @@ algorithm
   $\ldots$
 end f;
 \end{lstlisting}
-The vector P indicates whether argument m of f has a default value (\lstinline!true! for default value, \lstinline!false! otherwise).  A call
-f($A_1$, $a_{2}$,\ldots{}, $a_{k}$, $b_{1}$ = $w_{1}$ ,\ldots{}, $b_{p}$ = $w_{p}$)
-with distinct names $b_{j}$ is a valid match for the function f, provided (treating \lstinline!Integer! and \lstinline!Real! as the same type)
 
+The vector $P$ indicates whether argument $m$ of \lstinline!f! has a default value (\lstinline!true! for default value, \lstinline!false! otherwise).
+A call \lstinline!f($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldots$, $b_{p}$ = $w_{p}$)! with distinct names $b_{j}$ is a valid match for the function \lstinline!f!, provided (treating \lstinline!Integer! and \lstinline!Real! as the same type)
 \begin{itemize}
 \item
   $A_{i}$ = typeOf($A_{i}$) for $1 \leq i \leq k$,
 \item
-  the names $b_{j}$ = $u_{\mathit{Qj}}$, $\mathit{Qj} > k$, $A_{\mathit{Qj}}$ = typeOf($w_{i}$) for $1 \leq j \leq p$, and
+  the names $b_{j}$ = $u_{Q_{j}}$, $Q_{j} > k$, $A_{Q_{j}}$ = typeOf($w_{i}$) for $1 \leq j \leq p$, and
 \item
-  if the union of $\{i: 1 \leq i \leq k \}$, $\{\mathit{Qj}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ is \lstinline!true! and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
+  if the union of $\{i: 1 \leq i \leq k \}$, $\{Q_{j}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ is \lstinline!true! and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
 \end{itemize}
 
 \begin{nonnormative}

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -78,7 +78,7 @@ A call \lstinline!f($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldot
 \item
   $A_{i}$ = typeOf($A_{i}$) for $1 \leq i \leq k$,
 \item
-  the names $b_{j}$ = $u_{Q_{j}}$, $Q_{j} > k$, $A_{Q_{j}}$ = typeOf($w_{i}$) for $1 \leq j \leq p$, and
+  the names $b_{j}$ = $u_{Q_{j}}$, $Q_{j} > k$, $A_{Q_{j}}$ = typeOf($w_{j}$) for $1 \leq j \leq p$, and
 \item
   if the union of $\{i: 1 \leq i \leq k \}$, $\{Q_{j}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ is \lstinline!true! and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
 \end{itemize}

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -63,7 +63,7 @@ All functions defined inside the \lstinline!operator! class must return one outp
 function f
   input $A_1$ $u_1$;
   $\ldots$
-  input $A_{m}$ $u_{m}$ := $A_{m}$;
+  input $A_{m}$ $u_{m}$ := $a_{m}$;
   $\ldots$
   input $A_{n}$ $u_{n}$;
   output B y;
@@ -73,10 +73,10 @@ end f;
 \end{lstlisting}
 
 The vector $P$ indicates whether argument $m$ of \lstinline!f! has a default value (\lstinline!true! for default value, \lstinline!false! otherwise).
-A call \lstinline!f($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldots$, $b_{p}$ = $w_{p}$)! with distinct names $b_{j}$ is a valid match for the function \lstinline!f!, provided (treating \lstinline!Integer! and \lstinline!Real! as the same type)
+A call \lstinline!f($a_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldots$, $b_{p}$ = $w_{p}$)! with distinct names $b_{j}$ is a valid match for the function \lstinline!f!, provided (treating \lstinline!Integer! and \lstinline!Real! as the same type)
 \begin{itemize}
 \item
-  $A_{i}$ = typeOf($A_{i}$) for $1 \leq i \leq k$,
+  $A_{i}$ = typeOf($a_{i}$) for $1 \leq i \leq k$,
 \item
   the names $b_{j}$ = $u_{Q_{j}}$, $Q_{j} > k$, $A_{Q_{j}}$ = typeOf($w_{j}$) for $1 \leq j \leq p$, and
 \item


### PR DESCRIPTION
This is a mix of adding missing formatting, fixing typos introduced after 3.4, and fixing a typo that was already present in 3.4, see individual commit messages.
