### PR TITLE
Sentence-based line breaking in operatorsandexpressions.tex

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -4,44 +4,37 @@ The lexical units are combined to form even larger building blocks such as \firs
 For example, they can be built from operators, function references, components, or component references (referring to components) and literals.
 Each expression has a type and a variability.
 
-This chapter describes the evaluation rules for expressions, the concept
-of expression variability, built-in mathematical operators and
-functions, and the built-in special Modelica operators with function
-syntax.
+This chapter describes the evaluation rules for expressions, the concept of expression variability, built-in mathematical operators and functions, and the built-in special Modelica operators with function syntax.
 
-Expressions can contain variables and constants, which have types,
-predefined or user defined. The predefined built-in types of Modelica
-are \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, \lstinline!String!, and enumeration types which are
-presented in more detail in \cref{predefined-types-and-classes}.
+Expressions can contain variables and constants, which have types, predefined or user defined.
+The predefined built-in types of Modelica are \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, \lstinline!String!, and enumeration types which are presented in more detail in \cref{predefined-types-and-classes}.
 
 \section{Expressions}\label{expressions}
 
-Modelica equations, assignments and declaration equations contain
-expressions.
+Modelica equations, assignments and declaration equations contain expressions.
 
-Expressions can contain basic operations, \lstinline!+!, \lstinline!-!, \lstinline!*!, \lstinline!/!, \lstinline!^!, etc.\ with
-normal precedence as defined in the Table in \cref{operator-precedence-and-associativity} and the grammar
-in \cref{modelica-concrete-syntax}. The semantics of the operations is defined for both
-scalar and array arguments in \cref{scalar-vector-matrix-and-array-operator-functions}.
+Expressions can contain basic operations, \lstinline!+!, \lstinline!-!, \lstinline!*!, \lstinline!/!, \lstinline!^!, etc.\ with normal precedence as defined in \cref{tab:operator-precedence} in \cref{operator-precedence-and-associativity} and the grammar in \cref{modelica-concrete-syntax}.
+The semantics of the operations is defined for both scalar and array arguments in \cref{scalar-vector-matrix-and-array-operator-functions}.
 
-It is also possible to define functions and call them in a normal
-fashion. The function call syntax for both positional and named
-arguments is described in \cref{positional-or-named-input-arguments-of-functions} and for vectorized calls in
-\cref{initialization-and-binding-equations-of-components-in-functions}. The built-in array functions are given in \cref{array-dimension-lower-and-upper-index-bounds}
-and other built-in operators in \cref{built-in-intrinsic-operators-with-function-syntax}.
+It is also possible to define functions and call them in a normal fashion.
+The function call syntax for both positional and named arguments is described in \cref{positional-or-named-input-arguments-of-functions} and for vectorized calls in \cref{initialization-and-binding-equations-of-components-in-functions}.
+The built-in array functions are given in \cref{array-dimension-lower-and-upper-index-bounds} and other built-in operators in \cref{built-in-intrinsic-operators-with-function-syntax}.
 
 \section{Operator Precedence and Associativity}\label{operator-precedence-and-associativity}
 
-Operator precedence determines the order of evaluation of operators in
-an expression. An operator with higher precedence is evaluated before an
-operator with lower precedence in the same expression.
+Operator precedence determines the order of evaluation of operators in an expression.
+An operator with higher precedence is evaluated before an operator with lower precedence in the same expression.
 
 The following table presents all the expression operators in order of precedence.
 \begin{table}[H]
 % Beware that the array construction operator, normally expressed as \lstinline!{ }! needs escaped braces inside \caption.
 % This isn't handled correctly by LaTeXML, as reported here:
 % - https://github.com/brucemiller/LaTeXML/issues/1377
-\caption{Operators in order of precedence from highest to lowest, as derived from the Modelica grammar in \cref{modelica-concrete-syntax}.  All operators are binary except the postfix operators and those shown as unary together with \emph{expr}, the conditional operator, the array construction operator \lstinline!\{ \}! and concatenation operator \lstinline![ ]!, and the array range constructor which is either binary or ternary.  Operators with the same precedence occur at the same table row.}\label{tab:operator-precedence}
+\caption{%
+Operators in order of precedence from highest to lowest, as derived from the Modelica grammar in \cref{modelica-concrete-syntax}.
+All operators are binary except the postfix operators and those shown as unary together with \emph{expr}, the conditional operator, the array construction operator \lstinline!\{ \}! and concatenation operator \lstinline![ ]!, and the array range constructor which is either binary or ternary.
+Operators with the same precedence occur at the same table row.
+}\label{tab:operator-precedence}
 \begin{center}
 \begin{tabular}{l l l}
 \hline
@@ -92,8 +85,7 @@ All binary expression operators are left associative, except exponentiation whic
 The array range operator is non-associative.
 
 \begin{nonnormative}
