### PR TITLE
Revert part of #2841

### DIFF
--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -158,8 +158,9 @@ nav > div.ltx_TOC {
 :target:before {
   visibility: hidden;
   content: "X"; /* Hidden, but needs to be non-empty to work in Chrome. */
-  display: block;
+  display: inline-block;
   position: relative;
+  padding-top: calc((3.5rem + 2px));
   top: calc(-(2.5rem + 2px)); /* Offset by total height of .ltx_page_header. */
 }
 


### PR DESCRIPTION
Closes #2967
I'm fully aware that it isn't ideal, but it seems the best of three choices:
* Fully revert #2841 - which means you cannot see the linked part
* Current odd line-break after dot.
* Wait until someone finds the ideal solution
Obviously it can be improved if someone figures out how.