### PR TITLE
Clean up formulations and formatting related to 'is not provided' in 'Synchronous Language Elements'

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -578,7 +578,10 @@ The operators listed below convert between a continuous-time and a clocked-time 
 sample($u$, $\mathit{clock}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Input argument $u$ is a continuous-time expression according to \cref{continuous-time-expressions}.  The optional input argument $\mathit{clock}$ is of type \lstinline!Clock!, and can in a call be given as a named argument (with the name $\mathit{clock}$), or as positional argument.  The operator returns a clocked variable that has $\mathit{clock}$ as associated clock and has the value of the left limit of $u$ when $\mathit{clock}$ is active (that is the value of $u$ just before the event of \lstinline!c! is triggered).  If argument $\mathit{clock}$ is not provided, it is inferred, see \cref{sub-clock-inferencing}.
+Input argument $u$ is a continuous-time expression according to \cref{continuous-time-expressions}.
+The optional input argument $\mathit{clock}$ is of type \lstinline!Clock!, and can in a call be given as a named argument (with the name $\mathit{clock}$), or as positional argument.
+The operator returns a clocked variable that has $\mathit{clock}$ as associated clock and has the value of the left limit of $u$ when $\mathit{clock}$ is active (that is the value of $u$ just before the event of \lstinline!c! is triggered).
+If $\mathit{clock}$ is not provided, it is inferred, see \cref{sub-clock-inferencing}.
 \begin{nonnormative}
 Since the operator returns the left limit of $u$, it introduces an infinitesimal small delay between the continuous-time and the clocked partition.  This corresponds to the reality, where a sampled data system cannot act infinitely fast and even for a very idealized simulation, an infinitesimal small delay is present.  The consequences for the sorting are discussed below.
 
@@ -673,7 +676,7 @@ subSample($u$, factor=$\mathit{factor}$)
 The clock of \lstinline!y = subSample($u$, $\mathit{factor}$)! is $\mathit{factor}$ times slower than the clock of $u$.
 At every $\mathit{factor}$ ticks of the clock of $u$, the operator returns the value of $u$.
 The first activation of the clock of \lstinline!y! coincides with the first activation of the clock of $u$, and then every activation of the clock of \lstinline!y! coincides with the every $\mathit{factor}$th activativation of the clock of $u$.
-If argument $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
+If $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
 \end{semantics}
 \end{operatordefinition}
 
@@ -686,7 +689,8 @@ The clock of \lstinline!y = superSample($u$, $\mathit{factor}$)! is $\mathit{fac
 \begin{nonnormative}
 Thus \lstinline!subSample(superSample($u$, $\mathit{factor}$), $\mathit{factor}$)! = $u$.
 \end{nonnormative}
-If argument factor is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.  If an event clock is associated to a base-clock partition, all its sub-clock partitions must have resulting clocks that are sub-sampled with an \lstinline!Integer! factor with respect to this base-clock.
+If $\mathit{factor}$ is not provided or is equal to zero, it is inferred, see \cref{sub-clock-inferencing}.
+If an event clock is associated to a base-clock partition, all its sub-clock partitions must have resulting clocks that are sub-sampled with an \lstinline!Integer! factor with respect to this base-clock.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
Two changes:
- Make sure symbolic argument is math-formatted.
- Remove redundant "argument" before math-formatted symbolic reference to argument.