-The unary minus and plus in Modelica is slightly different than in Mathematica\footnote{\emph{Mathematica} is a registered trademark of Wolfram Research Inc.} and in MATLAB\footnote{\emph{MATLAB} is
-a registered trademark of MathWorks Inc.}, since the following expressions are illegal (whereas in Mathematica and in MATLAB these are valid expressions):
+The unary minus and plus in Modelica is slightly different than in Mathematica\footnote{\emph{Mathematica} is a registered trademark of Wolfram Research Inc.} and in MATLAB\footnote{\emph{MATLAB} is a registered trademark of MathWorks Inc.}, since the following expressions are illegal (whereas in Mathematica and in MATLAB these are valid expressions):
 \begin{lstlisting}[language=modelica]
 2*-2  // = -4 in Mathematica/MATLAB; is illegal in Modelica
 --2   // = 2 in Mathematica/MATLAB; is illegal in Modelica
@@ -113,9 +105,8 @@ a:b:c:d:e:f:g // Not legal, and scalar arguments gives no legal interpretation.
 A tool is free to solve equations, reorder expressions and to not evaluate expressions if their values do not influence the result (e.g.\ short-circuit evaluation of \lstinline!Boolean! expressions).
 \lstinline!if!-statements and \lstinline!if!-expressions guarantee that their branches are only evaluated if the appropriate condition is true, but relational operators generating state or time events will during continuous integration have the value from the most recent event.
 
-If a numeric operation overflows the result is undefined. For literals
-it is recommended to automatically convert the number to another type
-with greater precision.
+If a numeric operation overflows the result is undefined.
+For literals it is recommended to automatically convert the number to another type with greater precision.
 
 \subsection{Example: Guarding Expressions Against Incorrect Evaluation}\label{example-guarding-expressions-against-incorrect-evaluation}
 
@@ -126,14 +117,14 @@ If one wants to guard an expression against incorrect evaluation, it should be g
   Boolean b;
   Integer I;
 equation
-  b=(I>=1 and I<=n) and v[I]; // Invalid
-  b=if (I>=1 and I<=n) then v[I] else false; // Correct
+  b = (I >= 1 and I <= n) and v[I];                // Invalid
+  b = if (I >= 1 and I <= n) then v[I] else false; // Correct
 \end{lstlisting}
 
 To guard square against square root of negative number use \lstinline!noEvent!:
 \begin{lstlisting}[language=modelica]
-der(h)=if h>0 then -c*sqrt(h) else 0; // Incorrect
-der(h)=if noEvent(h>0) then -c*sqrt(h) else 0; // Correct
+der(h) = if h > 0 then -c * sqrt(h) else 0;          // Incorrect
+der(h) = if noEvent(h > 0) then -c * sqrt(h) else 0; // Correct
 \end{lstlisting}
 \end{example}
 
@@ -154,11 +145,9 @@ Modelica supports five binary arithmetic operators that operate on any numerical
 \end{tabular}
 \end{center}
 
-Some of these operators can also be applied to a combination of a scalar
-type and an array type, see \cref{scalar-vector-matrix-and-array-operator-functions}.
+Some of these operators can also be applied to a combination of a scalar type and an array type, see \cref{scalar-vector-matrix-and-array-operator-functions}.
 
-The syntax of these operators is defined by the following rules from the
-Modelica grammar:
+The syntax of these operators is defined by the following rules from the Modelica grammar:
 \begin{lstlisting}[language=grammar]
 arithmetic-expression :
    [ add-operator ] term { add-operator term }
@@ -194,9 +183,7 @@ Modelica supports the standard set of relational and logical operators, all of w
 \end{tabular}
 \end{center}
 
-A single equals sign \lstinline!=! is never used in relational expressions, only in
-equations (\cref{equations}, \cref{equality-and-assignment}) and in function calls using named
-parameter passing (\cref{positional-or-named-input-arguments-of-functions}).
+A single equals sign \lstinline!=! is never used in relational expressions, only in equations (\cref{equations}, \cref{equality-and-assignment}) and in function calls using named parameter passing (\cref{positional-or-named-input-arguments-of-functions}).
 
 The following logical operators are defined:
 \begin{center}
@@ -232,24 +219,19 @@ relational-operator :
 The following holds for relational operators:
 \begin{itemize}
 \item
-  Relational operators \lstinline!<!, \lstinline!<=!,\lstinline!>!,
-\lstinline!>=!, \lstinline!==!, \lstinline!<>!, are only defined for
-  scalar operands of simple types. The result is \lstinline!Boolean! and is true or
-  false if the relation is fulfilled or not, respectively.
+  Relational operators \lstinline!<!, \lstinline!<=!,\lstinline!>!, \lstinline!>=!, \lstinline!==!, \lstinline!<>!, are only defined for scalar operands of simple types.
+  The result is \lstinline!Boolean! and is true or false if the relation is fulfilled or not, respectively.
 \item
-  For operands of type \lstinline!String!, \lstinline!str1 $\mathit{op}$ str2! is for each relational
-  operator, $\mathit{op}$, defined in terms of the C function \lstinline[language=C]!strcmp! as
-  \lstinline[language=C]!strcmp(str1, str2) $\mathit{op}$ 0!.
+  For operands of type \lstinline!String!, \lstinline!str1 $\mathit{op}$ str2! is for each relational operator, $\mathit{op}$, defined in terms of the C function \lstinline[language=C]!strcmp! as \lstinline[language=C]!strcmp(str1, str2) $\mathit{op}$ 0!.
 \item
   For operands of type \lstinline!Boolean!, \lstinline!false < true!.
 \item
