### PR TITLE
Clearly define discrete time variable

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -337,23 +337,23 @@ end HasCycles;
 
 \subsection{Component Variability Prefixes discrete, parameter, constant}\label{component-variability-prefixes-discrete-parameter-constant}
 
-The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! of a component declaration are called \firstuse{variability prefixes}\index{variability!prefix}\index{declared variability}\index{variability!declared|see{declared variability}} and define in which situation the variable values of a component are initialized (see \cref{events-and-synchronization} and \cref{initialization-initial-equation-and-initial-algorithm}) and when they are changed in transient analysis (= solution of initial value problem of the hybrid DAE):
+The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! of a component declaration are called \firstuse{variability prefixes}\index{variability!prefix}\index{component variability}\index{declared variability}\index{variability!declared|see{declared variability}} and define in which situation the variable values of a component are initialized (see \cref{events-and-synchronization} and \cref{initialization-initial-equation-and-initial-algorithm}) and when they are changed in transient analysis (= solution of initial value problem of the hybrid DAE):
 \begin{itemize}
 \item
   A variable \lstinline!vc! declared with \lstinline!constant!\indexinline{constant} prefix remains constant during transient analysis, with a value that is unaffected by the initialization problem.
-  This is called a \firstuse{constant}, or \firstuse{constant variable}\index{constant variable}\index{component variability!constant}.
+  This is called a \firstuse{constant}, or \firstuse{constant!variable}\index{constant!variable}\index{component variability!constant}.
 \item
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
-  This is called a \firstuse{parameter}, or \firstuse{parameter variable}\index{parameter variable}\index{component variability!parameter}.
+  This is called a \firstuse{parameter}, or \firstuse{parameter!variable}\index{parameter!variable}\index{component variability!parameter}.
 \item
-  A \emph{discrete-time} variable \lstinline!vd! is a variable that is discrete-valued (that is, not of \lstinline!Real! type) or assigned in a \lstinline!when!-clause.
+  A \emph{discrete-time}\index{discrete-time!variable}\index{component variability!discrete-time} variable \lstinline!vd! is a variable that is discrete-valued (that is, not of \lstinline!Real! type) or assigned in a \lstinline!when!-clause.
   The \lstinline!discrete!\indexinline{discrete} prefix may be used to clarify that a variable is discrete-time.
   It has a vanishing time derivative between events.
   Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events.
   It is not allowed to apply \lstinline!der! to discrete-time variables.
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
-  A \emph{continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
+  A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
   A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
   If there are any discontinuities the variable is not differentiable.
 \end{itemize}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -346,7 +346,7 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \item
   A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
   It has a vanishing time derivative between events.
-  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events, and it is not legal to apply \lstinline!der! to discrete-time variables as they are not continuous. 
+  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events, and it is not legal to apply \lstinline!der! to discrete-time variables as they are not continuous.
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -353,10 +353,10 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   It is not allowed to apply \lstinline!der! to discrete-time variables.
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
-  A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
+  A \firstuse{continuous-time variable}\index{continuous-time!variable}\index{component variability!continuous-time} is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
   A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (provided \lstinline!der(vn)! is allowed this can be expressed as \lstinline!der(vn) <> 0!) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
   It may also contain a combination of these effects.
-  Note that \lstinline!der(vn)! is not allowed if there are any discontinuities, see \cref{modelica:der}.
+  Regarding existence of \lstinline!der(vn)!, see \cref{modelica:der}.
 \end{itemize}
 
 Components declared as \lstinline!constant! shall have an associated declaration equation with a constant expression, if the constant is directly in the simulation model, or used in the simulation model.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -341,10 +341,10 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \begin{itemize}
 \item
   A variable \lstinline!vc! declared with \lstinline!constant!\indexinline{constant} prefix remains constant during transient analysis, with a value that is unaffected by the initialization problem.
-  This is a called a constant, or constant variable.
+  This is called a constant, or constant variable.
 \item
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
-  This is a called a parameter, or parameter variable.
+  This is called a parameter, or parameter variable.
 \item
   A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
   It has a vanishing time derivative between events.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -354,7 +354,7 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
-  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible - if \lstinline!der(vn)! is allowed) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
+  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn) <> 0! is possible, provided \lstinline!der(vn)! is defined) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
   It may also contain a combination of these effects.
   If there are any discontinuities the variable is not differentiable.
 \end{itemize}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -383,7 +383,7 @@ The variability of expressions and restrictions on variability for
 definition equations is given in \cref{variability-of-expressions}.
 
 \begin{nonnormative}
