### PR TITLE
Address fancyhdr warning about too small 'headheight'

### DIFF
--- a/MLS.tex
+++ b/MLS.tex
@@ -36,6 +36,7 @@
 % Using nouppercase since it is seems more normal for the sections, and is also
 % needed for over-determined connectors (as it would otherwise overflow)
 \cleardoublepage
+\setlength{\headheight}{10.5mm} % Make tall enough to fit fancy header.
 \pagestyle{fancy}
 \rhead{Modelica Language Specification \mlsversion\\ \nouppercase{\rightmark} \vspace{1mm}}
 \lhead{\includegraphics[height=6.5mm]{Modelica_Language}}

--- a/preamble.tex
+++ b/preamble.tex
@@ -6,6 +6,7 @@
 \usepackage[english]{babel}
 
 \usepackage{fancyhdr}
+\setlength{\headheight}{10.5mm} % Address fancyhdr warning about height being too small.
 
 % The general view was that parskip without indent was most readable, so use it
 \usepackage{parskip}

--- a/preamble.tex
+++ b/preamble.tex
@@ -6,7 +6,6 @@
 \usepackage[english]{babel}
 
 \usepackage{fancyhdr}
-\setlength{\headheight}{10.5mm} % Address fancyhdr warning about height being too small.
 
 % The general view was that parskip without indent was most readable, so use it
 \usepackage{parskip}


### PR DESCRIPTION
I just made a fresh installation of texlive, and without this I'm getting a warning from fancyhdr on every page, making all other messages drown completely in the fancyhdr noise.