### PR TITLE
Fix oversize listing lines

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -692,7 +692,8 @@ record Placement
   Transformation transformation "Placement in the diagram layer";
 
   Boolean iconVisible "Visible in icon layer; for public connector";
-  Transformation iconTransformation "Placement in the icon layer; for public connector";
+  Transformation iconTransformation
+    "Placement in the icon layer; for public connector";
 end Placement;
 \end{lstlisting}%
 \annotationindex{Placement}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1725,21 +1725,20 @@ In case a parameter is simply renamed it is preferable to use \lstinline!convert
 using the parameter.
 \end{nonnormative}
 
-
 \begin{example}
 The conversion
 \begin{lstlisting}[language=modelica]
 convertClass("Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe",
              "Modelica.Thermal.FluidHeatFlow.Components.Pipe");
 convertModifiers({"Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe"},
-   fill("",0), {"useHeatPort=false"});
+                 fill("", 0), {"useHeatPort=false"});
 
 convertClass("Modelica.StateGraph.Temporary.NumericValue",
              "Modelica.Blocks.Interaction.Show.RealValue");
 convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
-   {"Value"}, {"number=%Value%"});
+                 {"Value"}, {"number=%Value%"});
 convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
-   {"hideConnector"}, {"use_numberPort=not %hideConnector%"});
+                 {"hideConnector"}, {"use_numberPort=not %hideConnector%"});
 
 convertModifiers("Modelica.Blocks.Math.LinearDependency",
    {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"},
@@ -1748,37 +1747,39 @@ convertClass(
    "Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines",
    "Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines");
 convertElement("Modelica.Electrical.Machines.Interfaces.PartialBasicDCMachine",
-                "quasiStationary", "quasiStatic");
-convertElement("Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited",
-                "quasiStationary", "quasiStatic");
+               "quasiStationary", "quasiStatic");
+convertElement("Modelica.Electrical.Machines.BasicMachines." +
+                "QuasiStationaryDCMachines.DC_ElectricalExcited",
+               "quasiStationary", "quasiStatic");
 \end{lstlisting}
 converts
 \begin{lstlisting}[language=modelica]
 Modelica.Thermal.FluidHeatFlow.Components.IsolatedPipe pipe1;
-Modelica.StateGraph.Temporary.NumericValue tempValue(Value=10,
-   hideConnector=true);
-Modelica.Blocks.Math.LinearDependency linearDep(y0=2, k2=1);
+Modelica.StateGraph.Temporary.NumericValue tempValue(
+  Value = 10, hideConnector = true);
+Modelica.Blocks.Math.LinearDependency linearDep(y0 = 2, k2 = 1);
 model A
   import Modelica.Electrical.Machines.BasicMachines;
   extends BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited;
 end A;
 model B
   extends A;
-  Boolean b=quasiStationary;
+  Boolean b = quasiStationary;
 end B;
 \end{lstlisting}
 to
 \begin{lstlisting}[language=modelica]
-Modelica.Thermal.FluidHeatFlow.Components.Pipe pipe1(useHeatPort=false);
-Modelica.Blocks.Interaction.Show.RealValue(number=10, use_numberPort=not true);
-Modelica.Blocks.Math.LinearDependency linearDep(y0=2, k1=0, k2=2);
+Modelica.Thermal.FluidHeatFlow.Components.Pipe pipe1(useHeatPort = false);
+Modelica.Blocks.Interaction.Show.RealValue(
+  number = 10, use_numberPort = not true);
+Modelica.Blocks.Math.LinearDependency linearDep(y0 = 2, k1 = 0, k2 = 2);
 model A
   import Modelica.Electrical.Machines.BasicMachines;
   extends BasicMachines.QuasiStaticDCMachines.DC_ElectricalExcited;
 end A;
 model B
   extends A;
-  Boolean b=a.quasiStatic;
+  Boolean b = a.quasiStatic;
 end B;
 \end{lstlisting}
 The \lstinline!convertElement! call for \lstinline!DC_ElectricalExcited! is needed to avoid relying on base classes in the original library where \lstinline!DC_ElectricalExcited! inherits from \lstinline!PartialBasicDCMachine!.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -493,7 +493,8 @@ The \lstinline!AssertionLevel.warning! case can be used when the boundary of val
 When the temperature gets out of the smaller interval, but still stays in the largest one, the user should be warned, but the simulation should continue without any further action.
 The corresponding code would be:
 \begin{lstlisting}[language=modelica]
-assert(T > 250 and T < 400, "Medium model outside full accuracy range", AssertionLevel.warning);
+assert(T > 250 and T < 400, "Medium model outside full accuracy range",
+       AssertionLevel.warning);
 assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 \end{nonnormative}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -544,7 +544,7 @@ function quadrature2 "Integrate function y=integrand(x) from x1 to x2"
 algorithm
   integral :=
     quadrature(x1, (x1 + x2) / 2, integrand) +
-      quadrature((x1 + x2) / 2, x2, integrand);
+    quadrature((x1 + x2) / 2, x2, integrand);
 end quadrature2;
 \end{lstlisting}
 \end{example}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1079,7 +1079,9 @@ package Demo;
     input Real r5 = 5.0;
     input Real r6[n1];
     input Real r7[n2];
-    output Record2 $\mathit{result}$(r0=r0,c2=c2,n1=n1,n2=n2,r1=r1,r2=r2,r4=r4,r5=r5,r6=r6,r7=r7);
+    output Record2 $\mathit{result}$(
+      r0 = r0, c2 = c2, n1 = n1, n2 = n2,
+      r1 = r1, r2 = r2, r4 = r4, r5 = r5, r6 = r6, r7 = r7);
   protected
     final constant Real c1 = 2.0; // referenced from r2
     final parameter Real r3 = Modelica.Math.cos(r2);
@@ -1089,9 +1091,13 @@ end Demo;
 and can be applied in the following way
 % henrikt-ma: TODO: Fix too long lines.
 \begin{lstlisting}[language=modelica]
-Demo.Record2 r1 = Demo.Record2(r0=1, c2=2, n1=2, n2=3, r1=1, r2=2,r4=5, r5=5, r6={1,2}, r7={1,2,3});
-Demo.Record2 r2 = Demo.Record2(1,2,2,3,1,2,5,5,{1,2},{1,2,3});
-parameter Demo.Record2 r3 = Demo.Record2(c2=2, n2=1, r1=1,r4=4, r6=1:5, r7={1});
+Demo.Record2 r1 =
+  Demo.Record2(r0 = 1, c2 = 2, n1 = 2, n2 = 3, r1 = 1, r2 = 2, r4 = 5, r5 = 5,
+               r6 = {1, 2}, r7 = {1, 2, 3});
+Demo.Record2 r2 =
+  Demo.Record2(1, 2, 2, 3, 1, 2, 5, 5, {1, 2}, {1, 2, 3});
+parameter Demo.Record2 r3 =
+  Demo.Record2(c2 = 2, n2 = 1, r1 = 1, r4 = 4, r6 = 1 : 5, r7 = {1});
 \end{lstlisting}
 
 The above example is only used to show the different variants

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -542,7 +542,9 @@ function quadrature2 "Integrate function y=integrand(x) from x1 to x2"
   input Integrand integrand; // Integrand is a partial function type
   output Real integral;
 algorithm
-  integral := quadrature(x1, (x1+x2)/2, integrand)+  quadrature((x1+x2)/2, x2, integrand);
+  integral :=
+    quadrature(x1, (x1 + x2) / 2, integrand) +
+      quadrature((x1 + x2) / 2, x2, integrand);
 end quadrature2;
 \end{lstlisting}
 \end{example}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -982,7 +982,7 @@ Examples:
 
   function add
     input Complex u, v;
-    output Complex w(re=u.re + v.re, im=u.im+v.re);
+    output Complex w(re = u.re + v.re, im = u.im + v.re);
   end add;
 
   Complex c1, c2;

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -139,7 +139,7 @@ This function can only be used in state machines.
 \end{operatordefinition}
 
 \begin{example}
-If there is a transition with \lstinline!immediate=false! from
+If there is a transition with \lstinline!immediate = false! from
 state \lstinline!A1! to \lstinline!A2! and the condition is \lstinline!ticksInState() >= 5!, and \lstinline!A1! became
 active at 10ms, and the clock period is 1ms, then \lstinline!A1! will be active at
 10ms, 11ms, 12ms, 13ms, 14ms, and will be not active at 15 ms.
@@ -151,7 +151,7 @@ active at 10ms, and the clock period is 1ms, then \lstinline!A1! will be active 
 equation
   initialState(A0);
   transition(A0, A1, sample(time, Clock(1, 1000)) > 0.0095);
-  transition(A1, A2, ticksInState() >= 5, immediate=false);
+  transition(A1, A2, ticksInState() >= 5, immediate = false);
 \end{lstlisting}
 \end{example}
 
@@ -177,7 +177,8 @@ and \lstinline!Text! annotations defined in \cref{annotations}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-transition(state2, state1, x < 10, immediate=true, reset=true, synchronize=false, priority=1)
+transition(state2, state1, x < 10,
+           immediate = true, reset = true, synchronize = false, priority = 1)
   annotation(
     Line(
       points = {{-40,-16},{-36,-4},{-32,8},{-40,26},{-40,32},{-46,50}},
@@ -197,15 +198,15 @@ transition(state2, state1, x < 10, immediate=true, reset=true, synchronize=false
 
 The \lstinline!Text! annotation representing the transition condition can use the notation \lstinline!%condition! to refer to the condition expression.
 
-The extent of the Text is interpreted relative to either the first point of the \lstinline!Line!, in the case of \lstinline!immediate=false!, or the last point (\lstinline!immediate=true!).
+The extent of the Text is interpreted relative to either the first point of the \lstinline!Line!, in the case of \lstinline!immediate = false!, or the last point (\lstinline!immediate = true!).
 
-In addition to the line defined by the points of the \lstinline!Line! annotation, a perpendicular line is used to represent the transition.  This line is closer to the first point if \lstinline!immediate=false! otherwise closer to the last point.
+In addition to the line defined by the points of the \lstinline!Line! annotation, a perpendicular line is used to represent the transition.  This line is closer to the first point if \lstinline!immediate = false! otherwise closer to the last point.
 
 If the condition text is somewhat distant from the perpendicular line, a dimmed straight line joins the transition text and the perpendicular line.  (See the rightmost transition above.)
 
-If \lstinline!reset=true!, a filled arrow head is used otherwise an open arrow head.
-For \lstinline!synchronize=true!, an inverse ``fork'' symbol is used in the
-beginning of the arrow.  (See the rightmost transition above.)
+If \lstinline!reset = true!, a filled arrow head is used otherwise an open arrow head.
+For \lstinline!synchronize = true!, an inverse ``fork'' symbol is used in the beginning of the arrow.
+(See the rightmost transition above.)
 
 The value of the \lstinline!priority! attribute is prefixing the condition text
 followed by a colon if \lstinline!priority! \textgreater{} 1.
@@ -257,7 +258,7 @@ Integer fired =
         else false)
       then i
       else 0
-    for i in 1:size(t,1));
+    for i in 1 : size(t, 1));
 \end{lstlisting}
 The start value of c is false. This definition would require that the
 previous value is recorded for all transitions conditions. Below is
@@ -277,7 +278,7 @@ Integer immediate =
         else false)
       then i
       else 0
