### PR TITLE
Cross reference multiple extends rule, and related cleanup

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -115,7 +115,10 @@ Equations that are mathematically equivalent but not syntactically equivalent ar
 \subsection{Multiple Inheritance}\label{multiple-inheritance}
 
 Multiple inheritance is possible since multiple \lstinline!extends!-clauses can be present in a class.
-As stated in \cref{the-inherited-contents-of-the-element}, it is illegal for one of these \lstinline!extends!-clauses to influence the lookup of another's (or its own) class name.
+
+\begin{nonnormative}
+As stated in \cref{the-inherited-contents-of-the-element}, it is illegal for an \lstinline!extends!-clause to influence the lookup of the class name of any \lstinline!extends!-clause in the same class definition.
+\end{nonnormative}
 
 \subsection{Inheritance of Protected and Public Elements}\label{inheritance-of-protected-and-public-elements}
 

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -98,7 +98,7 @@ function B
   extends A;
   input Real a;
 end B;
-// The inputs of B are "a, b" in that order; and the "input Real a;" is ignored.
+// The inputs of B are {a, b} in that order; the "input Real a;" is ignored.
 \end{lstlisting}
 \end{nonnormative}
 

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -115,6 +115,7 @@ Equations that are mathematically equivalent but not syntactically equivalent ar
 \subsection{Multiple Inheritance}\label{multiple-inheritance}
 
 Multiple inheritance is possible since multiple \lstinline!extends!-clauses can be present in a class.
+As stated in \cref{the-inherited-contents-of-the-element}, it is illegal for one of these \lstinline!extends!-clauses to influence the lookup of another's (or its own) class name.
 
 \subsection{Inheritance of Protected and Public Elements}\label{inheritance-of-protected-and-public-elements}
 

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -23,7 +23,7 @@ During flattening, the enclosing class of an element being flattened is
 a partially flattened class.
 
 \begin{nonnormative}
-For example, this means that a declaration can refer to a name inherited through an extends-clause.
+For example, this means that a declaration can refer to a name inherited through an \lstinline!extends!-clause.
 \end{nonnormative}
 
 \begin{example}
@@ -78,9 +78,10 @@ This lookup in each \emph{instance} scope is performed as follows:
 \item
   Among declared named elements (\lstinline!class-definition! and \lstinline!component-declaration!) of the class (including elements inherited from base classes).
 \item
-  Among the import names of qualified import-clauses in the \emph{instance} scope.  The import name of \lstinline!import A.B.C!; is \lstinline!C! and the import name of \lstinline!import D=A.B.C;! is \lstinline!D!.
+  Among the import names of qualified \lstinline!import!-clauses in the \emph{instance} scope.
+  The import name of \lstinline!import A.B.C!; is \lstinline!C! and the import name of \lstinline!import D=A.B.C;! is \lstinline!D!.
 \item
-  Among the public members of packages imported via unqualified import-clauses in the \emph{instance} scope.  It is an error if this step produces matches from several unqualified imports.
+  Among the public members of packages imported via unqualified \lstinline!import!-clauses in the \emph{instance} scope.  It is an error if this step produces matches from several unqualified imports.
 \end{itemize}
 
 The \lstinline!import!-clauses defined in inherited classes are ignored for the lookup, i.e.\ \lstinline!import!-clauses are not inherited.
@@ -112,7 +113,7 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
 \end{itemize}
 
 \begin{nonnormative}
-The temporary class flattening performed for composite names follow the same rules as class flattening of the base class in an extends-clause, local classes and the type in a \lstinline[language=grammar]!component-clause!, except that the environment is empty.
+The temporary class flattening performed for composite names follow the same rules as class flattening of the base class in an \lstinline!extends!-clause, local classes and the type in a \lstinline[language=grammar]!component-clause!, except that the environment is empty.
 See also \lstinline!MoistAir2! example in \cref{redeclaration} for further explanations regarding looking inside partial packages.
 \end{nonnormative}
 \begin{example}
