### PR TITLE
Align keywords for 'grammar' with keywords for 'modelica'

### DIFF
--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -102,12 +102,21 @@
     breaklines=true,
     breakatwhitespace=true,
     morekeywords=[1]{%
-        annotation,assert,block,break,class,connect,connector,constant,constrainedby,discrete,%
-        each,encapsulated,else,elseif,elsewhen,end,expandable,extends,external,final,flow,for,%
-        function,if,in,inner,initial,input,import,loop,model,operator,outer,%
-        output,package,parameter,partial,record,redeclare,replaceable,return,%
-        stream,terminate,then,type,when,while,algorithm,equation,%
-        protected,public,and,false,not,or,true,pure,impure,within,%
+        % Keywords corresponding to morekeywords=[1] for language=modelica
+        der,connect,assert,terminate,break,return,%
+        false,true,and,not,or,%
+        final,each,%
+        flow,stream,%
+        input,output,%
+        discrete,parameter,constant,%
+        % Keywords corresponding to morekeywords=[2] for language=modelica
+        annotation,block,class,connector,constrainedby,%
+        encapsulated,enumeration,else,elseif,elsewhen,end,%
+        expandable,extends,external,for,%
+        function,if,in,inner,initial,import,loop,model,operator,outer,%
+        package,partial,record,redeclare,replaceable,%
+        then,type,when,while,within,algorithm,equation,%
+        protected,public,pure,impure,%
     },
     % Instead of using color to highlight BNF syntactical constructs as below, the production rule names
     % are set in italics, so that the syntactical constructs stand out by having upright shape.


### PR DESCRIPTION
This fixes a problem I noted when looking at the grammar describing partial derivative functions.  Since `der` wasn't a keyword for `language=grammar`, it was typeset as the name of a grammar production rule.

In addition to treating `der`, this PR also makes `enumeration` a grammar keyword, fixing a similar issue in the `short-class-specifier` rule.