### PR TITLE
Ensure that Modelica code in HTML is teletype!

### DIFF
--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -13,10 +13,11 @@
 %   white background due to anti-aliasing and similar effects.
 % Warning: Note that changing to a font with different width -- especially a wider one -- means
 % that existing manual line breaks are potentially becoming out of place.
+% Finally, don't use newtexttt in listings in the LaTeXML build, see:
+% - https://github.com/brucemiller/LaTeXML/issues/1713
 \ifpdf
 \usepackage{newtxtt}
 \fi
-% There seems to be some major issue with using that font in LaTeXML in listings
 
 \usepackage{listings}
 \usepackage{color}

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -200,7 +200,7 @@
   belowskip=0pt,
   defaultdialect=[MLS]C,
 }
-% Note: Not using \sffamily for comments since that causes comments to be of a different size, which looks plain weird
+% Note: Needing size for sans serif font, or LaTeXML will have different size for them which looks weird.
 % 
 
 % Misc math

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -189,7 +189,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}\sffamily\small, % comment style, need smaller size for sans serif font in LaTeXML
+  commentstyle=\color{commentcolor}\sffamily\small, % For the LaTeXML build this is smaller than for 'basicstyle', need due to sans serif font.
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -188,7 +188,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}, % comment style
+  commentstyle=\color{commentcolor}\sffamily\smallifpdf, % comment style
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -13,7 +13,10 @@
 %   white background due to anti-aliasing and similar effects.
 % Warning: Note that changing to a font with different width -- especially a wider one -- means
 % that existing manual line breaks are potentially becoming out of place.
+\ifpdf
 \usepackage{newtxtt}
+\fi
+% There seems to be some major issue with using that font in LaTeXML in listings
 
 \usepackage{listings}
 \usepackage{color}
@@ -185,7 +188,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}\sffamily, % comment style
+  commentstyle=\color{commentcolor}, % comment style
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
@@ -197,6 +200,8 @@
   belowskip=0pt,
   defaultdialect=[MLS]C,
 }
+% Note: Not using \sffamily for comments since that causes comments to be of a different size, which looks plain weird
+% 
 
 % Misc math
 \newcommand{\ud}{\mathrm{d}}

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -188,7 +188,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}\sffamily\smallifpdf, % comment style
+  commentstyle=\color{commentcolor}\sffamily\small, % comment style, need smaller size for sans serif font in LaTeXML
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,
@@ -200,8 +200,6 @@
   belowskip=0pt,
   defaultdialect=[MLS]C,
 }
-% Note: Needing size for sans serif font, or LaTeXML will have different size for them which looks weird.
-% 
 
 % Misc math
 \newcommand{\ud}{\mathrm{d}}

--- a/preamble.tex
+++ b/preamble.tex
@@ -151,6 +151,7 @@
 \fi
 
 % There seems to be some major issue with using this as a package in LaTeXML messing up font in listing
+% See https://github.com/brucemiller/LaTeXML/issues/1713
 \ifpdf
 \usepackage{mlsshared}
 \else

--- a/preamble.tex
+++ b/preamble.tex
@@ -150,7 +150,12 @@
 \usepackage[nameinlink,noabbrev]{cleveref}
 \fi
 
+% There seems to be some major issue with using this as a package in LaTeXML messing up font in listing
+\ifpdf
 \usepackage{mlsshared}
+\else
+\include{mlsshared.sty}
+\fi
 
 \ifpdf
 % This is the preferred load order for listings and cleveref, so that cleveref is aware of listings, see above.


### PR DESCRIPTION
Specifically fixed-width "teletype" style.

The underlying issue for #3024 is actually deeper, and more important.
The pdf-document has normal code listings in teletype-style, but the HTML-document does not.
That is causing a number of issues:

- Listings look weird as they don't align.
- The `--` problem in #3024.
- And probably a lot more.

I have not investigated this fully yet. Note that changing to include for a style is a terrible hack, but it seemed necessary.