### PR TITLE
Push builds to github-pages instead of SSH upload

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -73,6 +73,7 @@ pipeline {
         anyOf {
           buildingTag()
           anyOf {
+            branch 'jenkins'
             branch 'master'
             branch 'maint/**'
           }
@@ -86,7 +87,21 @@ pipeline {
     steps {
       unstash name: 'MLS'
       sh "test ! -z ${env.GIT_BRANCH}"
-      sshPublisher(publishers: [sshPublisherDesc(configName: 'ModelicaSpecification', transfers: [sshTransfer(remoteDirectory: "${env.GIT_BRANCH}", sourceFiles: '*.html,*.css,*.js,MLS.pdf,media/**,css/**')])])
+      sshagent (credentials: ['Hudson-SSH-Key']) {
+        sh 'ssh-keyscan github.com >> ~/.ssh/known_hosts'
+        sh "test -d specification.modelica.org || git clone git@github.com:modelica/specification.modelica.org"
+        sh "cd specification.modelica.org/ && git fetch && git reset --hard origin/master"
+        sh "rm -rf  'specification.modelica.org/${env.GIT_BRANCH}' && mkdir -p  'specification.modelica.org/${env.GIT_BRANCH}'"
+        sh "cp -a *.html *.css *.js MLS.pdf media css 'specification.modelica.org/${env.GIT_BRANCH}'"
+        sh """
+        cd specification.modelica.org
+        git add '${env.GIT_BRANCH}'
+        if ! git diff-index --quiet origin/master --; then
+          git commit --amend -m "Initial commit"
+          git push -f
+        fi
+        """
+      }
     }
   }
   stage('index') {
@@ -108,7 +123,20 @@ pipeline {
     }
     steps {
       sh 'python3 .CI/index.py'
-      sshPublisher(publishers: [sshPublisherDesc(configName: 'ModelicaSpecification', transfers: [sshTransfer(sourceFiles: 'index.html')])])
+      sshagent (credentials: ['Hudson-SSH-Key']) {
+        sh 'ssh-keyscan github.com >> ~/.ssh/known_hosts'
+        sh "test -d specification.modelica.org || git clone git@github.com:modelica/specification.modelica.org"
+        sh "cd specification.modelica.org/ && git fetch && git reset --hard origin/master"
+        sh "cp -a index.html specification.modelica.org/"
+        sh """
+        cd specification.modelica.org
+        git add index.html
+        if ! git diff-index --quiet origin/master --; then
+          git commit --amend -m "Initial commit"
+          git push -f
+        fi
+        """
+      }
     }
   }
   }


### PR DESCRIPTION
We will not have access to the server that we currently uploaded files to. So I propose pushing to a separate repository for github pages. This PR then needs to be cherry-picked into the maintenance branches.

The builds will be available at https://modelica.github.io/specification.modelica.org/ (only https://modelica.github.io/specification.modelica.org/jenkins/MLS.html until this is pushed) and I will change the domain name after the PRs are merged.