-  For operands of enumeration types, the order is given by the order of
-  declaration of the enumeration literals.
+  For operands of enumeration types, the order is given by the order of declaration of the enumeration literals.
 \item
-  In relations of the form \lstinline!v1 == v2 or v1 <> v2!,
-  \lstinline!v1! or \lstinline!v2! shall, unless used in a function, not be a subtype of \lstinline!Real!.
+  In relations of the form \lstinline!v1 == v2 or v1 <> v2!, \lstinline!v1! or \lstinline!v2! shall, unless used in a function, not be a subtype of \lstinline!Real!.
   \begin{nonnormative}
-  The reason for this rule is that relations with \lstinline!Real! arguments are transformed to state events (see Events, \cref{events-and-synchronization}) and this transformation becomes unnecessarily complicated for the \lstinline!==! and \lstinline!<>! relational operators (e.g.\ two crossing functions instead of one crossing function needed, epsilon strategy needed even at event instants).  Furthermore, testing on equality of \lstinline!Real! variables is questionable on machines where the number length in registers is different to number length in main memory.
+  The reason for this rule is that relations with \lstinline!Real! arguments are transformed to state events (see \cref{events-and-synchronization}) and this transformation becomes unnecessarily complicated for the \lstinline!==! and \lstinline!<>! relational operators (e.g.\ two crossing functions instead of one crossing function needed, epsilon strategy needed even at event instants).
+  Furthermore, testing on equality of \lstinline!Real! variables is questionable on machines where the number length in registers is different to number length in main memory.
   \end{nonnormative}
 \item
   Relational operators can generate events, see \cref{discrete-time-expressions}.
@@ -257,14 +239,12 @@ The following holds for relational operators:
 
 \section{Miscellaneous Operators and Variables}\label{miscellaneous-operators-and-variables}
 
-Modelica also contains a few built-in operators which are not standard
-arithmetic, relational, or logical operators. These are described below,
-including \lstinline!time!, which is a built-in variable, not an operator.
+Modelica also contains a few built-in operators which are not standard arithmetic, relational, or logical operators.
+These are described below, including \lstinline!time!, which is a built-in variable, not an operator.
 
 \subsection{String Concatenation}\label{string-concatenation}
 
-Concatenation of strings (see the Modelica grammar) is denoted by the \lstinline!+!
-operator in Modelica.
+Concatenation of strings (see the Modelica grammar) is denoted by the \lstinline!+! operator in Modelica.
 
 \begin{example}
 \lstinline!"a" + "b"! becomes \lstinline!"ab"!.
@@ -288,8 +268,8 @@ An expression
 \begin{lstlisting}[language=modelica]
 if expression1 then expression2 else expression3
 \end{lstlisting}%
-\index{if@\robustinline{if}!expression}\index{then@\robustinline{then}!if-expression@\robustinline{if}-expression}\index{else@\robustinline{else}!if-expression@\robustinline{if}-expression}
-is one example of \lstinline!if!-expression. First \lstinline!expression1!, which must be \lstinline!Boolean! expression, is evaluated.
+\index{if@\robustinline{if}!expression}\index{then@\robustinline{then}!if-expression@\robustinline{if}-expression}\index{else@\robustinline{else}!if-expression@\robustinline{if}-expression} is one example of \lstinline!if!-expression.
+First \lstinline!expression1!, which must be \lstinline!Boolean! expression, is evaluated.
 If \lstinline!expression1! is true \lstinline!expression2! is evaluated and is the value of the \lstinline!if!-expression, else \lstinline!expression3! is evaluated and is the value of the \lstinline!if!-expression.
 The two expressions, \lstinline!expression2! and \lstinline!expression3!, must be type compatible expressions (\cref{type-compatible-expressions}) giving the type of the \lstinline!if!-expression.
 The \lstinline!if!-expressions with \lstinline!elseif!\index{elseif@\robustinline{elseif}!if-expression} are defined by replacing \lstinline!elseif! by \lstinline!else if!.
@@ -302,29 +282,25 @@ For short-circuit evaluation see \cref{evaluation-order}.
 \begin{example}
 \begin{lstlisting}[language=modelica]
 Integer i;
-Integer sign_of_i1=if i<0 then -1 elseif i==0 then 0 else 1;
-Integer sign_of_i2=if i<0 then -1 else if i==0 then 0 else 1;
+Integer sign_of_i1 = if i < 0 then -1 elseif i == 0 then 0 else 1;
+Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 \end{lstlisting}
 \end{example}
 
 \subsection{Member Access Operator}\label{member-access-operator}
 
-It is possible to access members of a class instance using dot notation,
-i.e., the \lstinline!.! operator.
+It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
 
 \begin{example}
-\lstinline!R1.R! for accessing the resistance component \lstinline!R!
-of resistor \lstinline!R1!. Another use of dot notation: local classes
-which are members of a class can of course also be accessed using dot
-notation on the name of the class, not on instances of the class.
+\lstinline!R1.R! for accessing the resistance component \lstinline!R! of resistor \lstinline!R1!.
+Another use of dot notation: local classes which are members of a class can of course also be accessed using dot notation on the name of the class, not on instances of the class.
 \end{example}
 
 \subsection{Built-in Variable time}\label{built-in-variable-time}
 
 All declared variables are functions of the independent variable \lstinline!time!.