@@ -140,7 +141,7 @@ For a name starting with dot, e.g.: \lstinline!.A! (or \lstinline!.A.B!, \lstinl
 \begin{itemize}
 \item
   The first identifier (\lstinline!A!) is looked up in the global scope.
-  This is possible even if the class is encapsulated\indexinline{encapsulated} and import-clauses are not used for this.
+  This is possible even if the class is encapsulated\indexinline{encapsulated} and \lstinline!import!-clauses are not used for this.
   If there does not exist a class \lstinline!A! in global scope this is an error.
 \item
   If the name is simple then the class \lstinline!A! is the result of lookup.
@@ -517,13 +518,10 @@ The \lstinline!extends!-clauses are not looked up, but empty \lstinline!extends!
 
 Classes of \lstinline!extends!-clauses of the current class are looked up in the instance tree, modifiers (including redeclarations) are merged, the contents of these classes are partially instantiated using the new modification environment, and are inserted into an \lstinline!extends!-clause node, which is an unnamed node in the current instance that only contains the inherited contents from that base class.
 
-The classes of extends-clauses are looked up before and after handling
-extends-clauses; and it is an error if those lookups generate different
-results.
+The classes of \lstinline!extends!-clauses are looked up before and after handling \lstinline!extends!-clauses; and it is an error if those lookups generate different results.
 
-At the end, the current instance is checked whether their children
-(including children of extends-clauses) with the same name are identical
-and only the first one of them is kept.  It is an error if they are not identical.
+At the end, the current instance is checked whether their children (including children of \lstinline!extends!-clauses) with the same name are identical and only the first one of them is kept.
+It is an error if they are not identical.
 
 \begin{nonnormative}
 Only keeping the first among the children with the same name is important for function arguments where the order matters.
@@ -645,7 +643,7 @@ is not instantiated yet (or only partially instantiated), it is instantiated in 
 \end{nonnormative}
 
 The flat equation system consists of a list of variables with dimensions, flattened equations and algorithms, and a list of called functions which are flattened separately.
-A flattened function consists of algorithm or external-clause and top-level variables (variables directly declared in the function or one of its base classes) -- which recursively can contain other variables; the list of non-top-level variables is not needed.
+A flattened function consists of an algorithm or \lstinline!external!-clause and top-level variables (variables directly declared in the function or one of its base classes) -- which recursively can contain other variables; the list of non-top-level variables is not needed.
 
 The instance tree is recursively walked through as follows for elements
 of the class (if necessary a partially instantiated component is first
@@ -698,8 +696,7 @@ instantiated):
 \item
   Instances of local classes are ignored.
 \item
-  The unnamed nodes corresponding to extends-clauses are recursively
-  handled.
+  The unnamed nodes corresponding to \lstinline!extends!-clauses are recursively handled.
 \item
   If there are function calls encountered during this process, the call
   is filled up with default arguments as defined in \cref{positional-or-named-input-arguments-of-functions}. These are

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -79,7 +79,7 @@ This lookup in each \emph{instance} scope is performed as follows:
   Among declared named elements (\lstinline!class-definition! and \lstinline!component-declaration!) of the class (including elements inherited from base classes).
 \item
   Among the import names of qualified \lstinline!import!-clauses in the \emph{instance} scope.
-  The import name of \lstinline!import A.B.C!; is \lstinline!C! and the import name of \lstinline!import D=A.B.C;! is \lstinline!D!.
+  The import name of \lstinline!import A.B.C!; is \lstinline!C! and the import name of \lstinline!import D = A.B.C;! is \lstinline!D!.
 \item
   Among the public members of packages imported via unqualified \lstinline!import!-clauses in the \emph{instance} scope.  It is an error if this step produces matches from several unqualified imports.
 \end{itemize}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -133,7 +133,8 @@ composition :
      | algorithm-section
    }
    [ external [ language-specification ]
-   [ external-function-call ] [ annotation-clause ] ";" ]
+     [ external-function-call ] [ annotation-clause ] ";"
+   ]
    [ annotation-clause ";" ]
 
 language-specification :


### PR DESCRIPTION
The core of this PR is fix an unreported problem of finding the rule that says that `extends`-clauses must not interfere.
