### PR TITLE
Place restrictions on String content in relevant sections

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1479,6 +1479,15 @@ end String;
 \index{start@\robustinline{start}!attribute of \robustinline{String}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{String}}
 
+The $\langle\mathit{value}\rangle$ may only contain characters in the subset of Unicode characters identical with the 7-bit US-ASCII character set.
+
+\begin{nonnormative}
+As a consequence, operators like `\lstinline!>!' or `\lstinline!<!', and external functions only operate on ASCII strings and not on Unicode-strings.
+
+Note that some \lstinline[language=grammar]!STRING! literals that do not constitute \lstinline!String! expressions may contain general Unicode data, see \cref{lexical-conventions}.
+\end{nonnormative}
+
+
 \subsection{Enumeration Types}\label{enumeration-types}
 
 A declaration of the form

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2009,6 +2009,7 @@ Enumeration type & \lstinline[language=C]!int! & \lstinline[language=C]!int *!\\
 An exception is made when the argument is of the form \lstinline!size($\ldots$, $\ldots$)!. In this case the corresponding C type is \lstinline!size_t!.
 
 Strings are \textsc{nul}-terminated (i.e., terminated by \lstinline[language=C]!'\0'!) to facilitate calling of C functions.
+The mapping of character data uses ASCII encoding, which is sufficient for any valid \lstinline!String! value, see \cref{string-type}.
 The valid return values for an external function returning a \lstinline!String! are:
 \begin{itemize}
 \item A string given as \lstinline!String! input to the external function.
@@ -2045,10 +2046,9 @@ Enumeration type & \lstinline[language=FORTRAN77]!INTEGER! & \lstinline[language
 \end{tabular}
 \end{center}
 
-Sending string literals to FORTRAN~77 subroutines/functions is supported
-for Lapack/Blas-routines, and the strings are \textsc{nul}-terminated for
-compatibility with C. Returning strings from FORTRAN~77
-subroutines/functions is currently not supported.
+Sending string literals to FORTRAN~77 subroutines/functions is supported for Lapack/Blas-routines, and the strings are \textsc{nul}-terminated for compatibility with C.
+The mapping of character data uses ASCII encoding, which is sufficient for any valid \lstinline!String! value, see \cref{string-type}.
+Returning strings from FORTRAN~77 subroutines/functions is currently not supported.
 
 Enumeration types used as arguments are mapped to type int when calling an external C function, and to type \lstinline!INTEGER! when calling an external FORTRAN function.
 The $i$th enumeration literal is mapped to integer value $i$, starting at 1.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -58,9 +58,8 @@ Note:
   Modelica also has structured comments in the form of annotations and string comments.
 \item
   Each \lstinline[language=grammar]!description-string! or string in annotations (that is, a \lstinline[language=grammar]!STRING! with production \lstinline[language=grammar]!annotation-clause! in the grammar) may contain any member of the Unicode character set.
-  All other strings have to contain only the subset of Unicode characters identical with the 7-bit US-ASCII character set.
+  A \lstinline[language=grammar]!STRING! literal outside of \lstinline[language=grammar]!annotation-clause!, on the other hand, corresponds to a \lstinline!String! expression and must therefore fulfill the requirements on data representable as a \lstinline!String! value, see \cref{string-type}.
   \begin{nonnormative}
-  As a consequence, operators like `\lstinline!>!' or `\lstinline!<!', and external functions only operate on ASCII strings and not on Unicode-strings.
   Within a \lstinline[language=grammar]!description-string! the tags \lstinline!<HTML>! and \lstinline!</HTML>! or \lstinline!<html>! and \lstinline!</html>! define optionally begin and end of content that is HTML encoded.
   \end{nonnormative}
 \item


### PR DESCRIPTION
This addresses the problem that the rather important restriction of what data a `String` may contain is hidden away in an appendix.