-    for i in 1:size(t,1));
+    for i in 1 : size(t, 1));
 \end{lstlisting}
 
 In a similar way, the \lstinline!Integer delayed! is calculated as the index for a
@@ -292,7 +293,7 @@ Integer delayed =
         else false)
       then i
       else 0
-    for i in 1:size(t,1));
+    for i in 1 : size(t, 1));
 \end{lstlisting}
 
 The transition to be fired is determined as follows, taking into account
@@ -315,9 +316,9 @@ determine which are the final states, i.e.\ states without
 from-transitions and to determine if the state machine is in a final
 state currently:
 \begin{lstlisting}[language=modelica]
-Boolean finalStates[nStates] = {
-  max(if  t[j].from == i then 1 else 0 for j in 1:size(t,1)) == 0
-  for i in 1:nStates};
+Boolean finalStates[nStates] =
+  {max(if t[j].from == i then 1 else 0 for j in 1 : size(t, 1)) == 0
+    for i in 1 : nStates};
 Boolean stateMachineInFinalState = finalStates[activeState];
 \end{lstlisting}
 To enable a synchronize transition, all the \lstinline!stateMachineInFinalState! conditions of all state machines within the meta state must be true.  An example is given below in the semantic example model.
@@ -339,13 +340,15 @@ The first reset mechanism is handled by the \lstinline!activeResetStates! and \l
 
 The state machine reset flag is propagated and maintained to each state individually:
 \begin{lstlisting}[language=modelica]