-The variable \lstinline!time! is a built-in variable available in all models and
-blocks, which is treated as an input variable. It is implicitly defined
-as:
+The variable \lstinline!time! is a built-in variable available in all models and blocks, which is treated as an input variable.
+It is implicitly defined as:
 \begin{lstlisting}[language=modelica]
 input Real time (final quantity = "Time",
                  final unit = "s");
@@ -344,34 +320,25 @@ end SineSource;
 
 \section{Built-in Intrinsic Operators with Function Syntax}\label{built-in-intrinsic-operators-with-function-syntax}
 
-Certain built-in operators of Modelica have the same syntax as a
-function call. However, they do not behave as a mathematical function,
-because the result depends not only on the input arguments but also on
-the status of the simulation.
+Certain built-in operators of Modelica have the same syntax as a function call.
+However, they do not behave as a mathematical function, because the result depends not only on the input arguments but also on the status of the simulation.
 
-There are also built-in functions that depend only on the input
-argument, but also may trigger events in addition to returning a value.
-Intrinsic means that they are defined at the Modelica language level,
-not in the Modelica library. The following built-in intrinsic
-operators/functions are available:
+There are also built-in functions that depend only on the input argument, but also may trigger events in addition to returning a value.
+Intrinsic means that they are defined at the Modelica language level, not in the Modelica library.
+The following built-in intrinsic operators/functions are available:
 \begin{itemize}
 \item
-  Mathematical functions and conversion functions, see \cref{numeric-functions-and-conversion-functions}
-  below.
+  Mathematical functions and conversion functions, see \cref{numeric-functions-and-conversion-functions} below.
 \item
-  Derivative and special purpose operators with function syntax, see
-  \cref{derivative-and-special-purpose-operators-with-function-syntax} below.
+  Derivative and special purpose operators with function syntax, see \cref{derivative-and-special-purpose-operators-with-function-syntax} below.
 \item
   Event-related operators with function syntax, see \cref{event-related-operators-with-function-syntax} below.
 \item
   Array operators/functions, see \cref{array-dimension-lower-and-upper-index-bounds}.
 \end{itemize}
 
-Note that when the specification references a function having the name
-of a built-in function it references the built-in function, not a
-user-defined function having the same name, see also \cref{built-in-functions}. With
-exception of the built-in \lstinline!String! operator, all operators in this section
-can only be called with positional arguments.
+Note that when the specification references a function having the name of a built-in function it references the built-in function, not a user-defined function having the same name, see also \cref{built-in-functions}.
+With exception of the built-in \lstinline!String! operator, all operators in this section can only be called with positional arguments.
 
 \subsection{Numeric Functions and Conversion Functions}\label{numeric-functions-and-conversion-functions}
 
