### PR TITLE
Don't repeatedly explain that non-discrete time is continuous-time

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -803,7 +803,7 @@ the \lstinline!start!-value can be used as a guess-value during initialization.
 \begin{nonnormative}
 In the case a parameter has both a binding equation and \lstinline!fixed = false! a diagnostics is recommended, but the parameter should be solved from the binding equation.
 
-Non-discrete \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization
+Non-discrete-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization
 \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
 
 Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!. If this is not the case for some variables

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -761,7 +761,7 @@ variables, can be defined in the following ways:
   The equations and assignments in these initial sections are purely algebraic, stating constraints between the variables at the initial time instant.
   It is not allowed to use when-clauses in these sections.
 \item
-  For a non-discrete \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
+  For a non-discrete-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
   \begin{nonnormative}
   If \lstinline!pre(vc)! is not present in the flattened model, a tool may choose not to introduce this equation, or if it was introduced
   it can eliminate it (to avoid the introduction of many dummy variables \lstinline!pre(vc)!).

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -761,7 +761,7 @@ variables, can be defined in the following ways:
   The equations and assignments in these initial sections are purely algebraic, stating constraints between the variables at the initial time instant.
   It is not allowed to use when-clauses in these sections.
 \item
-  For a non-discrete (that is continuous-time) \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
+  For a non-discrete \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
   \begin{nonnormative}
   If \lstinline!pre(vc)! is not present in the flattened model, a tool may choose not to introduce this equation, or if it was introduced
   it can eliminate it (to avoid the introduction of many dummy variables \lstinline!pre(vc)!).
@@ -770,7 +770,7 @@ variables, can be defined in the following ways:
   Implicitly by using the \lstinline!start! attribute for variables with \lstinline!fixed = true!.  With \lstinline!start! given by \lstinline!startExpression!:
   \begin{itemize}
   \item
-    For a non-discrete-time (that is continuous-time) \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!vc = startExpression! is added to the initialization equations.
+    For a non-discrete-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!vc = startExpression! is added to the initialization equations.
   \item
     For a discrete-time variable \lstinline!vd!, the equation \lstinline!pre(vd) = startExpression! is added to the initialization equations.
   \item
@@ -803,7 +803,7 @@ the \lstinline!start!-value can be used as a guess-value during initialization.
 \begin{nonnormative}
 In the case a parameter has both a binding equation and \lstinline!fixed = false! a diagnostics is recommended, but the parameter should be solved from the binding equation.
 
-Non-discrete (that is continuous-time) \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization
+Non-discrete \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization
 \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
 
 Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!. If this is not the case for some variables


### PR DESCRIPTION
The reasons are:
* It isn't true! Non-discrete-time is continuous-time, except discrete-time. Repeating that complete statement several times would be more tedious.
* It causes bad line break in one case.
Closes #2891