-Note that for expressions discrete-time expressions include parameter expressions, whereas discrete-time variables do not include parameter variables.
+Note that discrete-time \emph{expressions} include parameter expressions, whereas discrete-time \emph{variables} do not include parameter variables.
 This is consistent with restrictions on variability for expressions normally being upper limits.
 
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -341,14 +341,15 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \begin{itemize}
 \item
   A variable \lstinline!vc! declared with \lstinline!constant!\indexinline{constant} prefix remains constant during transient analysis, with a value that is unaffected by the initialization problem.
-  This is called a constant, or constant variable.
+  This is called a \firstuse{constant}, or \firstuse{constant variable}\index{constant variable}\index{component variability!constant}.
 \item
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
-  This is called a parameter, or parameter variable.
+  This is called a \firstuse{parameter}, or \firstuse{parameter variable}\index{parameter variable}\index{component variability!parameter}.
 \item
   A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
   It has a vanishing time derivative between events.
-  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events, and it is not legal to apply \lstinline!der! to discrete-time variables as they are not continuous.
+  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events.
+  It is not allowed to apply \lstinline!der! to discrete-time variables.
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -344,13 +344,14 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \item
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
 \item
-  A \emph{discrete-time} variable \lstinline!vd! has a vanishing time derivative between events.
+  A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
+  It has a vanishing time derivative between events.
   Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere,
   as the derivative is not even defined at the events, and it is not legal
-  to apply \lstinline!der! to discrete-time variables as they are not continuous. During transient analysis the variable
-  can only change its value at event
-  instants (see \cref{events-and-synchronization}).
+  to apply \lstinline!der! to discrete-time variables as they are not continuous. 
+  During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
+  A continuous-time variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
   A \emph{continuous-time} variable \lstinline!vn! may have a non-vanishing time
   derivative (\lstinline!der(vn)<>0! possible) and may also
   change its value discontinuously at any time during transient analysis

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -354,7 +354,7 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
-  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
+  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible - if \lstinline!der(vn)! is allowed) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
   If there are any discontinuities the variable is not differentiable.
 \end{itemize}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -341,8 +341,10 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \begin{itemize}
 \item
   A variable \lstinline!vc! declared with \lstinline!constant!\indexinline{constant} prefix remains constant during transient analysis, with a value that is unaffected by the initialization problem.
+  This is a called a constant, or constant variable.
 \item
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
+  This is a called a parameter, or parameter variable.
 \item
   A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
   It has a vanishing time derivative between events.
@@ -384,7 +386,11 @@ definition equations is given in \cref{variability-of-expressions}.
 
 \begin{nonnormative}
 Note that discrete-time \emph{expressions} include parameter expressions, whereas discrete-time \emph{variables} do not include parameter variables.
-This is consistent with restrictions on variability for expressions normally being upper limits.
+The reason can intuitively be explained as follows
+\begin{itemize}
+\item When discussing variables we also want to consider them as left-hand-side variables in assignments, and thus a lower variability would be a problem.
+\item When discussing expressions we only consider them as right-hand-side expressions in those assignment, and thus a lower variability can automatically be included; and additionally we have sub-expressions where lower variability is not an issue.
+\end{itemize}
 
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.
 The \lstinline!Real! variables declared with the prefix \lstinline!discrete! is a subset of the discrete-time \lstinline!Real! variables.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -346,7 +346,8 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
   This is called a \firstuse{parameter}, or \firstuse{parameter variable}\index{parameter variable}\index{component variability!parameter}.
 \item
