### PR TITLE
Remove copy-paste from unknown source. 

### DIFF
--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -553,10 +553,6 @@ algorithm
 end PointMassGravity;
 
 model Body
-  model UseDriveLine "illegal model"
-    DriveLineBase base(redeclare Clutch friction);
-    // Cannot connect to friction.pressure
-  end UseDriveLine;
   Modelica.Mechanics.MultiBody.Interface.Frame_a frame_a;
   replaceable function gravity = GravityInterface;
 equation


### PR DESCRIPTION
UseDriveLine is part of other example.
Closes #2968

I tried to search and the issue appeared already in the first latex-version 74e1cb4a - but not in the Word-version. I don't know how that was messed up in the conversion.