### PR TITLE
Avoid just a '0' in \lstinline when generating HTML

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -793,8 +793,8 @@ end Record;
 The array dimension $n$ of \lstinline!residue! shall be a constant \lstinline!Integer! expression that can be evaluated during translation, with $n \geq 0$.
 The \lstinline!equalityConstraint! expresses the equality between the two type instances \lstinline!T1! and \lstinline!T2! or the record instances \lstinline!R1! and \lstinline!R2!, respectively, as the $n$ non-redundant equation residuals returned in \lstinline!residue!.
 That is, the set of $n$ non-redundant equations stating that \lstinline!R1 = R2! is given by the equation (%
-% Just a '0' doesn't work in \lstinline as reported in:
-% - https://github.com/brucemiller/LaTeXML/issues/1651
+% Just a '0' doesn't work in \lstinline as reported in (closed as fixed on 2020-09-07):
+% - https://github.com/brucemiller/LaTeXML/issues/1651 -- fixed on 'master'
 \ifpdf
 \lstinline!0!
 \else

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -792,7 +792,15 @@ end Record;
 \end{lstlisting}
 The array dimension $n$ of \lstinline!residue! shall be a constant \lstinline!Integer! expression that can be evaluated during translation, with $n \geq 0$.
 The \lstinline!equalityConstraint! expresses the equality between the two type instances \lstinline!T1! and \lstinline!T2! or the record instances \lstinline!R1! and \lstinline!R2!, respectively, as the $n$ non-redundant equation residuals returned in \lstinline!residue!.
-That is, the set of $n$ non-redundant equations stating that \lstinline!R1 = R2! is given by the equation (\lstinline!0! represents a vector of zeros of appropriate size):
+That is, the set of $n$ non-redundant equations stating that \lstinline!R1 = R2! is given by the equation (%
+% Just a '0' doesn't work in \lstinline as reported in:
+% - https://github.com/brucemiller/LaTeXML/issues/1651
+\ifpdf
+\lstinline!0!
+\else
+0
+\fi
+represents a vector of zeros of appropriate size):
 \begin{lstlisting}[language=modelica]
   Record R1, R2;
 equation

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -153,7 +153,15 @@ but can be converted to a floating point number.
 
 \subsection{Integer Literals}\label{integer-literals}
 
-Literals of type \lstinline!Integer! are sequences of decimal digits, e.g.\ as in the integer numbers \lstinline!33!, \lstinline!0!, \lstinline!100!, \lstinline!30030044!.
+Literals of type \lstinline!Integer! are sequences of decimal digits, e.g.\ as in the integer numbers \lstinline!33!,
+% Just a '0' doesn't work in \lstinline as reported in:
+% - https://github.com/brucemiller/LaTeXML/issues/1651
+\ifpdf
+\lstinline!0!%
+\else
+0%
+\fi
+, \lstinline!100!, \lstinline!30030044!.
 The range of supported \lstinline!Integer! literals shall be at least large enough to represent the largest positive \lstinline!IntegerType! value, see \cref{integer-type}.
 
 \begin{nonnormative}

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -154,8 +154,8 @@ but can be converted to a floating point number.
 \subsection{Integer Literals}\label{integer-literals}
 
 Literals of type \lstinline!Integer! are sequences of decimal digits, e.g.\ as in the integer numbers \lstinline!33!,
-% Just a '0' doesn't work in \lstinline as reported in:
-% - https://github.com/brucemiller/LaTeXML/issues/1651
+% Just a '0' doesn't work in \lstinline as reported in (closed as fixed on 2020-09-07):
+% - https://github.com/brucemiller/LaTeXML/issues/1651 -- fixed on 'master'
 \ifpdf
 \lstinline!0!%
 \else


### PR DESCRIPTION
Fixes #2991.  Actually, it's more of a temporary workaround and we'll have to return this once we've switched to a future version of LaTeXML where the upstream issue has been fixed.