### PR TITLE
Tick off "Investigate need for 'final'"

### DIFF
--- a/RationaleMCP/0031/ReadMe.md
+++ b/RationaleMCP/0031/ReadMe.md
@@ -57,7 +57,7 @@ These are subtopics that are considered necessary to resolve for a first version
 - [x] Allowing array subscripting on general expressions. [Design in progress](https://github.com/modelica/ModelicaSpecification/pull/2540/commits/b5eab9d5edcab8766a79637292be6a1e68b2bacc#diff-069d28cf3b6b78debdcada80b99b6c0b), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2540)
 - [ ] Handling of parameters treated as constants.
 - [ ] Get rid of `protected`.
-- [ ] Investigate need for `final`.
+- [x] Investigate need for `final`.
 - [ ] Origin of modifications (for start value prioritization).
 - [ ] Get rid of `false` as default for `fixed`.
 - [ ] Restricted rules for use of `start` attribute for parameter initialization.


### PR DESCRIPTION
According to [today's web meeting](https://github.com/modelica/ModelicaSpecification/pull/2748#issuecomment-914116630), I'm setting up this PR for documenting why we're ticking off this item on the road map.

All occurrences of `final` in the https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2Beliminate-final/RationaleMCP/0031/grammar.md, and things that have made this possible include:
- Flat Modelica describes a state of affairs where all checking for modifications that violate `final` should have taken place during reduction from full Modelica to Flat Modelica.
- One thing one cannot check during reduction to Flat Modelica is that a final modification of `start` in full Modelica won't be modified at the time of simulation initialization.  For this we needed something else in Flat Modelica, and we now instead have the new _parameter equations_ that allows expressing that something _can_ be modified at the time of initialization.  That is, to express that the original Full Modelica modification of `start` was final, one should simply use a normal initial equation instead of a parameter equation.

Borrowing examples from https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2Beliminate-final/RationaleMCP/0031/differences.md:
```
  Real 'x';
  parameter equation guess('x') = 1.5; /* Coming from Full Modelica non-final modification of 'start'. */
  Real 'y';
initial equation
  guess('y') - 1.5 = 0; /* Coming from Full Modelica final modification of 'start'. */
```
