### PR TITLE
Increase sizes a bit, and use "smallifpdf" for comments.

### DIFF
--- a/css/MLS.css
+++ b/css/MLS.css
@@ -34,8 +34,8 @@ a:hover { text-decoration: underline; }
  * 13/16 = 0.8125
  */
 .ltx_font_typewriter { font-size:110%; }
-.ltx_Math { font-size:110%; }
-/*.ltx_font_typewriter .ltx_Math { font-size: 100%; }*/
+/*.ltx_Math { font-size:100%; }*/
+/*.ltx_font_typewriter .ltx_Math { font-size: 110%; }*/
 
 /* Undo the ltx-report.css setting that destroys parskip.sty style paragraphs.
  */

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -34,8 +34,11 @@ a:hover { text-decoration: underline; }
  * 13/16 = 0.8125
  */
 .ltx_font_typewriter { font-size:110%; }
-/*.ltx_Math { font-size:100%; }*/
-/*.ltx_font_typewriter .ltx_Math { font-size: 110%; }*/
+.ltx_Math { font-size:120%; }
+.MathJax .ltx_Math { font-size: 100%; }
+.ltx_font_typewriter { font-size:110%; }
+.ltx_font_typewriter .ltx_Math { font-size: 120%; }
+.ltx_font_typewriter .MathJax .ltx_Math { font-size: 110%; }
 
 /* Undo the ltx-report.css setting that destroys parskip.sty style paragraphs.
  */

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -1,4 +1,4 @@
-﻿/* This CSS makes adjustments for the MLS on top of the style sheets that come with LaTeXML.
+/* This CSS makes adjustments for the MLS on top of the style sheets that come with LaTeXML.
  * By not editing copies of the ones from LaTeXML, we can take advantage of upstream improvements to the LaTeXML files.
  */
 
@@ -87,7 +87,7 @@ a:hover { text-decoration: underline; }
  * term ends and the links begin.
  */
 .ltx_indexrefs > .ltx_text:first-child:before {
-  content: " â€“";
+  content: " -";
 }
 
 .ltx_page_header *[rel~="up"],

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -1,4 +1,4 @@
-/* This CSS makes adjustments for the MLS on top of the style sheets that come with LaTeXML.
+﻿/* This CSS makes adjustments for the MLS on top of the style sheets that come with LaTeXML.
  * By not editing copies of the ones from LaTeXML, we can take advantage of upstream improvements to the LaTeXML files.
  */
 
@@ -33,9 +33,9 @@ a:hover { text-decoration: underline; }
  * font set to monospace (the font probably only matters for font size selection in the case of math content).
  * 13/16 = 0.8125
  */
-/*.ltx_font_typewriter { font-size:123%; }*/
-.ltx_Math { font-size: 81.25%; }
-.ltx_font_typewriter .ltx_Math { font-size: 100%; }
+.ltx_font_typewriter { font-size:110%; }
+.ltx_Math { font-size:110%; }
+/*.ltx_font_typewriter .ltx_Math { font-size: 100%; }*/
 
 /* Undo the ltx-report.css setting that destroys parskip.sty style paragraphs.
  */
@@ -87,7 +87,7 @@ a:hover { text-decoration: underline; }
  * term ends and the links begin.
  */
 .ltx_indexrefs > .ltx_text:first-child:before {
-  content: " –";
+  content: " â€“";
 }
 
 .ltx_page_header *[rel~="up"],

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -87,7 +87,7 @@ a:hover { text-decoration: underline; }
  * term ends and the links begin.
  */
 .ltx_indexrefs > .ltx_text:first-child:before {
-  content: " -";
+  content: " –";
 }
 
 .ltx_page_header *[rel~="up"],

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -189,7 +189,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}\sffamily\small, % For the LaTeXML build this is smaller than for 'basicstyle', need due to sans serif font.
+  commentstyle=\color{commentcolor}\sffamily\smallifpdf, % For the LaTeXML build this is smaller than for 'basicstyle', need due to sans serif font.
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -189,7 +189,7 @@
   breaklines=true,                 % automatic line breaking only at white-space
   keepspaces,                      % don't remove space such as those after closing parenthesis
   captionpos=b,                    % sets the caption-position to bottom
-  commentstyle=\color{commentcolor}\sffamily\smallifpdf, % For the LaTeXML build this is smaller than for 'basicstyle', need due to sans serif font.
+  commentstyle=\color{commentcolor}\sffamily,
   keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
   keywordstyle=[1]\color{keywordcolor1},
   keywordstyle=[2]\color{keywordcolor1}\bfseries,


### PR DESCRIPTION
Note that this is not really consistent, it should be 123% to be consistent for listings - but that looks too large; so this is a nice middle ground. Listings and math should use same size, or it becomes messed up.

Related to #2825 