### PR TITLE
Tick off roadmap item "Get rid of 'false' as default for 'fixed'"

### DIFF
--- a/RationaleMCP/0031/ReadMe.md
+++ b/RationaleMCP/0031/ReadMe.md
@@ -59,7 +59,7 @@ These are subtopics that are considered necessary to resolve for a first version
 - [ ] Get rid of `protected`.
 - [ ] Investigate need for `final`.
 - [ ] Origin of modifications (for start value prioritization).
-- [ ] Get rid of `false` as default for `fixed`.
+- [x] Get rid of `false` as default for `fixed`.
 - [ ] Restricted rules for use of `start` attribute for parameter initialization.
 - [x] Get rid of record member variability prefixes `constant` and `parameter`. [Design in progress](https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2Brecord-member-variability/RationaleMCP/0031/differences.md#variability-in-record-member-declaration), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2694) (Not gone, but restricted.)
 - [x] Simplify modifications. [Design in progress](https://github.com/modelica/ModelicaSpecification/blob/MCP/0031%2BModifications/RationaleMCP/0031/differences.md#simplify-modifications), [PR with discussion](https://github.com/modelica/ModelicaSpecification/pull/2558) (Remaining parts covered by other items.)


### PR DESCRIPTION
According to [yesterday's web meeting](https://github.com/modelica/ModelicaSpecification/pull/2748#issuecomment-914116630), I'm setting up this PR for documenting why we're ticking off this item on the road map.

As I remember it, the purpose of the roadmap item was to see if anything could be done to remove the need to have to add `fixed = true` each time one simply wants to unconditionally set the start value of a variable.  Instead of discussion to which degree this really is a problem in full Modelica, let's take a look at what it is like in the current design for Flat Modelica:
- The full Modelica `fixed` attribute does not have a corresponding actual built-in attribute in Flat Modelica.
- Flat Modelica supports `fixed = true` as a syntactic sugar, but there is no need to use this if you stick with the core language.
- Instead of `fixed = true`, Flat Modelica uses explicit initial equations to tie the start value of a variable to the corresponding guess value parameter.

Actually, while it can be argued that we have technically gotten rid of the default for `fixed` by not keeping `fixed` as a built-in attribute at all, it should be noted that the underlying purpose of the roadmap item has not been addressed by the current Flat Modelica design.

What I find more important, on the other hand, is that a main design goal for the design of Flat Modelica initialization is to have explicit equations rather than an intricate play with various attributes and flags.  Addressing the underlying purpose of the roadmap item would likely be a change away from this design goal (we want the connection between a variable and its guess value parameter to be explicit in the form of an equation, even if it can be tedious to write down the equation by hand), and in view of this it would also seem right to tick it off as a way of saying that we've considered it, but deliberately chose to ignore it in the end.