-output Boolean activeResetStates[nStates] = {if reset then true else previous(nextResetStates[i]) for i in 1:nStates};
+output Boolean activeResetStates[nStates] =
+  {if reset then true else previous(nextResetStates[i]) for i in 1 : nStates};
 \end{lstlisting}
 until a state is eventually executed, then its corresponding reset condition is set to false:
 \begin{lstlisting}[language=modelica]
 Boolean nextResetStates[nStates] =
   if active then
-    {if activeState == i then false else activeResetStates[i] for i in 1:nStates}
+    {if activeState == i then false else activeResetStates[i]
+      for i in 1 : nStates}
   else
     previous(nextResetStates)
 \end{lstlisting}
@@ -368,31 +371,50 @@ The entire semantics model is given below:
 model StateMachineSemantics "Semantics of state machines"
   parameter Integer nStates;
   parameter Transition t[:] "Array of transition data sorted in priority";
-  input
-  Boolean c[size(t,1)] "Transition conditions sorted in priority";
+  input Boolean c[size(t, 1)] "Transition conditions sorted in priority";
   input Boolean active "true if the state machine is active";
-  input Boolean reset "true when the state
-machine should be reset";
+  input Boolean reset "true when the state machine should be reset";
   Integer selectedState = if reset then 1 else previous(nextState);
   Boolean selectedReset = if reset then true else previous(nextReset);
   // For strong (immediate) and weak (delayed) transitions