-  A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
+  A \emph{discrete-time} variable \lstinline!vd! is a variable that is discrete-valued (that is, not of \lstinline!Real! type) or assigned in a \lstinline!when!-clause.
+  The \lstinline!discrete!\indexinline{discrete} prefix may be used to clarify that a variable is discrete-time.
   It has a vanishing time derivative between events.
   Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events.
   It is not allowed to apply \lstinline!der! to discrete-time variables.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -346,17 +346,12 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \item
   A \emph{discrete-time} variable \lstinline!vd! is a variable declared with the \lstinline!discrete!\indexinline{discrete} prefix, or a variable without any prefix that is not a continuous-time variable.
   It has a vanishing time derivative between events.
-  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere,
-  as the derivative is not even defined at the events, and it is not legal
-  to apply \lstinline!der! to discrete-time variables as they are not continuous. 
+  Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events, and it is not legal to apply \lstinline!der! to discrete-time variables as they are not continuous. 
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
-  A continuous-time variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
-  A \emph{continuous-time} variable \lstinline!vn! may have a non-vanishing time
-  derivative (\lstinline!der(vn)<>0! possible) and may also
-  change its value discontinuously at any time during transient analysis
-  (see \cref{events-and-synchronization}). If there are any discontinuities the variable is
-  not differentiable.
+  A \emph{continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
+  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
+  If there are any discontinuities the variable is not differentiable.
 \end{itemize}
 
 Components declared as \lstinline!constant! shall have an associated declaration equation with a constant expression, if the constant is directly in the simulation model, or used in the simulation model.
@@ -388,6 +383,9 @@ The variability of expressions and restrictions on variability for
 definition equations is given in \cref{variability-of-expressions}.
 
 \begin{nonnormative}
+Note that for expressions discrete-time expressions include parameter expressions, whereas discrete-time variables do not include parameter variables.
+This is consistent with restrictions on variability for expressions normally being upper limits.
+
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.
 The \lstinline!Real! variables declared with the prefix \lstinline!discrete! is a subset of the discrete-time \lstinline!Real! variables.
 For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in a \lstinline!when!-clause.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -355,6 +355,7 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
 \item
   A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
   A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn)<>0! possible - if \lstinline!der(vn)! is allowed) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
+  It may also contain a combination of these effects.
   If there are any discontinuities the variable is not differentiable.
 \end{itemize}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -346,7 +346,7 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   A variable \lstinline!vc! declared with the \lstinline!parameter!\indexinline{parameter} prefix remains constant during transient analysis, with a value determined by the initialization problem.
   This is called a \firstuse{parameter}, or \firstuse{parameter!variable}\index{parameter!variable}\index{component variability!parameter}.
 \item
-  A \emph{discrete-time}\index{discrete-time!variable}\index{component variability!discrete-time} variable \lstinline!vd! is a variable that is discrete-valued (that is, not of \lstinline!Real! type) or assigned in a \lstinline!when!-clause.
+  A \firstuse{discrete-time variable}\index{discrete-time!variable}\index{component variability!discrete-time} \lstinline!vd! is a variable that is discrete-valued (that is, not of \lstinline!Real! type) or assigned in a \lstinline!when!-clause.
   The \lstinline!discrete!\indexinline{discrete} prefix may be used to clarify that a variable is discrete-time.
   It has a vanishing time derivative between events.
   Note that this is not the same as saying that \lstinline!der(vd)=0! almost everywhere, as the derivative is not even defined at the events.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -354,9 +354,9 @@ The prefixes \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant! o
   During transient analysis the variable can only change its value at event instants (see \cref{events-and-synchronization}).
 \item
   A \emph{continuous-time}\index{continuous-time!variable}\index{component variability!continuous-time} variable is a \lstinline!Real! variable without any prefix that is not assigned in a \lstinline!when!-clause.
