### PR TITLE
Allocate MCP number for 'Licensing and encryption'

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -20,6 +20,7 @@ but the rest of the development on a branch/pull-request before being accepted.
 
 |Status|Number|Name|Link|
 |------|------|----|----|
+|Active|0039|Licensing and encryption|([MCP/0039](https://github.com/modelica/ModelicaSpecification/tree/MCP/0039/RationaleMCP/0039))|
 |Active|0038|Initialization of Clocked Partitions|([MCP/0038](https://github.com/modelica/ModelicaSpecification/tree/MCP/0038/RationaleMCP/0038))|
 |Active|0037|Generalized Modelica URIs|([MCP/0037](https://github.com/modelica/ModelicaSpecification/tree/MCP/0037/RationaleMCP/0037))|
 |Active|0036|Setting states|([MCP/0036](https://github.com/modelica/ModelicaSpecification/tree/MCP/0036/RationaleMCP/0036))|


### PR DESCRIPTION
As the good intentions of #2917 are obvious, I'm avoiding unnecessary delays by creating the required PR for MCP number allocation.

For an overview of the proposal, I recommend this document from #2917:
https://github.com/modelica/ModelicaSpecification/blob/origin/MCP/0039/RationaleMCP/0039/SEMLA_Overview_20210225.pdf

I expect that we can vote on this during the upcoming phone meeting.