-  Integer immediate = max(if (if t[i].immediate and t[i].from == selectedState
-    then c[i] else false) then i else 0 for i in 1:size(t,1));
-  Integer delayed = max(if  (if not t[i].immediate and t[i].from == nextState
-    then c[i] else false) then i else 0 for i in 1:size(t,1));
+  Integer immediate =
+    max(
+      if (if t[i].immediate and t[i].from == selectedState
+          then c[i]
+          else false)
+        then i
+        else 0
+      for i in 1 : size(t, 1));
+  Integer delayed =
+    max(
+      if (if not t[i].immediate and t[i].from == nextState
+          then c[i]
+          else false)
+        then i
+        else 0
+      for i in 1 : size(t, 1));
   Integer fired = max(previous(delayed), immediate);
-  output Integer activeState = if reset then 1 elseif fired > 0 then t[fired].to else selectedState;
-  output Boolean activeReset = if reset then true elseif fired > 0 then t[fired].reset else selectedReset;
+  output Integer activeState =
+    if reset then 1 elseif fired > 0 then t[fired].to else selectedState;
+  output Boolean activeReset =
+    if reset then true elseif fired > 0 then t[fired].reset else selectedReset;
 
   // Update states
   Integer nextState = if active then activeState else previous(nextState);
   Boolean nextReset = if active then false else previous(nextReset);
   // Delayed resetting of individual states
-  output Boolean activeResetStates[nStates] = {if reset then true else
-    previous(nextResetStates[i]) for i in 1:nStates};
-  Boolean nextResetStates[nStates] = if active then {if activeState == i then false
-    else activeResetStates[i] for i in 1:nStates} else previous(nextResetStates);
-  Boolean finalStates[nStates] = {max(if  t[j].from == i then 1 else 0 for j in 1:size(t,1))== 0 for i in 1:nStates};
+  output Boolean activeResetStates[nStates] =
+    {if reset then true else previous(nextResetStates[i])
+      for i in 1 : nStates};
+  Boolean nextResetStates[nStates] =
+    if active then
+      {if activeState == i then false else activeResetStates[i]
+        for i in 1 : nStates}
+    else
+      previous(nextResetStates);
+  Boolean finalStates[nStates] =
+    {max(if t[j].from == i then 1 else 0 for j in 1 : size(t, 1)) == 0
+      for i in 1 : nStates};
   Boolean stateMachineInFinalState = finalStates[activeState];
 end StateMachineSemantics;
 \end{lstlisting}