-  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (\lstinline!der(vn) <> 0! is possible, provided \lstinline!der(vn)! is defined) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
+  A continuous-time variable \lstinline!vn! may have a non-vanishing time derivative (provided \lstinline!der(vn)! is allowed this can be expressed as \lstinline!der(vn) <> 0!) and may also change its value discontinuously at any time during transient analysis (see \cref{events-and-synchronization}).
   It may also contain a combination of these effects.
-  If there are any discontinuities the variable is not differentiable.
+  Note that \lstinline!der(vn)! is not allowed if there are any discontinuities, see \cref{modelica:der}.
 \end{itemize}
 
 Components declared as \lstinline!constant! shall have an associated declaration equation with a constant expression, if the constant is directly in the simulation model, or used in the simulation model.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -718,7 +718,7 @@ similarly as \lstinline!when false then!.
 There is no special handling of inactive \lstinline!when!-statements during initialization, instead variables assigned in \lstinline!when!-statements are initialized using \lstinline!v := pre(v)! before the body of the algorithm (since they are discrete), see \cref{execution-of-an-algorithm-in-a-model}.
 \end{nonnormative}
 
-Further constraints, necessary to determine the initial values of all variables (depending on the variability of the variable, see \cref{component-variability-prefixes-discrete-parameter-constant} for definitions), can be defined in the following ways:
+Further constraints, necessary to determine the initial values of all variables (depending on the component variability, see \cref{component-variability-prefixes-discrete-parameter-constant} for definitions), can be defined in the following ways:
 \begin{enumerate}
 \item
   As equations in an \lstinline!initial equation!\indexinline{initial equation} section or as assignments in an \lstinline!initial algorithm!\indexinline{initial algorithm} section.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -718,7 +718,7 @@ similarly as \lstinline!when false then!.
 There is no special handling of inactive \lstinline!when!-statements during initialization, instead variables assigned in \lstinline!when!-statements are initialized using \lstinline!v := pre(v)! before the body of the algorithm (since they are discrete), see \cref{execution-of-an-algorithm-in-a-model}.
 \end{nonnormative}
 
-Further constraints, necessary to determine the initial values of all variables, can be defined in the following ways:
+Further constraints, necessary to determine the initial values of all variables (depending on the variability see \cref{component-variability-prefixes-discrete-parameter-constant} for definitions), can be defined in the following ways:
 \begin{enumerate}
 \item
   As equations in an \lstinline!initial equation!\indexinline{initial equation} section or as assignments in an \lstinline!initial algorithm!\indexinline{initial algorithm} section.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -725,7 +725,7 @@ Further constraints, necessary to determine the initial values of all variables,
   The equations and assignments in these initial sections are purely algebraic, stating constraints between the variables at the initial time instant.
   It is not allowed to use \lstinline!when!-clauses in these sections.
 \item
-  For a non-discrete-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
+  For a continuous-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!pre(vc) = vc! is added to the initialization equations.
   \begin{nonnormative}
   If \lstinline!pre(vc)! is not present in the flattened model, a tool may choose not to introduce this equation, or if it was introduced
   it can eliminate it (to avoid the introduction of many dummy variables \lstinline!pre(vc)!).
@@ -739,7 +739,7 @@ Further constraints, necessary to determine the initial values of all variables,
   \item
     For a discrete-time variable \lstinline!vd!, the equation \lstinline!pre(vd) = startExpression! is added to the initialization equations.
   \item
-    For a non-discrete-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!vc = startExpression! is added to the initialization equations.
+    For a continuous-time \lstinline!Real! variable \lstinline!vc!, the equation \lstinline!vc = startExpression! is added to the initialization equations.
   \end{itemize}
 \end{enumerate}
 
@@ -765,7 +765,7 @@ All variables declared as \lstinline!parameter! having \lstinline!fixed = false!
 \begin{nonnormative}
 In the case a parameter has both a binding equation and \lstinline!fixed = false! a diagnostics is recommended, but the parameter should be solved from the binding equation.
 
