### PR TITLE
Mostly trivial clean up related to equations and statements

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -26,11 +26,9 @@ Equations in Modelica can be classified into different categories depending on t
 
 \section{Flattening and Lookup in Equations}\label{flattening-and-lookup-in-equations}
 
-A flattened equation is identical to the corresponding nonflattened
-equation.
+A flattened equation is identical to the corresponding nonflattened equation.
 
-Names in an equation shall be found by looking up in the partially
-flattened enclosing class of the equation.
+Names in an equation shall be found by looking up in the partially flattened enclosing class of the equation.
 
 \section{Equations in Equation Sections}\label{equations-in-equation-sections}
 
@@ -41,8 +39,8 @@ equation-section :
    [ initial ] equation { equation ";" }
 \end{lstlisting}
 
-The following kinds of equations may occur in equation sections. The
-syntax is defined as follows:
+The following kinds of equations may occur in equation sections.
+The syntax is defined as follows:
 \begin{lstlisting}[language=grammar]
 equation :
    ( simple-expression "=" expression
@@ -54,24 +52,18 @@ equation :
    )
    description
 \end{lstlisting}
-No statements are allowed in equation sections, including the assignment
-statement using the := operator.
+No statements are allowed in equation sections, including the assignment statement using the := operator.
 
 \subsection{Simple Equality Equations}\label{simple-equality-equations}
 
-Simple equality equations are the traditional kinds of equations known
-from mathematics that express an equality relation between two
-expressions. There are two syntactic forms of such equations in
-Modelica. The first form below is \emph{equality} equations between two
-expressions, whereas the second form is used when calling a function
-with \emph{several} results. The syntax for simple equality equations is
-as follows:
+Simple equality equations are the traditional kinds of equations known from mathematics that express an equality relation between two expressions.
+There are two syntactic forms of such equations in Modelica.
+The first form below is \emph{equality} equations between two expressions, whereas the second form is used when calling a function with \emph{several} results.
+The syntax for simple equality equations is as follows:
 \begin{lstlisting}[language=grammar]
 simple-expression "=" expression
 \end{lstlisting}
-The types of the left-hand-side and the right-hand-side of an equation
-need to be compatible in the same way as two arguments of binary
-operators (\cref{type-compatible-expressions}).
+The types of the left-hand-side and the right-hand-side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 
 Three examples:
 \begin{itemize}
@@ -81,10 +73,8 @@ Three examples:
 \end{itemize}
 
 \begin{nonnormative}
-Note: According to the grammar the if-then-else expression in
-the second example needs to be enclosed in parentheses to avoid parsing
-ambiguities. Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling
-functions with several results in assignment statements.
+Note: According to the grammar the if-then-else expression in the second example needs to be enclosed in parentheses to avoid parsing ambiguities.
+Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling functions with several results in assignment statements.
 \end{nonnormative}
 
 \subsection{For-Equations -- Repetitive Equation Structures}\label{for-equations-repetitive-equation-structures}
@@ -128,7 +118,8 @@ for i in TwoEnums loop         // i takes the values TwoEnums.one, TwoEnums.two
                                // for TwoEnums = enumeration(one,two)
 \end{lstlisting}
 
-The loop-variable may hide other variables as in the following example.  Using another name for the loop-variable is, however, strongly recommended.
+The loop-variable may hide other variables as in the following example.
+Using another name for the loop-variable is, however, strongly recommended.
 \begin{lstlisting}[language=modelica]
   constant Integer j = 4;
   Real x[j]
@@ -142,7 +133,8 @@ equation
 
 \subsubsection{Implicit Iteration Ranges of For-Equations}\label{implicit-iteration-ranges-of-for-equations}
 
-The iteration range of a loop-variable may sometimes be inferred from its use as an array index.  See \cref{implicit-iteration-ranges} for more information.
+The iteration range of a loop-variable may sometimes be inferred from its use as an array index.
+See \cref{implicit-iteration-ranges} for more information.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -191,8 +183,7 @@ The bodies that are not selected have no effect on that model evaluation.
 The \lstinline!if!-equations in equation sections which do not have exclusively parameter expressions as switching conditions shall have the same number of equations in each branch (a missing else is counted as zero equations and the number of equations is defined after expanding the equations to scalar equations).
 
 \begin{nonnormative}
-If this condition is violated, the single assignment rule would not hold, because the number of equations may change during simulation
-although the number of unknowns remains the same.
+If this condition is violated, the single assignment rule would not hold, because the number of equations may change during simulation although the number of unknowns remains the same.
 \end{nonnormative}
 
 \subsection{When-Equations}\label{when-equations}
@@ -243,7 +234,8 @@ equation
 \end{lstlisting}
 
 \begin{nonnormative}
-The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause.  Example:
+The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause.
+Example:
 \begin{lstlisting}[language=modelica]
   /* discrete */ Real x;
   input Real u;
@@ -256,12 +248,11 @@ equation
 \end{lstlisting}
 
 Here, \lstinline!x! is a discrete-time variable (whether it is declared with the \lstinline!discrete! prefix or not), but \lstinline!u! and \lstinline!y! cannot be discrete-time variables
-(since they are not assigned in \lstinline!when!-clauses).  However, \lstinline!pre(u)! is legal within the \lstinline!when!-clause, since the body of the \lstinline!when!-clause is only evaluated at events, and thus all expressions
-are discrete-time expressions.
+(since they are not assigned in \lstinline!when!-clauses).
+However, \lstinline!pre(u)! is legal within the \lstinline!when!-clause, since the body of the \lstinline!when!-clause is only evaluated at events, and thus all expressions are discrete-time expressions.
 \end{nonnormative}
 