@@ -410,7 +432,14 @@ different mutually exclusive states needs to be merged.
 In each state, the outer output variables are solved for and for each
 such variable a single definition is formed:
 \begin{lstlisting}[language=modelica,escapechar=!]
-v := if activeState(state!\textsubscript{1}!) then expre!\textsubscript{1}! elseif activeState(state!\textsubscript{2}!) then expre!\textsubscript{2}! elseif $\ldots$ else last(v)
+v :=
+  if activeState(state!\textsubscript{1}!) then
+    expre!\textsubscript{1}!
+  elseif activeState(state!\textsubscript{2}!) then
+    expre!\textsubscript{2}!
+  elseif $\ldots$
+  else
+    last(v)
 \end{lstlisting}
 
 \lstinline!last! is special internal semantic operator returning its
@@ -489,19 +518,20 @@ Consider the hierarchical state machine in \cref{fig:hierarchical-statemachine}.
 The Modelica code (without annotations) is:
 \begin{lstlisting}[language=modelica]
 block HierarchicalAndParallelStateMachine
-  inner Integer v(start=0);
+  inner Integer v(start = 0);
 
   State1 state1;
   State2 state2;
 equation
   initialState(state1);
-  transition(state1,state2,activeState(state1.stateD) and
-    activeState(state1.stateY), immediate=false);
-  transition(state2,state1,v >= 20, immediate=false);
+  transition(state1, state2,
+             activeState(state1.stateD) and activeState(state1.stateY),
+             immediate = false);
+  transition(state2, state1, v >= 20, immediate = false);
 
 public
   block State1
-    inner Integer count(start=0);
+    inner Integer count(start = 0);
     inner outer output Integer v;
 
     block StateA
@@ -531,15 +561,15 @@ public
 
   equation
     initialState(stateA);
-    transition(stateA, stateB, v >= 6, immediate=false);
-    transition(stateB, stateC, v == 0, immediate=false);
-    transition(stateC, stateA, true, immediate=false, priority=2);
-    transition(stateC, stateD, count >= 2, immediate=false);
+    transition(stateA, stateB, v >= 6, immediate = false);
+    transition(stateB, stateC, v == 0, immediate = false);
+    transition(stateC, stateA, true, immediate = false, priority = 2);
+    transition(stateC, stateD, count >= 2, immediate = false);
 
   public
     block StateX
       outer input Integer v;
-      Integer i(start=0);
+      Integer i(start = 0);
       Integer w; // = v;
     equation
       i = previous(i) + 1;
@@ -548,7 +578,7 @@ public
     StateX stateX;
 
     block StateY
-      Integer j(start=0);
+      Integer j(start = 0);
     equation
       j = previous(j) + 1;
     end StateY;
@@ -556,8 +586,8 @@ public
 
   equation
     initialState(stateX);
-    transition(stateX, stateY, stateX.i > 20, immediate=false,
-    reset=false);
+    transition(stateX, stateY, stateX.i > 20,
+               immediate = false, reset = false);
   end State1;
 
   block State2
@@ -583,28 +613,28 @@ equivalent model is shown below:
 \begin{lstlisting}[language=modelica]
 block HierarchicalAndParallelStateMachine
   extends StateMachineSemantics(
-    nStates=2,
-    t={Transition(from=1, to=2, immediate=false, synchronize=true),
-       Transition(from=2, to=1, immediate=false)},
-    c={true, v >= 20});
-  Boolean init(start=true) = sample(false);
+    nStates = 2,
+    t = {Transition(from = 1, to = 2, immediate = false, synchronize = true),
+         Transition(from = 2, to = 1, immediate = false)},
+    c = {true, v >= 20});
+  Boolean init(start = true) = sample(false);
 
   block State1
     Boolean active;
     Boolean reset;
     outer input Integer v_previous;
     inner output Integer v;