@@ -401,7 +368,8 @@ Additional non-event generating mathematical functions are described in \cref{bu
 abs($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Expands into \lstinline!noEvent(if $v$ >= 0 then $v$ else -$v$)!.  Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
+Expands into \lstinline!noEvent(if $v$ >= 0 then $v$ else -$v$)!.
+Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
 \end{semantics}
 \end{functiondefinition}
 
@@ -410,7 +378,8 @@ Expands into \lstinline!noEvent(if $v$ >= 0 then $v$ else -$v$)!.  Argument $v$ 
 sign($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Expands into \lstinline!noEvent(if $v$ > 0 then 1 else if $v$ < 0 then -1 else 0)!.  Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
+Expands into \lstinline!noEvent(if $v$ > 0 then 1 else if $v$ < 0 then -1 else 0)!.
+Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
 \end{semantics}
 \end{functiondefinition}
 
@@ -419,7 +388,8 @@ Expands into \lstinline!noEvent(if $v$ > 0 then 1 else if $v$ < 0 then -1 else 0
 sqrt($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Square root of $v$ if $v \geq 0$, otherwise an error occurs.  Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
+Square root of $v$ if $v \geq 0$, otherwise an error occurs.
+Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
 \end{semantics}
 \end{functiondefinition}
 
@@ -438,9 +408,11 @@ See also \cref{type-conversion-of-enumeration-values-to-string-or-integer}.
 EnumTypeName($i$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-For any enumeration type \lstinline!EnumTypeName!, returns the enumeration value \lstinline!EnumTypeName.e! such that $\text{\lstinline!Integer(EnumTypeName.e)!} = i$.  Refer to the definition of \lstinline!Integer! above.
+For any enumeration type \lstinline!EnumTypeName!, returns the enumeration value \lstinline!EnumTypeName.e! such that $\text{\lstinline!Integer(EnumTypeName.e)!} = i$.
+Refer to the definition of \lstinline!Integer! above.
 
-It is an error to attempt to convert values of $i$ that do not correspond to values of the enumeration type.  See also \cref{type-conversion-of-integer-to-enumeration-values}.
+It is an error to attempt to convert values of $i$ that do not correspond to values of the enumeration type.
+See also \cref{type-conversion-of-integer-to-enumeration-values}.
 \end{semantics}
 \end{operatordefinition*}
 
@@ -448,17 +420,21 @@ It is an error to attempt to convert values of $i$ that do not correspond to val
 \begin{synopsis}\begin{lstlisting}
 String($b$, <options>)
 String($i$, <options>)
-String($r$, significantDigits=$d$, <options>)
-String($r$, format=$s$)
+String($r$, significantDigits = $d$, <options>)
+String($r$, format = $s$)
 String($e$, <options>)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Convert a scalar non-\lstinline!String! expression to a \lstinline!String! representation.  The first argument may be a \lstinline!Boolean! $b$, an \lstinline!Integer! $i$, a \lstinline!Real! $r$ or an enumeration value $e$ (\cref{type-conversion-of-enumeration-values-to-string-or-integer}).  The other arguments must use named arguments.  For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
+Convert a scalar non-\lstinline!String! expression to a \lstinline!String! representation.
+The first argument may be a \lstinline!Boolean! $b$, an \lstinline!Integer! $i$, a \lstinline!Real! $r$ or an enumeration value $e$ (\cref{type-conversion-of-enumeration-values-to-string-or-integer}).
+The other arguments must use named arguments.
+For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
 
 The optional \lstinline!<options>! are:
 \begin{itemize}
 \item
-  \lstinline!Integer minimumLength = 0!: Minimum length of the resulting string.  If necessary, the blank character is used to fill up unused space.
+  \lstinline!Integer minimumLength = 0!: Minimum length of the resulting string.
+  If necessary, the blank character is used to fill up unused space.
 \item
   \lstinline!Boolean leftJustified = true!: If true, the converted result is left justified in the string; if false it is right justified in the string.
 \item
@@ -480,7 +456,10 @@ The \lstinline!format! string corresponding to \lstinline!<options>! is:
   \lstinline!(if leftJustified then "-" else "") + String(minimumLength) + "d"!
 \end{itemize}
 
-Form of the \lstinline!format! string:  According to ANSI-C the format string specifies one conversion specifier (excluding the leading \%), shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.  For all numeric values the format specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.  For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' format specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
+Form of the \lstinline!format! string:
+According to ANSI-C the format string specifies one conversion specifier (excluding the leading \%), shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
+For all numeric values the format specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
+For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' format specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 \end{semantics}
@@ -506,10 +485,12 @@ The operators listed below trigger events if used outside of a \lstinline!when!-
 \end{tabular}
 \end{center}
 
-These expression for \lstinline!div!, \lstinline!ceil!, \lstinline!floor!, and \lstinline!integer! are event generating expression.  The event generating expression for \lstinline!mod(x,y)! is \lstinline!floor(x/y)!, and for \lstinline!rem(x,y)! it is \lstinline!div(x,y)! -- i.e.\ events are not generated when \lstinline!mod! or \lstinline!rem! changes continuously in an interval, but when they change discontinuously from one interval to the next.
+These expression for \lstinline!div!, \lstinline!ceil!, \lstinline!floor!, and \lstinline!integer! are event generating expression.
+The event generating expression for \lstinline!mod(x,y)! is \lstinline!floor(x/y)!, and for \lstinline!rem(x,y)! it is \lstinline!div(x,y)! -- i.e.\ events are not generated when \lstinline!mod! or \lstinline!rem! changes continuously in an interval, but when they change discontinuously from one interval to the next.
 
 \begin{nonnormative}
-If this is not desired, the \lstinline!noEvent! operator can be applied to them.  E.g.\ \lstinline!noEvent(integer(v))!.
+If this is not desired, the \lstinline!noEvent! operator can be applied to them.
+E.g., \lstinline!noEvent(integer(v))!.
 \end{nonnormative}
 
 \begin{operatordefinition}[div]
@@ -521,7 +502,8 @@ Algebraic quotient $x / y$ with any fractional part discarded (also known as tru
 \begin{nonnormative}
 This is defined for \lstinline!/! in C99; in C89 the result for negative numbers is implementation-defined, so the standard function \lstinline[language=C]!div! must be used.
 \end{nonnormative}
-Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.  If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
+Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
+If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \end{semantics}
 \end{operatordefinition}
 
@@ -530,9 +512,12 @@ Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.  I
 mod($x$, $y$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Integer modulus of $x / y$, i.e. \lstinline!mod($x$, $y$) = $x$ - floor($x$ / $y$) * $y$!.  Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.  If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
+Integer modulus of $x / y$, i.e., \lstinline!mod($x$, $y$) = $x$ - floor($x$ / $y$) * $y$!.
+Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
+If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.  Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
+Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -542,9 +527,12 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 rem($x$, $y$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Integer remainder of $x / y$, such that \lstinline!div($x$, $y$) * $y$ + rem($x$, $y$) = $x$!.  Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.  If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
+Integer remainder of $x / y$, such that \lstinline!div($x$, $y$) * $y$ + rem($x$, $y$) = $x$!.
+Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
+If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.  Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
+Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -554,7 +542,8 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 ceil($x$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Smallest integer not less than $x$.  Result and argument shall have type \lstinline!Real!.
+Smallest integer not less than $x$.
+Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
@@ -566,7 +555,8 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 floor($x$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Largest integer not greater than $x$.  Result and argument shall have type \lstinline!Real!.
+Largest integer not greater than $x$.
+Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
@@ -578,7 +568,9 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 integer($x$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Largest integer not greater than $x$.  The argument shall have type \lstinline!Real!.  The result has type \lstinline!Integer!.
+Largest integer not greater than $x$.
+The argument shall have type \lstinline!Real!.
+The result has type \lstinline!Integer!.
 \begin{nonnormative}
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
@@ -587,7 +579,8 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 
 \subsection{Elementary Mathematical Functions}\label{built-in-mathematical-functions-and-external-built-in-functions}
 
-The functions listed below are elementary mathematical functions.  Tools are expected to utilize well known properties of these functions (derivatives, inverses, etc) for symbolic processing of expressions and equations.
+The functions listed below are elementary mathematical functions.
+Tools are expected to utilize well known properties of these functions (derivatives, inverses, etc) for symbolic processing of expressions and equations.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -622,7 +615,8 @@ End user oriented information about the elementary mathematical functions can be
 atan2($y$, $x$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Principal value of the arc tangent of $y/x$, using the signs of the two arguments to determine the quadrant of the result.  The result $\varphi$ is in the interval $\left[-\pi,\, \pi\right]$ and satisfies:
+Principal value of the arc tangent of $y/x$, using the signs of the two arguments to determine the quadrant of the result.
+The result $\varphi$ is in the interval $\left[-\pi,\, \pi\right]$ and satisfies:
 \begin{equation*}
 \begin{aligned}
 \abs{(x,\, y)}\, \cos(\varphi) &= x\\
@@ -704,7 +698,7 @@ For further details, see \cref{cardinality-deprecated}.
 
 \begin{operatordefinition}[homotopy]
 \begin{synopsis}\begin{lstlisting}
-homotopy(actual=$\mathit{actual}$, simplified=$\mathit{simplified}$)
+homotopy(actual = $\mathit{actual}$, simplified = $\mathit{simplified}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 The scalar expressions $\mathit{actual}$ and $\mathit{simplified}$ are subtypes of \lstinline!Real!.
@@ -762,10 +756,10 @@ For further details, see \cref{stream-operator-actualstream}.
 \begin{operatordefinition}[spatialDistribution]
 \begin{synopsis}\begin{lstlisting}
 spatialDistribution(
-  in0=$\mathit{in0}$, in1=$\mathit{in1}$, x=$x$,
-  positiveVelocity=$\ldots$,
-  initialPoints=$\ldots$,
-  initialValues=$\ldots$)
+  in0 = $\mathit{in0}$, in1 = $\mathit{in1}$, x = $x$,
+  positiveVelocity = $\ldots$,
+  initialPoints = $\ldots$,
+  initialValues = $\ldots$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \lstinline!spatialDistribution! allows approximation of variable-speed transport of properties.
@@ -1005,9 +999,9 @@ protected
   Real Goff2;
 equation
   off = s < 0;
-  Goff2 = homotopy(actual=Goff, simplified=Goff_flat);
-  u = s*(if off then 1 else Ron2) + Vknee;
-  i = s*(if off then Goff2 else 1 ) + Goff2*Vknee;
+  Goff2 = homotopy(actual = Goff, simplified = Goff_flat);
+  u = s * (if off then 1 else Ron2) + Vknee;
+  i = s * (if off then Goff2 else 1 ) + Goff2*Vknee;
   $\ldots$
 end IdealDiode;
 \end{lstlisting}
@@ -1021,7 +1015,7 @@ model ConstantVoltageSource
   extends Modelica.Electrical.Analog.Interfaces.OnePort;
   parameter Modelica.Units.SI.Voltage V;
 equation
-  v = homotopy(actual=V, simplified=0.0);
+  v = homotopy(actual = V, simplified = 0.0);
 end ConstantVoltageSource;
 \end{lstlisting}
 \end{example}
@@ -1041,7 +1035,7 @@ model PressureLoss
 equation
   $\ldots$
   m_flow = homotopy(actual = turbulentFlow_dp(dp, rho, lambda),
-  simplified = dp/dp_nominal*m_flow_nominal);
+                    simplified = dp/dp_nominal*m_flow_nominal);
   $\ldots$
 end PressureLoss;
 \end{lstlisting}
@@ -1067,7 +1061,7 @@ and you can solve the two equations to give
 \begin{equation*}
 x = \frac{\lambda+(\lambda-1)x_0}{2\lambda-1}
 \end{equation*}
-which has the correct value of $x_0$ at $\lambda = 0$ and of 1 at $\lambda= 1$, but unfortunately has a singularity at $\lambda = 0.5 $.
+which has the correct value of $x_0$ at $\lambda = 0$ and of 1 at $\lambda = 1$, but unfortunately has a singularity at $\lambda = 0.5$.
 \end{example}
 
 
@@ -1150,8 +1144,7 @@ package MyLib
   end Controller;
 end MyLib;
 \end{lstlisting}
-If \lstinline!MyLib.Vehicle! is simulated, the call of \lstinline!getInstanceName()!
-returns \lstinline!"Vehicle.engine.controller"!.
+If \lstinline!MyLib.Vehicle! is simulated, the call of \lstinline!getInstanceName()! returns \lstinline!"Vehicle.engine.controller"!.
 \end{example}
 
 If this function is not called inside a model or block (e.g.\ the function is called in a function or in a constant of a package), the return value is not specified.
@@ -1162,7 +1155,8 @@ The simulation result should not depend on the return value of this function.
 
 \subsection{Event-Related Operators with Function Syntax}\label{event-related-operators-with-function-syntax}
 
-The operators listed below are event-related operators with function syntax.  The operators \lstinline!noEvent!, \lstinline!pre!, \lstinline!edge!, and \lstinline!change!, are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
+The operators listed below are event-related operators with function syntax.
+The operators \lstinline!noEvent!, \lstinline!pre!, \lstinline!edge!, and \lstinline!change!, are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -1211,7 +1205,9 @@ Hereby, \lstinline!terminal()! ensures an event at the end of successful simulat
 noEvent($\mathit{expr}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-\lstinline!Real! elementary relations within $\mathit{expr}$ are taken literally, i.e., no state or time event is triggered.  No zero crossing functions shall be used to monitor any of the normally event-generating subexpressions inside $\mathit{expr}$.  See also \crefnameref{modelica:smooth} and \cref{events-and-synchronization}.
+\lstinline!Real! elementary relations within $\mathit{expr}$ are taken literally, i.e., no state or time event is triggered.
+No zero crossing functions shall be used to monitor any of the normally event-generating subexpressions inside $\mathit{expr}$.
+See also \crefnameref{modelica:smooth} and \cref{events-and-synchronization}.
 \end{semantics}
 \end{operatordefinition}
 
@@ -1220,9 +1216,13 @@ noEvent($\mathit{expr}$)
 smooth($p$, $\mathit{expr}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-If $p \geq 0$ \lstinline!smooth($p$, $\mathit{expr}$)! returns $\mathit{expr}$ and states that $\mathit{expr}$ is $p$ times continuously differentiable, i.e.: $\mathit{expr}$ is continuous in all \lstinline!Real! variables appearing in the expression and all partial derivatives with respect to all appearing real variables exist and are continuous up to order $p$.  The argument $p$ should be a scalar \lstinline!Integer! parameter expression.  The only allowed types for $\mathit{expr}$ in \lstinline!smooth! are: \lstinline!Real! expressions, arrays of allowed expressions, and records containing only components of allowed expressions.
+If $p \geq 0$ \lstinline!smooth($p$, $\mathit{expr}$)! returns $\mathit{expr}$ and states that $\mathit{expr}$ is $p$ times continuously differentiable, i.e.: $\mathit{expr}$ is continuous in all \lstinline!Real! variables appearing in the expression and all partial derivatives with respect to all appearing real variables exist and are continuous up to order $p$.
+The argument $p$ should be a scalar \lstinline!Integer! parameter expression.
+The only allowed types for $\mathit{expr}$ in \lstinline!smooth! are: \lstinline!Real! expressions, arrays of allowed expressions, and records containing only components of allowed expressions.
 
-\lstinline!smooth! should be used instead of \lstinline!noEvent! in order to avoid events for efficiency reasons.  A tool is free to not generate events for expressions inside \lstinline!smooth!. However, \lstinline!smooth! does not guarantee that no events will be generated, and thus it can be necessary to use \lstinline!noEvent! inside \lstinline!smooth!.
+\lstinline!smooth! should be used instead of \lstinline!noEvent! in order to avoid events for efficiency reasons.
+A tool is free to not generate events for expressions inside \lstinline!smooth!.
+However, \lstinline!smooth! does not guarantee that no events will be generated, and thus it can be necessary to use \lstinline!noEvent! inside \lstinline!smooth!.
 
 \begin{nonnormative}
 Note that \lstinline!smooth! does not guarantee a smooth output if any of the occurring variables change discontinuously.
@@ -1235,7 +1235,8 @@ Note that \lstinline!smooth! does not guarantee a smooth output if any of the oc
 equation
   x = if time < 1 then 2 else time - 2;
   z = smooth(0, if time < 0 then 0 else time);
-  y = smooth(1, noEvent(if x < 0 then 0 else sqrt(x) * x)); // noEvent is necessary.
+  y = smooth(1,
+        noEvent(if x < 0 then 0 else sqrt(x) * x)); // Needs noEvent.
 \end{lstlisting}
 \end{example}
 \end{semantics}
@@ -1246,7 +1247,10 @@ equation
 sample($\mathit{start}$, $\mathit{interval}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Returns \lstinline!true! and triggers time events at time instants $\mathit{start} + i \cdot \mathit{interval}$ for $i = 0,\, 1\, \ldots$, and is only true during the first event iteration at those times.  At event iterations after the first one at each event and during continuous integration the operator always returns \lstinline!false!.  The starting time $\mathit{start}$ and the sample interval $\mathit{interval}$ must be parameter expressions and need to be a subtype of \lstinline!Real! or \lstinline!Integer!.  The sample interval $\mathit{interval}$ must be a positive number.
+Returns \lstinline!true! and triggers time events at time instants $\mathit{start} + i \cdot \mathit{interval}$ for $i = 0,\, 1\, \ldots$, and is only true during the first event iteration at those times.
+At event iterations after the first one at each event and during continuous integration the operator always returns \lstinline!false!.
+The starting time $\mathit{start}$ and the sample interval $\mathit{interval}$ must be parameter expressions and need to be a subtype of \lstinline!Real! or \lstinline!Integer!.
+The sample interval $\mathit{interval}$ must be a positive number.
 \end{semantics}
 \end{operatordefinition*}
 
@@ -1265,7 +1269,10 @@ This can be applied to continuous-time variables in \lstinline!when!-clauses, se
 \end{nonnormative}
 The first value of \lstinline!pre($y$)! is determined in the initialization phase.
 
-A new event is triggered if there is at least for one variable \lstinline!v! such that \lstinline!pre(v) <> v! after the active model equations are evaluated at an event instant.  In this case the model is at once reevaluated.  This evaluation sequence is called \emph{event iteration}.  The integration is restarted once \lstinline!pre(v) == v! for all \lstinline!v! appearing inside \lstinline!pre($\ldots$)!.
+A new event is triggered if there is at least for one variable \lstinline!v! such that \lstinline!pre(v) <> v! after the active model equations are evaluated at an event instant.
+In this case the model is at once reevaluated.
+This evaluation sequence is called \emph{event iteration}.
+The integration is restarted once \lstinline!pre(v) == v! for all \lstinline!v! appearing inside \lstinline!pre($\ldots$)!.
 
 \begin{nonnormative}
 If \lstinline!v! and \lstinline!pre(v)! are only used in \lstinline!when!-clauses, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
@@ -1283,7 +1290,8 @@ Again, it is a quality of implementation to solve these systems more efficiently
 edge($b$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Expands into \lstinline!($b$ and not pre($b$))! for \lstinline!Boolean! variable $b$.  The same restrictions as for \lstinline!pre! apply (e.g.\ not to be used in \lstinline!function! classes).
+Expands into \lstinline!($b$ and not pre($b$))! for \lstinline!Boolean! variable $b$.
+The same restrictions as for \lstinline!pre! apply (e.g.\ not to be used in \lstinline!function! classes).
 \end{semantics}
 \end{operatordefinition}
 
@@ -1292,7 +1300,8 @@ Expands into \lstinline!($b$ and not pre($b$))! for \lstinline!Boolean! variable
 change(v)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Expands into \lstinline!($v$ <> pre($v$))!.  The same restrictions as for \lstinline!pre! apply.
+Expands into \lstinline!($v$ <> pre($v$))!.
+The same restrictions as for \lstinline!pre! apply.
 \end{semantics}
 \end{operatordefinition}
 
@@ -1330,9 +1339,7 @@ There are four levels of variability of expressions, starting from the least var
   continuous-time variability
 \end{itemize}
 
-While many invalid models can be rejected based on the declared variabilities of variables alone (without the concept of expression
-variability), the following rules both help enforcing compliance of computed solutions to declared variability, and impose additional
-restrictions that simplify reasoning and reporting of errors:
+While many invalid models can be rejected based on the declared variabilities of variables alone (without the concept of expression variability), the following rules both help enforcing compliance of computed solutions to declared variability, and impose additional restrictions that simplify reasoning and reporting of errors:
 \begin{itemize}
 \item
   For an assignment \lstinline!v := expr! or binding equation \lstinline!v = expr!, \lstinline!v! must be declared to be at least as variable as \lstinline!expr!.
@@ -1452,7 +1459,9 @@ Discrete-time expressions\index{discrete-time expression}\index{expression varia
 \item
   Unless inside \lstinline!noEvent!: Ordered relations (\lstinline!>!, \lstinline!<!, \lstinline!>=!, \lstinline!<=!) and the event generating functions \lstinline!ceil!, \lstinline!floor!, \lstinline!div!, and \lstinline!integer!, if at least one argument is non-discrete time expression and subtype of \lstinline!Real!.
   \begin{nonnormative}
-  These will generate events, see \cref{events-and-synchronization}.  Note that \lstinline!rem! and \lstinline!mod! generate events but are not discrete-time expressions.  In other words, relations inside \lstinline!noEvent!, such as \lstinline!noEvent(x>1)!, are not discrete-time expressions.
+  These will generate events, see \cref{events-and-synchronization}.
+  Note that \lstinline!rem! and \lstinline!mod! generate events but are not discrete-time expressions.
+  In other words, relations inside \lstinline!noEvent!, such as \lstinline!noEvent(x>1)!, are not discrete-time expressions.
   \end{nonnormative}
 \item
   The functions \lstinline!pre!, \lstinline!edge!, and \lstinline!change! result in discrete-time expressions.
@@ -1463,8 +1472,7 @@ Discrete-time expressions\index{discrete-time expression}\index{expression varia
 Inside an \lstinline!if!-expression, \lstinline!if!-clause, \lstinline!while!-statement or \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the body of a \lstinline!when!-clause, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
 
 \begin{nonnormative}
-The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing
-functions do not become active between events.
+The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing functions do not become active between events.
 \end{nonnormative}
 
 For a scalar or array equation \lstinline!expr1 = expr2! where neither expression is of base type \lstinline!Real!, both expressions must be discrete-time expressions.


### PR DESCRIPTION
Slowly, one by one…  Reminded by https://github.com/modelica/ModelicaSpecification/pull/3025#discussion_r748393274, I thought it was about time we convert also this chapter to sentence-based line breaks.

To be merged after #3025 in order to not introduce merge conflicts.

As the conversion is done by hand, this commit also includes a small number of other fixes of cleanup character.
