### PR TITLE
Remove non-compensation sentence.

### DIFF
--- a/chapters/copyright.tex
+++ b/chapters/copyright.tex
@@ -6,4 +6,3 @@ No patent liability is assumed with respect to the use of information contained 
 While every precaution has been taken in the preparation of this document no responsibility for errors or omissions is assumed.
 
 The contributors to this and to previous versions of this document are listed in \cref{modelica-revision-history}.
-All contributors worked voluntarily and without compensation.


### PR DESCRIPTION
Remove dubious statements about people not being compensated, which was added in Spec 3.0 v47 described as 'Slighly improved the “copyright” notice'
@henrikt-ma