-The start values of the introduced \lstinline!Boolean! variables are defined by the taking the start value of the when-condition, as above where \lstinline!b! is a parameter
-variable.
+The start values of the introduced \lstinline!Boolean! variables are defined by the taking the start value of the when-condition, as above where \lstinline!b! is a parameter variable.
 The start value of the special functions \lstinline!initial!, \lstinline!terminal!, and \lstinline!sample! is \lstinline!false!.
 
 \subsubsection{Restrictions on Where a When-Equation may Occur}\label{restrictions-on-where-a-when-equation-may-occur}
@@ -304,8 +295,7 @@ The equations within the \lstinline!when!-equation must have one of the followin
   The branches of an \lstinline!if!-equation inside \lstinline!when!-equations must have the same set of component references on the left-hand side, unless all switching conditions of the \lstinline!if!-equation are parameter expressions.
 \end{itemize}
 
-Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must
-be a component reference, and any indices must be parameter expressions.
+Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be parameter expressions.
 
 \begin{nonnormative}
 The needed restrictions on equations within a \lstinline!when!-equation becomes apparent with the following example:
@@ -378,11 +368,8 @@ The Modelica single-assignment rule (\cref{synchronous-data-flow-principle-and-s
   Two \lstinline!when!-equations shall \emph{not} define the same variable.
 
 \begin{nonnormative}
-Without this rule this may actually happen for the erroneous
-model \lstinline!DoubleWhenConflict! below, since there are two equations
-(\lstinline!close = true; close = false;!) defining the same variable
-\lstinline!close!. A conflict between the equations will occur if both
-conditions would become \lstinline!true! at the same time instant.
+Without this rule this may actually happen for the erroneous model \lstinline!DoubleWhenConflict! below, since there are two equations (\lstinline!close = true; close = false;!) defining the same variable \lstinline!close!.
+A conflict between the equations will occur if both conditions would become \lstinline!true! at the same time instant.
 \begin{lstlisting}[language=modelica]
 model DoubleWhenConflict
   Boolean close;   // Erroneous model: close defined by two equations!
@@ -406,9 +393,7 @@ This is possible by rewriting the \lstinline!when!-equation using \lstinline!els
 \item
   A \lstinline!when!-equation involving elsewhen-parts can be used to resolve assignment conflicts since the first of the when/elsewhen parts are given higher priority than later ones:
 \begin{nonnormative}
-Below it is well defined what happens if both conditions
-become \lstinline!true! at the same time instant since \lstinline!condition1! with
-associated conditional equations has a higher priority than \lstinline!condition2!.
+Below it is well defined what happens if both conditions become \lstinline!true! at the same time instant since \lstinline!condition1! with associated conditional equations has a higher priority than \lstinline!condition2!.
 \begin{lstlisting}[language=modelica]
 model WhenPriority
   Boolean close;   // Correct model: close defined by two equations!
@@ -433,20 +418,19 @@ It has the following syntax:
 reinit(x, expr);
 \end{lstlisting}
 
-The operator reinitializes \lstinline!x! with \lstinline!expr! at an event instant.  \lstinline!x! is a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e.\ \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.  \lstinline!expr! needs to be type-compatible with \lstinline!x!.  \lstinline!reinit! can for the same variable (resp.\ array of variables) only be applied (either as an individual variable or as part of an array of variables) in one equation (having \lstinline!reinit! of the same variable in when and else-when of the same variable is allowed).  In case of \lstinline!reinit! active during initialization (due to when initial), see \cref{initialization-initial-equation-and-initial-algorithm}.
+The operator reinitializes \lstinline!x! with \lstinline!expr! at an event instant.
+\lstinline!x! is a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e.\ \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
+\lstinline!expr! needs to be type-compatible with \lstinline!x!.
+\lstinline!reinit! can for the same variable (resp.\ array of variables) only be applied (either as an individual variable or as part of an array of variables) in one equation (having \lstinline!reinit! of the same variable in when and else-when of the same variable is allowed).
+In case of \lstinline!reinit! active during initialization (due to when initial), see \cref{initialization-initial-equation-and-initial-algorithm}.
 
 \lstinline!reinit! does not break the single assignment rule, because \lstinline!reinit(x, expr)! in equations evaluates \lstinline!expr! to a value,
-then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is
-done after all other evaluations of the model and before copying \lstinline!x! to \lstinline!pre(x)!).
+then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is done after all other evaluations of the model and before copying \lstinline!x! to \lstinline!pre(x)!).
 
 \begin{example}
-If a higher index system is present, i.e., constraints between
-state variables, some state variables need to be redefined to non-state
-variables. During simulation, non-state variables should be chosen in
-such a way that variables with an applied \lstinline!reinit! are
-selected as states at least when the corresponding \lstinline!when!-clauses become
-active. If this is not possible, an error occurs, since otherwise
-\lstinline!reinit! would be applied to a non-state variable.
+If a higher index system is present, i.e., constraints between state variables, some state variables need to be redefined to non-state variables.
+During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding \lstinline!when!-clauses become active.
+If this is not possible, an error occurs, since otherwise \lstinline!reinit! would be applied to a non-state variable.
 
 Example for the usage of \lstinline!reinit! (bouncing ball):
 \begin{lstlisting}[language=modelica]
@@ -503,19 +487,11 @@ If the \lstinline!condition! evaluates to false, different actions are taken dep
 \end{itemize}
 
 \begin{nonnormative}
-The \lstinline!AssertionLevel.error! case can be used to avoid evaluating a
-model outside its limits of validity; for instance, a function to
-compute the saturated liquid temperature cannot be called with a
-pressure lower than the triple point value.
+The \lstinline!AssertionLevel.error! case can be used to avoid evaluating a model outside its limits of validity; for instance, a function to compute the saturated liquid temperature cannot be called with a pressure lower than the triple point value.
 