-Non-discrete-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
+Continuous-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
 
 Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!.
 If this is not the case for some variables \lstinline!vi!, \lstinline!pre(vi) := vi! must be set and an event iteration at the initial time must follow, so the model is re-evaluated, until this condition is fulfilled.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -718,7 +718,7 @@ similarly as \lstinline!when false then!.
 There is no special handling of inactive \lstinline!when!-statements during initialization, instead variables assigned in \lstinline!when!-statements are initialized using \lstinline!v := pre(v)! before the body of the algorithm (since they are discrete), see \cref{execution-of-an-algorithm-in-a-model}.
 \end{nonnormative}
 
-Further constraints, necessary to determine the initial values of all variables (depending on the variability see \cref{component-variability-prefixes-discrete-parameter-constant} for definitions), can be defined in the following ways:
+Further constraints, necessary to determine the initial values of all variables (depending on the variability of the variable, see \cref{component-variability-prefixes-discrete-parameter-constant} for definitions), can be defined in the following ways:
 \begin{enumerate}
 \item
   As equations in an \lstinline!initial equation!\indexinline{initial equation} section or as assignments in an \lstinline!initial algorithm!\indexinline{initial algorithm} section.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1386,7 +1386,7 @@ end Test;
 
 \subsection{Constant Expressions}\label{constant-expressions}
 
-Constant expressions\index{constant expression}\index{expression variability!constant} are:
+Constant expressions\index{constant!expression}\index{expression variability!constant} are:
 \begin{itemize}
 \item
   \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, \lstinline!String!, and \lstinline!enumeration! literals.
@@ -1407,7 +1407,7 @@ Constant expressions\index{constant expression}\index{expression variability!con
 
 \subsection{Parameter Expressions}\label{parameter-expressions}
 
-Parameter expressions\index{parameter expression}\index{expression variability!parameter}\index{parametric variability|see{parameter expression}} are:
+Parameter expressions\index{parameter!expression}\index{expression variability!parameter}\index{parametric variability|see{parameter, expression}} are:
 \begin{itemize}
 \item
   Constant expressions.
@@ -1437,7 +1437,7 @@ Parameter expressions\index{parameter expression}\index{expression variability!p
 
 \subsection{Discrete-Time Expressions}\label{discrete-time-expressions}
 
-Discrete-time expressions\index{discrete-time expression}\index{expression variability!discrete-time} are:
+Discrete-time expressions\index{discrete-time!expression}\index{expression variability!discrete-time} are:
 \begin{itemize}
 \item
   Parameter expressions.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1475,7 +1475,7 @@ This is called the \firstuse{discrete-valued equation variability rule}\index{di
 For a scalar equation, the rule follows from the observation that a discrete-valued equation does not provide sufficient information to solve for a continuous-valued variable.
 Hence, and according to the perfect matching rule (see \cref{synchronous-data-flow-principle-and-single-assignment-rule}), such an equation must be used to solve for a discrete-valued variable.
 By the interpretation of \eqref{eq:dae-discrete-valued} in \cref{modelica-dae-representation}, it follows that one of \lstinline!expr1! and \lstinline!expr2! must be the variable, and the other expression its solution.
-Since a discrete-valued variable is a discrete-time variable, it follows that its solution on the other side of the equation must have at most discrete-time variability.
+Since a discrete-valued variable is a discrete-time expression, it follows that its solution on the other side of the equation must have at most discrete-time variability.
 That is, both sides of the equation are discrete-time expressions.
 
 For example, this rule shows that (outside of a \lstinline!when!-clause) \lstinline!noEvent! cannot be applied to either side of a \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String!, or \lstinline!enumeration! equation, as this would result in a non-discrete-time expression.


### PR DESCRIPTION
As discovered in #2961 discrete-time variables aren't that clearly defined, and I thought that required a separate PR.


I'm fully aware that there is an unfortunate forward-reference from discrete-time to continuous-time.

The reason is that defining discrete-time by listing all the different cases would require an enumerated list, and it would still be complicated to understand, whereas I find this clearer.

There is, however, one radical way to avoid forward-references in the list: reorder the bullet points starting with continuous-time.

The largest pro _and_ con is that it is turns the list of variability for expressions upside down; that makes it clear that they are different - but is also confusing.