-    inner Integer count(start=0);
+    inner Integer count(start = 0);
     inner Integer count_previous = if reset then 0 else previous(count);
 
     block StateMachineOf_stateA
       extends StateMachineSemantics(
-        nStates=4,
-        t={Transition(from=1, to=2, immediate=false),
-           Transition(from=2, to=3, immediate=false),
-           Transition(from=3, to=1, immediate=false),
-           Transition(from=3, to=4, immediate=false)},
-        c={v >= 6, v==0, true, count >= 2});
+        nStates = 4,
+        t = {Transition(from = 1, to = 2, immediate = false),
+             Transition(from = 2, to = 3, immediate = false),
+             Transition(from = 3, to = 1, immediate = false),
+             Transition(from = 3, to = 4, immediate = false)},
+        c = {v >= 6, v == 0, true, count >= 2});
       outer input Integer v_previous;
       outer output Integer v;
       outer input Integer count_previous;
@@ -630,26 +660,26 @@ block HierarchicalAndParallelStateMachine
       end if;
     end StateMachineOf_stateA;
 
-    StateMachineOf_stateA stateMachineOf_stateA(active=active,
-      reset=reset);
+    StateMachineOf_stateA stateMachineOf_stateA(
+      active = active, reset = reset);
 
     block StateMachineOf_stateX
       extends StateMachineSemantics(
-        nStates=2,
-        t={Transition(from=1, to=2, immediate=false, reset=false)},
-        c={i>25});
+        nStates = 2,
+        t = {Transition(from = 1, to = 2, immediate = false, reset = false)},
+        c = {i > 25});
       outer input Integer v;
-      Integer i(start=0);
+      Integer i(start = 0);
       Integer i_previous;
-      Integer j(start=0);
+      Integer j(start = 0);
       Integer j_previous;
       Integer w;
     equation
       inFinalState = true; // no macro states
       if activeState == 1 then
         // equations for stateX
-        i_previous = if activeReset or
-          activeResetStates[1] then 0 else previous(i);
+        i_previous =
+          if activeReset or activeResetStates[1] then 0 else previous(i);
         j_previous = previous(j);
         i = i_previous + 1;
         w = v;
@@ -657,21 +687,23 @@ block HierarchicalAndParallelStateMachine
       else // if activeState == 2 then
         // equations for stateY
         i_previous = previous(i);
-        j_previous = if activeReset or activeResetStates[2] then 0 else previous(j);
+        j_previous =
+          if activeReset or activeResetStates[2] then 0 else previous(j);
         i = i_previous;
         w = previous(w);
         j = j_previous + 1;
       end if;
     end StateMachineOf_stateX;
 
-    StateMachineOf_stateX stateMachineOf_stateX(active=active,
-      reset=reset);
-    Boolean inFinalState = stateMachineOf_stateA.stateMachineInFinalState and
+    StateMachineOf_stateX stateMachineOf_stateX(
+      active = active, reset = reset);
+    Boolean inFinalState =
+      stateMachineOf_stateA.stateMachineInFinalState and
       stateMachineOf_stateX.stateMachineInFinalState;
   end State1;
 
   State1 state1;
-  Integer v(start=0);
+  Integer v(start = 0);
   inner Integer v_previous = if reset then 0 else previous(v);
 equation
   active = true;

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -367,7 +367,8 @@ definition it is assumed that an (inside or outside) connector \lstinline!c!
 contains a stream variable \lstinline!h_outflow! which is associated with a flow
 variable \lstinline!m_flow! in the same connector \lstinline!c!:
 \begin{lstlisting}[language=modelica]
-actualStream(c.h_outflow) = if c.m_flow > 0 then inStream(c.h_outflow) else c.h_outflow;
+actualStream(c.h_outflow) =
+  if c.m_flow > 0 then inStream(c.h_outflow) else c.h_outflow;
 \end{lstlisting}
 
 \begin{nonnormative}


### PR DESCRIPTION
Addressing a handful of oversize lines in listings reported to me by @maltelenz, plus a couple of more I happened to see when skimming nearby sections of the document.
