### PR TITLE
Do not use block links in the page header

### DIFF
--- a/css/MLS.css
+++ b/css/MLS.css
@@ -89,3 +89,6 @@ a:hover { text-decoration: underline; }
 .ltx_indexrefs > .ltx_text:first-child:before {
   content: " –";
 }
+
+.ltx_page_header *[rel~="up"],
+.ltx_page_footer *[rel~="up"] { display: table; margin: 0 auto; text-align: center; }


### PR DESCRIPTION
An issue was reported in #2825 where clicking the menu in top left
instead went to the block link the header.