### PR TITLE
More stable links for openprod

### DIFF
--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1706,16 +1706,16 @@ following funding agencies has been received:
 \item
   The German Ministry BMBF has partially funded DLR, Fraunhofer and
   Siemens (BMBF Förderkennzeichen: 01IS07022F) within the ITEA2 project
-  EUROSYSLIB (\url{https://itea3.org/project/eurosyslib.html}).
+  EUROSYSLIB (\url{https://itea4.org/project/eurosyslib.html}).
 \item
   The German Ministry BMBF has partially funded ITI GmbH (BMBF
   Förderkennzeichen: 01IS08002K), and the Swedish funding agency VINNOVA
   has partially funded Dynasim (2008-02291), within the ITEA2 project
-  MODELISAR (\url{https://itea3.org/project/modelisar.html}).
+  MODELISAR (\url{https://itea4.org/project/modelisar.html}).
 \item
   The Swedish funding agency VINNOVA has partially funded Linköping
   University (PELAB) within the ITEA2 project OPENPROD
-  (\url{https://itea2.org/project/openprod.html}).
+  (\url{https://itea4.org/project/openprod.html}).
 \item
   The Swedish Research Council has partially funded Linköping University
   (PELAB) within the project \emph{High-Level Debugging of Equation-Based
@@ -1723,7 +1723,7 @@ following funding agencies has been received:
 \item
   The German Ministry BMBF has partially funded FH Bielefeld (BMBF
   Förderkennzeichen: 01IS09029C) within the ITEA2 project OPENPROD
-  (\url{https://itea2.org/project/openprod.html}).
+  (\url{https://itea4.org/project/openprod.html}).
 \end{itemize}
 
 \section{Modelica 3.1}\label{modelica-3-1}

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1715,7 +1715,7 @@ following funding agencies has been received:
 \item
   The Swedish funding agency VINNOVA has partially funded Linköping
   University (PELAB) within the ITEA2 project OPENPROD
-  (http://www.openprod.org).
+  (\url{https://itea4.org/project/openprod.html}).
 \item
   The Swedish Research Council has partially funded Linköping University
   (PELAB) within the project \emph{High-Level Debugging of Equation-Based
@@ -1723,7 +1723,7 @@ following funding agencies has been received:
 \item
   The German Ministry BMBF has partially funded FH Bielefeld (BMBF
   Förderkennzeichen: 01IS09029C) within the ITEA2 project OPENPROD
-  (\href{http://www.openprod.}{http://www.openprod.org}).
+  (\url{https://itea4.org/project/openprod.html}).
 \end{itemize}
 
 \section{Modelica 3.1}\label{modelica-3-1}

--- a/chapters/revisions.tex
+++ b/chapters/revisions.tex
@@ -1715,7 +1715,7 @@ following funding agencies has been received:
 \item
   The Swedish funding agency VINNOVA has partially funded Linköping
   University (PELAB) within the ITEA2 project OPENPROD
-  (\url{https://itea4.org/project/openprod.html}).
+  (\url{https://itea2.org/project/openprod.html}).
 \item
   The Swedish Research Council has partially funded Linköping University
   (PELAB) within the project \emph{High-Level Debugging of Equation-Based
@@ -1723,7 +1723,7 @@ following funding agencies has been received:
 \item
   The German Ministry BMBF has partially funded FH Bielefeld (BMBF
   Förderkennzeichen: 01IS09029C) within the ITEA2 project OPENPROD
-  (\url{https://itea4.org/project/openprod.html}).
+  (\url{https://itea2.org/project/openprod.html}).
 \end{itemize}
 
 \section{Modelica 3.1}\label{modelica-3-1}


### PR DESCRIPTION
Closes #3055
I noticed one confusion: itea2.org and itea3.org redirect to itea4.org.
I downgraded to itea2.org and hope that continue to work, since it seems odd to discuss itea2 projects and give an itea4 link. If the redirects stop working we should also upgrade the itea3.org links.