-The \lstinline!AssertionLevel.warning! case can be used when the boundary of
-validity is not hard: for instance, a fluid property model based on a
-polynomial interpolation curve might give accurate results between
-temperatures of 250 K and 400 K, but still give reasonable results in
-the range 200 K and 500 K. When the temperature gets out of the smaller
-interval, but still stays in the largest one, the user should be warned,
-but the simulation should continue without any further action. The
-corresponding code would be:
+The \lstinline!AssertionLevel.warning! case can be used when the boundary of validity is not hard: for instance, a fluid property model based on a polynomial interpolation curve might give accurate results between temperatures of 250 K and 400 K, but still give reasonable results in the range 200 K and 500 K.
+When the temperature gets out of the smaller interval, but still stays in the largest one, the user should be warned, but the simulation should continue without any further action.
+The corresponding code would be:
 \begin{lstlisting}[language=modelica]
 assert(T > 250 and T < 400, "Medium model outside full accuracy range", AssertionLevel.warning);
 assert(T > 200 and T < 500, "Medium model outside feasible region");
@@ -553,8 +529,7 @@ See \cref{equation-operators-for-overconstrained-connection-based-equation-syste
 
 \section{Synchronous Data-flow Principle and Single Assignment Rule}\label{synchronous-data-flow-principle-and-single-assignment-rule}
 
-Modelica is based on the synchronous data flow principle and the single
-assignment rule, which are defined in the following way:
+Modelica is based on the synchronous data flow principle and the single assignment rule, which are defined in the following way:
 \begin{enumerate}
 \item Discrete-time variables keep their values until these variables are explicitly changed.
 Differentiated variables have \lstinline!der(x)! corresponding to the time-derivative of \lstinline!x!,
@@ -569,8 +544,7 @@ the equations express relations between variables which have to be fulfilled con
 If computation or communication time has to be simulated, this property has to be explicitly modeled.
 \end{nonnormative}
 
-\item There must exist a perfect matching of variables to equations after flattening, where a variable can only
-be matched to equations that can contribute to solving for the variable
+\item There must exist a perfect matching of variables to equations after flattening, where a variable can only be matched to equations that can contribute to solving for the variable
 (\firstuse{perfect matching rule}\index{perfect matching rule} -- previously called \emph{single assignment rule}\index{single assignment rule|see{perfect matching rule}}); see also globally balanced \cref{balanced-models}.
 \end{enumerate}
 
@@ -579,18 +553,13 @@ be matched to equations that can contribute to solving for the variable
 An \firstuse{event}\index{event} is something that occurs instantaneously at a specific time or when a specific condition occurs.
 Events are for example defined by the condition occurring in a \lstinline!when!-clause, \lstinline!if!-equation, or \lstinline!if!-expression.
 
-The integration is halted and an event occurs whenever an event
-generation expression, e.g.\ \lstinline!x > 2! o or \lstinline!floor(x)!, changes
-its value. An event generating expression has an internal buffer, and
-the value of the expression can only be changed at event instants. If
-the evaluated expression is inconsistent with the buffer, that will
-trigger an event and the buffer will be updated with a new value at the
-event instant. During continuous integration event generation expression
-has the constant value of the expression from the last event instant.
+The integration is halted and an event occurs whenever an event generation expression, e.g.\ \lstinline!x > 2! o or \lstinline!floor(x)!, changes its value.
+An event generating expression has an internal buffer, and the value of the expression can only be changed at event instants.
+If the evaluated expression is inconsistent with the buffer, that will trigger an event and the buffer will be updated with a new value at the event instant.
+During continuous integration event generation expression has the constant value of the expression from the last event instant.
 
 \begin{nonnormative}
-A root finding mechanism is needed which determines a small time interval in which the expression changes its value; the event occurs
-at the right side of this interval.
+A root finding mechanism is needed which determines a small time interval in which the expression changes its value; the event occurs at the right side of this interval.
 \end{nonnormative}
 
 \begin{example}
@@ -602,7 +571,8 @@ During continuous integration always the same \lstinline!if!-branch is evaluated
 The integration is halted whenever \lstinline!u-uMax! or \lstinline!u-uMin! crosses zero.
 At the event instant, the correct \lstinline!if!-branch is selected and the integration is restarted.
 
-Numerical integration methods of order $n$ ($n \geq 1$) require continuous model equations which are differentiable up to order $n$.  This requirement can be fulfilled if \lstinline!Real! elementary relations are not treated literally but as defined above, because discontinuous changes can only occur at event instants and no longer during continuous integration.
+Numerical integration methods of order $n$ ($n \geq 1$) require continuous model equations which are differentiable up to order $n$.
+This requirement can be fulfilled if \lstinline!Real! elementary relations are not treated literally but as defined above, because discontinuous changes can only occur at event instants and no longer during continuous integration.
 \end{example}
 
 \begin{nonnormative}
@@ -611,12 +581,13 @@ It is a quality of implementation issue that the following special relations
 time >= discrete expression
 time < discrete expression
 \end{lstlisting}
-trigger a time event at \lstinline!time! = \emph{discrete expression}, i.e., the
-event instant is known in advance and no iteration is needed to find the
-exact event instant.
+trigger a time event at \lstinline!time! = \emph{discrete expression}, i.e., the event instant is known in advance and no iteration is needed to find the exact event instant.
 \end{nonnormative}
 
-Relations are taken literally also during continuous integration, if the relation or the expression in which the relation is present, are the argument of \lstinline!noEvent!.  \lstinline!smooth! also allows relations used as argument to be taken literally.  The \lstinline!noEvent! feature is propagated to all subrelations in the scope of the \lstinline!noEvent! application.  For \lstinline!smooth! the liberty to not allow literal evaluation is propagated to all subrelations, but the smoothness property itself is not propagated.
+Relations are taken literally also during continuous integration, if the relation or the expression in which the relation is present, are the argument of \lstinline!noEvent!.
+\lstinline!smooth! also allows relations used as argument to be taken literally.
+The \lstinline!noEvent! feature is propagated to all subrelations in the scope of the \lstinline!noEvent! application.
+For \lstinline!smooth! the liberty to not allow literal evaluation is propagated to all subrelations, but the smoothness property itself is not propagated.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -653,12 +624,10 @@ The when-condition rule is stated in \cref{when-equations}, and the rule for a n
 Modelica is based on the synchronous data flow principle (\cref{synchronous-data-flow-principle-and-single-assignment-rule}).
 
 \begin{nonnormative}
-The rules for the synchronous data flow principle guarantee
-that variables are always defined by a unique set of equations. It is
-not possible that a variable is e.g.\ defined by two equations, which
-would give rise to conflicts or non-deterministic behavior. Furthermore,
-the continuous and the discrete parts of a model are always
-automatically ``synchronized''. Example:
+The rules for the synchronous data flow principle guarantee that variables are always defined by a unique set of equations.
+It is not possible that a variable is e.g.\ defined by two equations, which would give rise to conflicts or non-deterministic behavior.
+Furthermore, the continuous and the discrete parts of a model are always automatically ``synchronized''.
+Example:
 \begin{lstlisting}[language=modelica]
 equation // Illegal example
   when condition1 then
@@ -670,11 +639,9 @@ equation // Illegal example
   end when;
 \end{lstlisting}
 
-This is not a valid model because rule 4 is violated since there
-are two equations for the single unknown variable close. If this would
-be a valid model, a conflict occurs when both conditions become true at
-the same time instant, since no priorities between the two equations are
-assigned. To become valid, the model has to be changed to:
+This is not a valid model because rule 4 is violated since there are two equations for the single unknown variable close.
+If this would be a valid model, a conflict occurs when both conditions become true at the same time instant, since no priorities between the two equations are assigned.
+To become valid, the model has to be changed to:
 \begin{lstlisting}[language=modelica]
 equation
   when condition1 then
@@ -684,17 +651,14 @@ equation
   end when;
 \end{lstlisting}
 
-Here, it is well-defined if both conditions become true at the
-same time instant (\lstinline!condition1! has a higher priority than
-\lstinline!condition2!).
+Here, it is well-defined if both conditions become true at the same time instant (\lstinline!condition1! has a higher priority than \lstinline!condition2!).
 \end{nonnormative}
 
-There is no guarantee that two different events occur at the same time
-instant.
+There is no guarantee that two different events occur at the same time instant.
 
 \begin{nonnormative}
-As a consequence, synchronization of events has to be
-explicitly programmed in the model, e.g.\ via counters. Example:
+As a consequence, synchronization of events has to be explicitly programmed in the model, e.g.\ via counters.
+Example:
 \begin{lstlisting}[language=modelica]
   Boolean fastSample, slowSample;
   Integer ticks(start=0);
@@ -715,14 +679,11 @@ algorithm
   end when;
 \end{lstlisting}
 
-The \lstinline!slowSample! \lstinline!when!-clause is evaluated at every 5th occurrence of the
-\lstinline!fastSample! \lstinline!when!-clause.
+The \lstinline!slowSample! \lstinline!when!-clause is evaluated at every 5th occurrence of the \lstinline!fastSample! \lstinline!when!-clause.
 \end{nonnormative}
 
 \begin{nonnormative}
-The single assignment rule and the requirement to explicitly
-program the synchronization of events allow a certain degree of model
-verification already at compile time.
+The single assignment rule and the requirement to explicitly program the synchronization of events allow a certain degree of model verification already at compile time.
 \end{nonnormative}
 
 
@@ -732,23 +693,21 @@ Before any operation is carried out with a Modelica model (e.g., simulation or l
 During this phase, called the \firstuse{initialization problem}\index{initialization problem}, also the derivatives (\lstinline!der!), and the pre-variables (\lstinline!pre!), are interpreted as unknown algebraic variables.
 The initialization uses all equations and algorithms that are utilized in the intended operation (such as simulation or linearization).
 
-The equations of a \lstinline!when!-clause are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms
-\lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then! (and similarly for \lstinline!elsewhen! and algorithms see below).  In this case, the \lstinline!when!-clause equations remain active during the
-whole initialization phase.  In case of a \lstinline!reinit(x, expr)! being active during initialization (due to being inside \lstinline!when initial()!) this is interpreted as adding
-\lstinline!x = expr! (the \lstinline!reinit!-equation) as an initial equation.
+The equations of a \lstinline!when!-clause are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then! (and similarly for \lstinline!elsewhen! and algorithms see below).
+In this case, the \lstinline!when!-clause equations remain active during the whole initialization phase.
+In case of a \lstinline!reinit(x, expr)! being active during initialization (due to being inside \lstinline!when initial()!) this is interpreted as adding \lstinline!x = expr! (the \lstinline!reinit!-equation) as an initial equation.
 
 \begin{nonnormative}
-If a \lstinline!when!-clause equation \lstinline!v = expr;! is not active during the initialization phase, the equation \lstinline!v = pre(v)! is added for
-initialization.  This follows from the mapping rule of \lstinline!when!-clause equations.  If the condition of the \lstinline!when!-clause contains \lstinline!initial()!,
+If a \lstinline!when!-clause equation \lstinline!v = expr;! is not active during the initialization phase, the equation \lstinline!v = pre(v)! is added for initialization.
+This follows from the mapping rule of \lstinline!when!-clause equations.
+If the condition of the \lstinline!when!-clause contains \lstinline!initial()!,
 but not in one of the specific forms, the \lstinline!when!-clause is not active during initialization: \lstinline!when not initial() then print("simulation started"); end when;!
 \end{nonnormative}
 
 The algorithmic statements within a \lstinline!when!-statement are active during initialization, if and only they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the \lstinline!when!-statement remain active during the whole initialization phase.
 
-An active \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly as for \lstinline!when!-clauses during simulation), but apart from that
-the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as
-\lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
+An active \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly as for \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 
 \begin{nonnormative}
 That means that any subsequent \lstinline!elsewhen initial()! has no effect,
@@ -759,8 +718,7 @@ similarly as \lstinline!when false then!.
 There is no special handling of inactive \lstinline!when!-statements during initialization, instead variables assigned in \lstinline!when!-statements are initialized using \lstinline!v := pre(v)! before the body of the algorithm (since they are discrete), see \cref{execution-of-an-algorithm-in-a-model}.
 \end{nonnormative}
 
-Further constraints, necessary to determine the initial values of all
-variables, can be defined in the following ways:
+Further constraints, necessary to determine the initial values of all variables, can be defined in the following ways:
 \begin{enumerate}
 \item
   As equations in an \lstinline!initial equation!\indexinline{initial equation} section or as assignments in an \lstinline!initial algorithm!\indexinline{initial algorithm} section.
@@ -773,7 +731,8 @@ variables, can be defined in the following ways:
   it can eliminate it (to avoid the introduction of many dummy variables \lstinline!pre(vc)!).
   \end{nonnormative}
 \item
-  Implicitly by using the \lstinline!start!-attribute for variables with \lstinline!fixed = true!.  With \lstinline!start! given by \lstinline!startExpression!:
+  Implicitly by using the \lstinline!start!-attribute for variables with \lstinline!fixed = true!.
+  With \lstinline!start! given by \lstinline!startExpression!:
   \begin{itemize}
   \item
     For a variable declared as \lstinline!constant! or \lstinline!parameter!, no equation is added to the initialization equations.
@@ -798,33 +757,29 @@ If a parameter has a modifier for the \lstinline!start!-attribute, does not have
 In this case a diagnostic message is recommended in a simulation model.
 
 \begin{nonnormative}
-This is used in libraries to give non-zero defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters
-that need to be set.
+This is used in libraries to give non-zero defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
 \end{nonnormative}
 
-All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e.\ there must be additional equations for them -- and
-the \lstinline!start!-value can be used as a guess-value during initialization.
+All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e.\ there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.
 
 \begin{nonnormative}
 In the case a parameter has both a binding equation and \lstinline!fixed = false! a diagnostics is recommended, but the parameter should be solved from the binding equation.
 
-Non-discrete-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization
-\lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
+Non-discrete-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
 
-Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!. If this is not the case for some variables
-\lstinline!vi!, \lstinline!pre(vi) := vi! must be set and an event iteration at the initial time must follow, so the model is re-evaluated, until this condition is fulfilled.
+Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!.
+If this is not the case for some variables \lstinline!vi!, \lstinline!pre(vi) := vi! must be set and an event iteration at the initial time must follow, so the model is re-evaluated, until this condition is fulfilled.
 
-A Modelica translator may first transform the continuous equations of a model, at least conceptually, to state space form.  This may require to differentiate equations for index
-reduction, i.e., additional equations and, in some cases, additional unknown variables are introduced.  This whole set of equations, together with the additional constraints
-defined above, should lead to an algebraic system of equations where the number of equations and the number of all variables (including \lstinline!der! and \lstinline!pre!
-variables) is equal.  Often, this is a nonlinear system of equations and therefore it may be necessary to provide appropriate guess values (i.e., \lstinline!start! values and
-\lstinline!fixed = false!) in order to compute a solution numerically.
+A Modelica translator may first transform the continuous equations of a model, at least conceptually, to state space form.
+This may require to differentiate equations for index reduction, i.e., additional equations and, in some cases, additional unknown variables are introduced.
+This whole set of equations, together with the additional constraints defined above, should lead to an algebraic system of equations where the number of equations and the number of all variables (including \lstinline!der! and \lstinline!pre! variables) is equal.
+Often, this is a nonlinear system of equations and therefore it may be necessary to provide appropriate guess values (i.e., \lstinline!start! values and \lstinline!fixed = false!) in order to compute a solution numerically.
 
-It may be difficult for a user to figure out how many initial equations have to be added, especially if the system has a higher index. A tool may add or remove initial equations
-automatically such that the resulting system is structurally nonsingular.  In these cases diagnostics are appropriate since the result is not unique and not necessarily what the user
-expects.  A missing initial value of a discrete-time variable which does not influence the simulation result, may be automatically set to the \lstinline!start! value or its default without
-informing the user.  For example, variables assigned in a \lstinline!when!-clause which are not accessed outside of the \lstinline!when!-clause and where \lstinline!pre! is not explicitly
-used on these variables, do not have an effect on the simulation.
+It may be difficult for a user to figure out how many initial equations have to be added, especially if the system has a higher index.
+A tool may add or remove initial equations automatically such that the resulting system is structurally nonsingular.
+In these cases diagnostics are appropriate since the result is not unique and not necessarily what the user expects.
+A missing initial value of a discrete-time variable which does not influence the simulation result, may be automatically set to the \lstinline!start! value or its default without informing the user.
+For example, variables assigned in a \lstinline!when!-clause which are not accessed outside of the \lstinline!when!-clause and where \lstinline!pre! is not explicitly used on these variables, do not have an effect on the simulation.
 \end{nonnormative}
 
 \begin{example}
@@ -897,13 +852,9 @@ pre(y) := y;
 \subsection{The Number of Equations Needed for Initialization}\label{the-number-of-equations-needed-for-initialization}
 
 \begin{nonnormative}
-In general, for the case of a pure (first order) ordinary
-differential equation (ODE) system with $n$ state variables and $m$ output
-variables, we will have $n+m$ unknowns in the simulation problem. The ODE
-initialization problem has $n$ additional unknowns corresponding to the
-derivative variables. At initialization of an ODE we will need to find
-the values of $2n+m$ variables, in contrast to just $n+m$ variables to be
-solved for during simulation.
+In general, for the case of a pure (first order) ordinary differential equation (ODE) system with $n$ state variables and $m$ output variables, we will have $n+m$ unknowns in the simulation problem.
+The ODE initialization problem has $n$ additional unknowns corresponding to the derivative variables.
+At initialization of an ODE we will need to find the values of $2n+m$ variables, in contrast to just $n+m$ variables to be solved for during simulation.
 \end{nonnormative}
 
 \begin{example}
@@ -914,21 +865,13 @@ der(x2) = f2(x2);
 y = x1+x2+u;
 \end{lstlisting}
 
-Here we have three variables with unknown values: two dynamic
-variables that also are state variables, \lstinline!x1! and \lstinline!x2!, i.e.,
-$n=2$, one output variable \lstinline!y!, i.e., $m=1$, and one input variable \lstinline!u! with
-known value. A consistent solution of the initial value problem
-providing initial values for \lstinline!x1!, \lstinline!x2!, \lstinline!der(x1)!,
-\lstinline!der(x2)!, and \lstinline!y! needs to be found. Two additional initial
-equations thus need to be provided to solve the initialization problem.
+Here we have three variables with unknown values: two dynamic variables that also are state variables, \lstinline!x1! and \lstinline!x2!, i.e., $n=2$, one output variable \lstinline!y!, i.e., $m=1$, and one input variable \lstinline!u! with known value.
+A consistent solution of the initial value problem providing initial values for \lstinline!x1!, \lstinline!x2!, \lstinline!der(x1)!, \lstinline!der(x2)!, and \lstinline!y! needs to be found.
+Two additional initial equations thus need to be provided to solve the initialization problem.
 
-Regarding DAEs, only that at most $n$ additional equations are
-needed to arrive at $2n+m$ equations in the initialization system. The
-reason is that in a higher index DAE problem the number of dynamic
-continuous-time state variables might be less than the number of state
-variables $n$. As noted in \cref{initialization-initial-equation-and-initial-algorithm} a tool may add/remove
-initial equations to fulfill this requirement, if appropriate
-diagnostics are given.
+Regarding DAEs, only that at most $n$ additional equations are needed to arrive at $2n+m$ equations in the initialization system.
+The reason is that in a higher index DAE problem the number of dynamic continuous-time state variables might be less than the number of state variables $n$.
+As noted in \cref{initialization-initial-equation-and-initial-algorithm} a tool may add/remove initial equations to fulfill this requirement, if appropriate diagnostics are given.
 \end{example}
 
 \subsection{Recommended selection of start values}\label{recommended-selection-of-start-values}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -99,7 +99,7 @@ for for-indices loop
 A \lstinline!for!-equation may optionally use several iterators (\lstinline[language=grammar]!for-indices!)\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
 \begin{lstlisting}[language=grammar]
 for-indices:
-   for-index {"," for-index}
+   for-index { "," for-index }
 
 for-index:
    IDENT [ in expression ]

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -45,13 +45,14 @@ The following kinds of equations may occur in equation sections. The
 syntax is defined as follows:
 \begin{lstlisting}[language=grammar]
 equation :
-( simple-expression "=" expression
-   | if-equation
-   | for-equation
-   | connect-clause
-   | when-equation
-   | component-reference function-call-args )
-   comment
+   ( simple-expression "=" expression
+     | if-equation
+     | for-equation
+     | connect-clause
+     | when-equation
+     | component-reference function-call-args
+   )
+   description
 \end{lstlisting}
 No statements are allowed in equation sections, including the assignment
 statement using the := operator.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -92,8 +92,8 @@ functions with several results in assignment statements.
 The syntax of a \lstinline!for!-equation\index{for@\robustinline{for}!equation}\index{loop@\robustinline{loop}!for-equation@\robustinline{for}-equation} is as follows:
 \begin{lstlisting}[language=grammar]
 for for-indices loop
-   { equation ";" }
-   end for ";"
+  { equation ";" }
+end for ";"
 \end{lstlisting}
 
 A \lstinline!for!-equation may optionally use several iterators (\lstinline[language=grammar]!for-indices!)\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
@@ -171,11 +171,12 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 The \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} have the following syntax:
 \begin{lstlisting}[language=grammar]
 if expression then
