### PR TITLE
Remove incorrect escaping of '&' in bibliography 'url' entry

### DIFF
--- a/mls.bib
+++ b/mls.bib
@@ -39,7 +39,7 @@
   booktitle = {Proceedings of {ESM}’95, European Simulation Multiconference},
   pages = {xxiii--xxxiv},
   address = {Prague, Czech Republic},
-  url = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.127.3787\&rep=rep1\&type=pdf},
+  url = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.127.3787&rep=rep1&type=pdf},
 }
 
 @InProceedings{ForgetEtAl2008MultiPeriodic,


### PR DESCRIPTION
Fixes #3056.

Tested locally and works in both PDF and HTML.
