### PR TITLE
Tick off "Restricted rules for use of 'start' attribute for parameter initialization"

### DIFF
--- a/RationaleMCP/0031/ReadMe.md
+++ b/RationaleMCP/0031/ReadMe.md
@@ -60,7 +60,7 @@ These are subtopics that are considered necessary to resolve for a first version
 - [ ] Investigate need for `final`.
 - [ ] Origin of modifications (for start value prioritization).
 - [ ] Get rid of `false` as default for `fixed`.
-- [ ] Restricted rules for use of `start` attribute for parameter initialization.
+- [x] Restricted rules for use of `start` attribute for parameter initialization.
 - [x] Get rid of record member variability prefixes `constant` and `parameter`. [Design in progress](https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2Brecord-member-variability/RationaleMCP/0031/differences.md#variability-in-record-member-declaration), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2694) (Not gone, but restricted.)
 - [x] Simplify modifications. [Design in progress](https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2BModifications/RationaleMCP/0031/differences.md#simplify-modifications), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2558) (Remaining parts covered by other items.)
 - [ ] Simplify value modifications. [Design in progress](https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2Bvalue-modification/RationaleMCP/0031/differences.md#Value-modification), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2747)

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -398,7 +398,7 @@ The handling of guess values needed to solve parameters from nonlinear equations
 
 Instead of controlling the guess values for the variable `x` via its `start` attribute as in full Modelica, Flat Modelica makes use of an implicitly declared parameter `guess('x')`.  This is called the _guess value parameter_ for `'x'`, and has the same type as `x`.
 
-Since the declaration of `guess('x')` is implicit, a declaration equation cannot be provided in the same was as for a declared parameter.  Instead, a special form of _parameter equation_ is used, where the parameter being solved must appear on the left hand side, and the equation shall be solved with causality so that the right hand side can be overridden during initialization (that is, after translation).  In the grammar, it is an new alternative in _generic-element_ (**TODO:** Transfer to grammar.md.):
+Since the declaration of `guess('x')` is implicit, a declaration equation cannot be provided in the same was as for a declared parameter.  Instead, a special form of _parameter equation_ is used, where the parameter being solved must appear on the left hand side, and the equation shall be solved with causality so that the right hand side can be overridden during initialization (that is, after translation).  In the grammar, it is an new alternative in _generic-element_:
 
 > _generic-element_ → ~~_import-clause_ | _extends-clause_ |~~ _normal-element_ | _parameter-equation_
 

--- a/RationaleMCP/0031/grammar.md
+++ b/RationaleMCP/0031/grammar.md
@@ -144,7 +144,7 @@ end _F;
 
 > _external-function-call_ → ( _component-reference_ **=** )? _IDENT_ `[(]` _expression-list_? `[)]`
 
-> _generic-element_ → ~~_import-clause_ | _extends-clause_ |~~ _normal-element_
+> _generic-element_ → ~~_import-clause_ | _extends-clause_ |~~ _normal-element_ | _parameter-equation_
 
 > _normal-element_ →\
 > &emsp; ~~**redeclare**?~~\
@@ -154,6 +154,10 @@ end _F;
 > &emsp; | _component-clause_\
 > &emsp; ~~| **replaceable** ( _class-definition_ | _component-clause_ ) ( _constraining-clause_ _comment_ )?~~\
 > &emsp; )
+
+> _parameter-equation_ → **parameter** **equation** _guess-value_ **=** _expression_ _comment_
+
+> _guess-value_ → **guess** `[(]` _component-reference_ `[)]`
 
 > ~~_import-clause_ →\
 > &emsp; **import**\


### PR DESCRIPTION
According to [yesterday's web meeting](https://github.com/modelica/ModelicaSpecification/pull/2748#issuecomment-914116630), I'm setting up this PR for documenting why we're ticking off this item on the road map.  The PR also contains a forgotten transfer of grammar between documents.

The use of the `start` attribute for parameter initialization is now restricted by means of the following:
- The `p.start` in full Modelica is replaced by the implicitly declared guess value parameter `guess('p')` in Flat Modelica.
- The parameter `'p'` and `guess('p')` are not allowed to end up in the same equation system.
- A parameter equation for `guess('p')` will constrain the equation systems to ensure that a guess value may be provided during initialization.
- The full Modelica rule about fixed parameters with `start` but no declaration equation is not carried over to Flat Modelica; the tool reducing full Modelica to Flat Modelica will be responsible for notifying the user and turning this into valid Flat Modelica parameter initialization.

As an example of the last item, the full Modelica
```
parameter Real p(start = 4.2);
```
should result in a warning during reduction to Flat Modelica, where it could look like this:
```
parameter Real 'p' = 4.2;
```