-   { equation ";" }
+  { equation ";" }
 { elseif expression then
-   { equation ";" }    }
+  { equation ";" }
+}
 [ else
-   { equation ";" }
+  { equation ";" }
 ]
 end if ";"
 \end{lstlisting}
@@ -199,9 +200,10 @@ although the number of unknowns remains the same.
 The \lstinline!when!-equations\index{when@\robustinline{when}!equation}\index{then@\robustinline{then}!when-equation@\robustinline{when}-equation}\index{elsewhen@\robustinline{elsewhen}!when-equation@\robustinline{when}-equation} have the following syntax:
 \begin{lstlisting}[language=grammar]
 when expression then
-   { equation ";" }
+  { equation ";" }
 { elsewhen expression then
-   { equation ";" } }
+  { equation ";" }
+}
 end when ";"
 \end{lstlisting}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -185,7 +185,7 @@ end for
 A \lstinline!for!-statement may optionally use several iterators (\lstinline!for-indices!), see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
 \begin{lstlisting}[language=grammar]
 for-indices:
-   for-index {"," for-index}
+   for-index { "," for-index }
 
 for-index:
    IDENT [ in  expression ]

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -64,10 +64,10 @@ statements of the algorithm section remain together.
 Example:
 \begin{lstlisting}[language=modelica]
 model Test // wrong Modelica model (has 4 equations for 2 unknowns)
