### PR TITLE
Require correctly rounded result of exponentiation

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1280,10 +1280,10 @@ This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical 
 
 \subsection{Exponentiation of Scalars of Numeric Elements}\label{exponentiation-of-scalars-of-numeric-elements}
 
-Exponentiation \lstinline!a ^ b! is defined as \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library if both \lstinline!a! and \lstinline!b! are
-\lstinline!Real! scalars. A \lstinline!Real! scalar value is returned.  If \lstinline!a! or \lstinline!b! are \lstinline!Integer! scalars, they are
-automatically promoted to \lstinline!Real!.  Consequences of exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} \leq 0.0$,
-$\text{\lstinline!a!} < 0$ and \lstinline!b! is not an integer) or overflow are undefined.
+Exponentiation \lstinline!a ^ b! is only defined for \lstinline!Real! scalar operands \lstinline!a! and \lstinline!b!, producing a \lstinline!Real! result.
+(Standard type coerion will hence be applied for operands of type \lstinline!Integer!, see \cref{standard-type-coercion}.)
+The result is defined by \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library, with correctly rounded result as described in \textcite[section~9.2 \emph{Recommended correctly rounded functions}]{IEEE754CorrectlyRoundedFunctions}.
+Consequences of exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} \leq 0.0$, $\text{\lstinline!a!} < 0$ and \lstinline!b! is not an integer) or overflow are undefined.
 
 Element-wise exponentiation \lstinline!a .^ b! of numeric scalars, vectors, matrices, or arrays \lstinline!a! and \lstinline!b! requires a numeric type class for
 \lstinline!a! and \lstinline!b! and either \lstinline!size(a) = size(b)! or scalar \lstinline!a! or scalar \lstinline!b!.

--- a/mls.bib
+++ b/mls.bib
@@ -82,3 +82,11 @@
   year = {2006},
   url = {http://www.di.ens.fr/~pouzet/lucid-synchrone/},
 }
+
+@Article{IEEE754CorrectlyRoundedFunctions,
+  author={},
+  journal={IEEE Std 754-2008},
+  title={{IEEE} Standard for Floating-Point Arithmetic},
+  year={2008},
+  doi={10.1109/IEEESTD.2008.4610935},
+ }


### PR DESCRIPTION
Motivated by discussion in https://github.com/modelica/ModelicaStandardLibrary/issues/3836, where it was pointed out that just saying that 'pow' is the one in the ANSI C library doesn't give sufficient guarantees about the quality of the result to make it a viable way of defining exponentiation.

Question to reviewers: Would it be even better to completely drop the ANSI C connection, and just rely on IEEE 754-2008?