-  Real x[2](start={-11, -22});
-algorithm // conceptually: x = {1,-22}
+  Real x[2](start = {-11, -22});
+algorithm // conceptually: x = {1, -22}
   x[1] := 1;
-algorithm // conceptually: x = {-11,2}
+algorithm // conceptually: x = {-11, 2}
   x[2] := 2;
 end Test;
 \end{lstlisting}
@@ -129,7 +129,6 @@ The resulting value is stored into the variable denoted by \lstinline[language=g
 The \lstinline!expression! must not have higher variability than the assigned component, see \cref{variability-of-expressions}.
 
 Assignment to array variables with subscripts is described in \cref{array-indexing}.
-
 
 \subsubsection{Assignments from Called Functions with Multiple Results}\label{assignments-from-called-functions-with-multiple-results}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -1,9 +1,7 @@
 \chapter{Statements and Algorithm Sections}\label{statements-and-algorithm-sections}
 
-Whereas equations are very well suited for physical modeling, there are
-situations where computations are more conveniently expressed as
-algorithms, i.e., sequences of statements. In this chapter we describe
-the algorithmic constructs that are available in Modelica.
+Whereas equations are very well suited for physical modeling, there are situations where computations are more conveniently expressed as algorithms, i.e., sequences of statements.
+In this chapter we describe the algorithmic constructs that are available in Modelica.
 
 Statements are imperative constructs allowed in algorithm sections.
 
@@ -30,11 +28,8 @@ initial equation sections.
 
 \subsection{Execution of an algorithm in a model}\label{execution-of-an-algorithm-in-a-model}
 
-An algorithm section is conceptually a code fragment that remains
-together and the statements of an algorithm section are executed in the
-order of appearance. Whenever an algorithm section is invoked, all
-variables appearing on the left hand side of the assignment operator
-\lstinline!:=! are initialized (at least conceptually):
+An algorithm section is conceptually a code fragment that remains together and the statements of an algorithm section are executed in the order of appearance.
+Whenever an algorithm section is invoked, all variables appearing on the left hand side of the assignment operator \lstinline!:=! are initialized (at least conceptually):
 \begin{itemize}
 \item
   A continuous-time variable is initialized with the value of its \lstinline!start!-attribute.
@@ -47,19 +42,12 @@ variables appearing on the left hand side of the assignment operator
 \end{itemize}
 
 \begin{nonnormative}
-Initialization is performed, in order that an algorithm section
-cannot introduce a ``memory'' (except in the case of discrete-time variables assigned in the algorithm), which could invalidate the assumptions of a
-numerical integration algorithm. Note, a Modelica tool may change the
-evaluation of an algorithm section, provided the result is identical to
-the case, as if the above conceptual processing is performed.
+Initialization is performed, in order that an algorithm section cannot introduce a ``memory'' (except in the case of discrete-time variables assigned in the algorithm), which could invalidate the assumptions of a numerical integration algorithm.
+Note, a Modelica tool may change the evaluation of an algorithm section, provided the result is identical to the case, as if the above conceptual processing is performed.
 
-An algorithm section is treated as an atomic vector-equation,
-which is sorted together with all other equations. For the sorting
-process (BLT), every algorithm section with N different left-hand side
-variables, is treated as an atomic N-dimensional vector-equation
-containing all variables appearing in the algorithm section. This
-guarantees that all N equations end up in an algebraic loop and the
-statements of the algorithm section remain together.
+An algorithm section is treated as an atomic vector-equation, which is sorted together with all other equations.
+For the sorting process (BLT), every algorithm section with N different left-hand side variables, is treated as an atomic N-dimensional vector-equation containing all variables appearing in the algorithm section.
+This guarantees that all N equations end up in an algebraic loop and the statements of the algorithm section remain together.
 
 Example:
 \begin{lstlisting}[language=modelica]
@@ -82,22 +70,17 @@ See \crefnameref{initialization-and-binding-equations-of-components-in-functions
 
 \section{Statements}\label{statements}
 
-Statements are imperative constructs allowed in algorithm sections. A
-flattened statement is identical to the corresponding nonflattened
-statement.
+Statements are imperative constructs allowed in algorithm sections.
+A flattened statement is identical to the corresponding nonflattened statement.
 
 Names in statements are found as follows:
 \begin{itemize}
 \item
-  If the name occurs inside an expression: it is first found among the
-  lexically enclosing reduction functions (see \cref{reduction-functions-and-operators}) in order
-  starting from the inner-most, and if not found it proceeds as if it
-  were outside an expression:
+  If the name occurs inside an expression: it is first found among the lexically enclosing reduction functions (see \cref{reduction-functions-and-operators}) in order starting from the inner-most, and if not found it proceeds as if it were outside an expression:
 \item
   Names in a statement are first found among the lexically enclosing \lstinline!for!-statements in order starting from the inner-most, and if not found:
 \item
-  Names in a statement shall be found by looking up in the partially
-  flattened enclosing class of the algorithm section.
+  Names in a statement shall be found by looking up in the partially flattened enclosing class of the algorithm section.
 \end{itemize}
 
 The syntax of statements is as follows:
@@ -151,21 +134,20 @@ The function \lstinline!f! called below has three results and two inputs:
 (a, b, c) := f(1.0, 2.0);
 (x[1], x[2], x[1]) := f(3, 4);
 \end{lstlisting}
-In the second example above \lstinline!x[1]! is assigned twice: first with the first output, and then with the third output.  For that case the following will give the same result:
+In the second example above \lstinline!x[1]! is assigned twice: first with the first output, and then with the third output.
+For that case the following will give the same result:
 \begin{lstlisting}[language=modelica]
 (, x[2], x[1]) := f(3,4);
 \end{lstlisting}
 \end{example}
 
-The syntax of an assignment statement with a call to a function with
-multiple results is as follows:
+The syntax of an assignment statement with a call to a function with multiple results is as follows:
 \begin{lstlisting}[language=grammar]
 "(" output-expression-list ")" ":=" component-reference function-call-args
 \end{lstlisting}
 
 \begin{nonnormative}
-Also see \cref{simple-equality-equations} regarding calling functions with
-multiple results within equations.
+Also see \cref{simple-equality-equations} regarding calling functions with multiple results within equations.
 \end{nonnormative}
 
 \subsubsection{Restrictions on assigned variables}\label{restrictions-on-assigned-variables}
@@ -203,7 +185,8 @@ for i in {1, 3, 6, 7} loop // i takes the values 1, 3, 6, 7
 for i in TwoEnums loop // i takes the values TwoEnums.one, TwoEnums.two
                        // for TwoEnums = enumeration(one, two)
 \end{lstlisting}
-The loop-variable may hide other variables as in the following example.  Using another name for the loop-variable is, however, strongly recommended.
+The loop-variable may hide other variables as in the following example.
+Using another name for the loop-variable is, however, strongly recommended.
 \begin{lstlisting}[language=modelica]
   constant Integer j = 4;
   Real x[j];
@@ -221,8 +204,7 @@ The dimension size of the array expression in the indexed position is used to de
 If it is used to subscript several expressions, their ranges must be identical.
 The \lstinline!IDENT! may also, inside a reduction expression, array constructor expression, \lstinline!for!-statement, or \lstinline!for!-equation, occur freely outside of subscript positions, but only as a reference to the variable \lstinline!IDENT!, and not for deducing ranges.
 
-The \lstinline!IDENT! may also be used as a subscript for an array in a component of an expandable connector
-but it is only seen as a reference to the variable \lstinline!IDENT! and cannot be used for deducing ranges.
+The \lstinline!IDENT! may also be used as a subscript for an array in a component of an expandable connector but it is only seen as a reference to the variable \lstinline!IDENT! and cannot be used for deducing ranges.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -349,12 +349,12 @@ The \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\
 \begin{lstlisting}[language=grammar]
 if expression then
   { statement ";" }
-  { elseif expression then
-    { statement ";" }
-  }
-  [ else
-    { statement ";" }
-  ]
+{ elseif expression then
+  { statement ";" }
+}
+[ else
+  { statement ";" }
+]
 end if;
 \end{lstlisting}
 
@@ -371,8 +371,9 @@ A \lstinline!when!-statement\index{when@\robustinline{when}!statement}\index{the
 \begin{lstlisting}[language=grammar]
 when expression then
   { statement ";" }
-  { elsewhen expression then
-  { statement ";" } }
+{ elsewhen expression then
+  { statement ";" }
+}
 end when
 \end{lstlisting}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -103,15 +103,17 @@ Names in statements are found as follows:
 The syntax of statements is as follows:
 \begin{lstlisting}[language=grammar]
 statement :
-  ( component-reference ( ":=" expression | function-call-args )
-    | "(" output-expression-list ")" ":=" component-reference function-call-args
-    | break
-    | return
-    | if-statement
-    | for-statement
-    | while-statement
-    | when-statement )
-  comment
+   ( component-reference ( ":=" expression | function-call-args )
+     | "(" output-expression-list ")" ":="
+       component-reference function-call-args
+     | break
+     | return
+     | if-statement
+     | for-statement
+     | while-statement
+     | when-statement
+   )
+   description
 \end{lstlisting}
 
 \subsection{Simple Assignment Statements}\label{simple-assignment-statements}

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -202,7 +202,7 @@ for i in 1 : 10 loop // i takes the values 1, 2, 3, $\ldots$, 10
 for r in 1.0 : 1.5 : 5.5 loop // r takes the values 1.0, 2.5, 4.0, 5.5
 for i in {1, 3, 6, 7} loop // i takes the values 1, 3, 6, 7
 for i in TwoEnums loop // i takes the values TwoEnums.one, TwoEnums.two
-        // for TwoEnums = enumeration(one, two)
+                       // for TwoEnums = enumeration(one, two)
 \end{lstlisting}
 The loop-variable may hide other variables as in the following example.  Using another name for the loop-variable is, however, strongly recommended.
 \begin{lstlisting}[language=modelica]
@@ -389,7 +389,7 @@ end when;
 \end{lstlisting}
 The statements inside the \lstinline!when!-statement are activated on the positive edge of any of the expressions \lstinline!x > 2!, \lstinline!sample(0, 2)!, or \lstinline!x < 5!:
 \begin{lstlisting}[language=modelica]
-when {x > 2, sample(0,2), x < 5} then
+when {x > 2, sample(0, 2), x < 5} then
   y1 := sin(x);
   y3 := 2*x + y1+y2;
 end when;

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -13,7 +13,7 @@ An \firstuse{algorithm section}\index{algorithm!section} is a part of a class de
 The formal syntax is as follows:
 \begin{lstlisting}[language=grammar]
 algorithm-section :
-   [ initial ] algorithm { statement ";" | annotation ";" }
+   [ initial ] algorithm { statement ";" }
 \end{lstlisting}
 
 Like an equation, an algorithm section relates variables, i.e., constrains the values that these variables can take simultaneously.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -317,7 +317,7 @@ for-index :
 
 while-statement :
    while expression loop
-   { statement ";" }
+     { statement ";" }
    end while
 
 when-equation :


### PR DESCRIPTION
This PR is primarily a mix of easy cleanup changes related to equations and statements, falling into three categories (see individual commits for details):
- Update outdated copies of grammar rules.
- Align how multi-line grammar rules are indented.
- Finish transition to sentence-based line breaks in two files.
