### PR TITLE
Cleanup triggered by clumsy logic in Modelica code

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1157,8 +1157,8 @@ globally singular model.
 import Modelica.Units.SI;
 
 partial model BaseProperties
-  "Interface of medium model for all type of media"
-  parameter Boolean preferredMediumStates=false;
+    "Interface of medium model for all type of media"
+  parameter Boolean preferredStates = false;
   constant Integer nXi "Number of independent mass fractions";
   InputAbsolutePressure     p;
   InputSpecificEnthalpy     h;
@@ -1187,12 +1187,13 @@ variables'' from which all other intrinsic thermodynamic variables can
 be recursively computed. For example, a simple air model could be
 defined as:
 \begin{lstlisting}[language=modelica]
-model SimpleAir "Medium model of simple air. Independent variables: p,T"
-  extends BaseProperties(nXi = 0,
-     p(stateSelect = if preferredMediumStates then StateSelect.prefer
-                       else StateSelect.default),
-     T(stateSelect = if preferredMediumStates then StateSelect.prefer
-                       else StateSelect.default));
+model SimpleAir "Medium model of simple air. Independent variables: p, T"
+  extends BaseProperties(
+    nXi = 0,
+    p(stateSelect =
+      if preferredStates then StateSelect.prefer else StateSelect.default),
+    T(stateSelect =
+      if preferredStates then StateSelect.prefer else StateSelect.default));
   constant SI.SpecificHeatCapacity R = 287;
   constant SI.SpecificHeatCapacity cp = 1005.45;
   constant SI.Temperature T0 = 298.15
@@ -1235,14 +1236,15 @@ connector FluidPort
   SI.SpecificEnthalpy h;
   flow SI.EnthalpyFlowRate H_flow;
   SI.MassFraction Xi [Medium.nXi] "Independent mixture mass fractions";
-  flow SI.MassFlowRate mXi_flow[Medium.nXi] "Independent subst. mass flow rates";
+  flow SI.MassFlowRate mXi_flow[Medium.nXi]
+    "Independent subst. mass flow rates";
 end FluidPort;
 
 model DynamicVolume
   parameter SI.Volume V;
   replaceable model Medium = BaseProperties;
   FluidPort port(redeclare model Medium = Medium);
-  Medium medium(preferredMediumStates=true); // No modifier for p,h,Xi
+  Medium medium(preferredStates = true); // No modifier for p, h, Xi
   SI.InternalEnergy U;
   SI.Mass M;
   SI.Mass MXi[medium.nXi];

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -118,7 +118,7 @@ Simulation is performed in the following way:
 \item
   At an event instant, \eqref{eq:hydrid-dae} is a mixed set of algebraic equations which is solved for the \lstinline!Real!, \lstinline!Boolean! and \lstinline!Integer! unknowns.
 \item
-  After an event is processed, the integration is restarted with \ref{perform-simulation-integrate}.
+  After an event is processed, the integration is restarted at phase~\ref{perform-simulation-integrate}.
 \end{enumerate}
 
 Note, that both the values of the conditions $c$ as well as the values of $z$ and $m$ (all discrete-time \lstinline!Real!, \lstinline!Boolean! and \lstinline!Integer! variables) are only changed at an event instant and that these variables remain constant during continuous integration.

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -160,6 +160,6 @@ Specialized algorithms are needed to solve such systems.
 To summarize, symbolic transformation techniques are needed to transform \eqref{eq:hydrid-dae} into a set of equations which can be numerically solved reliably.
 Most important, the algorithm of Pantelides should to be applied to differentiate certain parts of the equations in order to reduce the index.
 Note, that also explicit integration methods, such as Runge-Kutta algorithms, can be used to solve \eqref{eq:dae}, after the index of \eqref{eq:dae} has been reduced by the Pantelides algorithm: During continuous integration, the integrator provides $x$ and $t$.
-% TODO: Structured formatting of inline "upright 'd' fraction".
-Then, \eqref{eq:dae} is a linear or nonlinear system of equations to compute the algebraic variables $y$ and the state derivatives $\mathrm{d}x/\mathrm{d}t$ and the model returns $\mathrm{d}x/\mathrm{d}t$ to the integrator by solving these systems of equations.
+Then, \eqref{eq:dae} is a linear or nonlinear system of equations to compute the algebraic variables $y$ and the state derivatives $\udfrac{x}{t}$ and the model returns $\udfrac{x}{t}$ to the integrator by solving these systems of equations.
+Often, \eqref{eq:dae} is just a linear system of equations in these unknowns, so that the solution is straightforward.
 This procedure is especially useful for real-time simulation where usually explicit one-step methods are used.

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -44,35 +44,49 @@ c := f_{\mathrm{c}}(\mathit{relation}(v))
 \end{subequations}
 and where
 \begin{itemize}
-\item $p$:
-Modelica variables declared as \lstinline!parameter! or \lstinline!constant!, i.e., variables without any time-dependency.
+\item
+  $p$:
+  Modelica variables declared as \lstinline!parameter! or \lstinline!constant!, i.e., variables without any time-dependency.
 
-\item $t$:
-Modelica variable \lstinline!time!, the independent (real) variable.
+\item
+  $t$:
+  Modelica variable \lstinline!time!, the independent (real) variable.
 
-\item $x(t)$:
-Modelica variables of type \lstinline!Real!, appearing differentiated.
+\item
+  $x(t)$:
+  Modelica variables of type \lstinline!Real!, appearing differentiated.
 
-\item $y(t)$:
-Continuous-time modelica variables of type \lstinline!Real! that do not appear differentiated (= algebraic variables).
+\item
+  $y(t)$:
+  Continuous-time modelica variables of type \lstinline!Real! that do not appear differentiated (= algebraic variables).
 
-\item $z(t_{\mathrm{e}})$:
-Discrete-time modelica variables of type \lstinline!Real!.  These variables change their value only at event instants $t_{\mathrm{e}}$.  \lstinline!pre(z)! are the values of $z$ immediately before the current event occurred.
+\item
+  $z(t_{\mathrm{e}})$:
+  Discrete-time modelica variables of type \lstinline!Real!.
+  These variables change their value only at event instants $t_{\mathrm{e}}$.
+  \lstinline!pre(z)! are the values of $z$ immediately before the current event occurred.
 
-\item $m(t_{\mathrm{e}})$:
-Modelica variables of discrete-valued types (\lstinline!Boolean!, \lstinline!Integer!, etc) which are unknown.  These variables change their value only at event instants $t_{\mathrm{e}}$.  \lstinline!pre(m)! are the values of $m$ immediately before the current event occurred.
+\item
+  $m(t_{\mathrm{e}})$:
+  Modelica variables of discrete-valued types (\lstinline!Boolean!, \lstinline!Integer!, etc) which are unknown.
+  These variables change their value only at event instants $t_{\mathrm{e}}$.
+  \lstinline!pre(m)! are the values of $m$ immediately before the current event occurred.
 
-\item $c(t_{\mathrm{e}})$:
-The conditions of all \lstinline!if!-expressions generated including \lstinline!when!-clauses after conversion, see \cref{when-equations}).
+\item
+  $c(t_{\mathrm{e}})$:
+  The conditions of all \lstinline!if!-expressions generated including \lstinline!when!-clauses after conversion, see \cref{when-equations}).
 
-\item $\mathit{relation}(v)$:
-A relation containing variables $v_{i}$, e.g.\ $v_{1} > v_{2}$, $v_{3} \geq 0$.
+\item
+  $\mathit{relation}(v)$:
+  A relation containing variables $v_{i}$, e.g.\ $v_{1} > v_{2}$, $v_{3} \geq 0$.
 \end{itemize}
 
-For simplicity, the special cases of \lstinline!noEvent! and \lstinline!reinit! are not contained in the equations
-above and are not discussed below.
+For simplicity, the special cases of \lstinline!noEvent! and \lstinline!reinit! are not contained in the equations above and are not discussed below.
 
-The key difference between the two groups of discrete-time variables $z$ and and $m$ here is how they are determined.  The interpretation of the solved form of \eqref{eq:dae-discrete-valued} is that given values for everything else, there is a closed-form solution for $m$ in the form of a sequence of assignments to each of the variables of $m$ in turn -- there must be no cyclic dependencies between the equations used to solve for $m$.  Further, each of the original model equations behind \eqref{eq:dae-discrete-valued} must be given in solved form, at most requiring flipping sides of the equation to obtain the used assignment form.  The interpretation of the non-solved form of \eqref{eq:dae-discrete-real} at events, on the other hand, is that at events, the discrete-time \lstinline!Real! variables $z$ are solved together with the continuous-time variables using \eqref{eq:dae} and \eqref{eq:dae-discrete-real}.
+The key difference between the two groups of discrete-time variables $z$ and and $m$ here is how they are determined.
+The interpretation of the solved form of \eqref{eq:dae-discrete-valued} is that given values for everything else, there is a closed-form solution for $m$ in the form of a sequence of assignments to each of the variables of $m$ in turn -- there must be no cyclic dependencies between the equations used to solve for $m$.
+Further, each of the original model equations behind \eqref{eq:dae-discrete-valued} must be given in solved form, at most requiring flipping sides of the equation to obtain the used assignment form.
+The interpretation of the non-solved form of \eqref{eq:dae-discrete-real} at events, on the other hand, is that at events, the discrete-time \lstinline!Real! variables $z$ are solved together with the continuous-time variables using \eqref{eq:dae} and \eqref{eq:dae-discrete-real}.
 
 \begin{example}
 The following model is illegal since there is no equation in solved form that can be used in \eqref{eq:dae-discrete-valued} to solve for the discrete-valued variable \lstinline!y!:
@@ -94,39 +108,26 @@ Such types of systems are called \firstuse[hybrid DAE]{hybrid DAEs}.
 Simulation is performed in the following way:
 \begin{enumerate}
 \item\label{perform-simulation-integrate}
-  The DAE \eqref{eq:dae} is solved by a numerical integration method. In this
-  phase the conditions $c$ of the if- and \lstinline!when!-clauses, as well as the
-  discrete-time variables $z$ and $m$ are kept constant. Therefore, \eqref{eq:dae} is a
-  continuous function of continuous variables and the most basic
-  requirement of numerical integrators is fulfilled.
+  The DAE \eqref{eq:dae} is solved by a numerical integration method.
+  In this phase the conditions $c$ of the if- and \lstinline!when!-clauses, as well as the discrete-time variables $z$ and $m$ are kept constant.
+  Therefore, \eqref{eq:dae} is a continuous function of continuous variables and the most basic requirement of numerical integrators is fulfilled.
 \item
-  During integration, all relations from \eqref{eq:crossing} are monitored. If one of
-  the relations changes its value an event is triggered, i.e., the exact
-  time instant of the change is determined and the integration is
-  halted. As discussed in \cref{events-and-synchronization}, relations which depend only on
-  time are usually treated in a special way, because this allows
-  determining the time instant of the next event in advance.
+  During integration, all relations from \eqref{eq:crossing} are monitored.
+  If one of the relations changes its value an event is triggered, i.e., the exact time instant of the change is determined and the integration is halted.
+  As discussed in \cref{events-and-synchronization}, relations which depend only on time are usually treated in a special way, because this allows determining the time instant of the next event in advance.
 \item
   At an event instant, \eqref{eq:hydrid-dae} is a mixed set of algebraic equations which is solved for the \lstinline!Real!, \lstinline!Boolean! and \lstinline!Integer! unknowns.
 \item
   After an event is processed, the integration is restarted with \ref{perform-simulation-integrate}.
 \end{enumerate}
 
-Note, that both the values of the conditions $c$ as well as the values of
-$z$ and $m$ (all discrete-time \lstinline!Real!, \lstinline!Boolean! and \lstinline!Integer! variables) are only changed at
-an event instant and that these variables remain constant during
-continuous integration. At every event instant, new values of the
-discrete-time variables $z$ and $m$, as well as of new initial values for the states $x$, are
-determined. The change of discrete-time variables may characterize a new
-structure of a DAE where elements of the state vector $x$ are
-\emph{disabled}. In other words, the number of state variables,
-algebraic variables and residue equations of a DAE may change at event
-instants by disabling the appropriate part of the DAE. For clarity of
-the equations, this is not explicitly shown by an additional index in
-\eqref{eq:hydrid-dae}.
+Note, that both the values of the conditions $c$ as well as the values of $z$ and $m$ (all discrete-time \lstinline!Real!, \lstinline!Boolean! and \lstinline!Integer! variables) are only changed at an event instant and that these variables remain constant during continuous integration.
+At every event instant, new values of the discrete-time variables $z$ and $m$, as well as of new initial values for the states $x$, are determined.
+The change of discrete-time variables may characterize a new structure of a DAE where elements of the state vector $x$ are \emph{disabled}.
+In other words, the number of state variables, algebraic variables and residue equations of a DAE may change at event instants by disabling the appropriate part of the DAE.
+For clarity of the equations, this is not explicitly shown by an additional index in \eqref{eq:hydrid-dae}.
 
-At an event instant, including the initial event, the model equations
-are reinitialized according to the following iteration procedure:
+At an event instant, including the initial event, the model equations are reinitialized according to the following iteration procedure:
 \begin{lstlisting}[language=modelica]
 known  variables: x, t, p
 unkown variables: dx/dt, y, z, m, pre(z), pre(m), c
@@ -156,18 +157,9 @@ Another problem is the handling of idealized elements, such as ideal diodes or C
 These elements lead to mixed systems of equations having both \lstinline!Real! and \lstinline!Boolean! unknowns.
 Specialized algorithms are needed to solve such systems.
 
-To summarize, symbolic transformation techniques are needed to transform
-\eqref{eq:hydrid-dae} into a set of equations which can be numerically solved reliably. Most
-important, the algorithm of Pantelides should to be applied to
-differentiate certain parts of the equations in order to reduce the
-index. Note, that also explicit integration methods, such as Runge-Kutta
-algorithms, can be used to solve \eqref{eq:dae}, after the index of \eqref{eq:dae} has been
-reduced by the Pantelides algorithm: During continuous integration, the
-integrator provides $x$ and $t$. Then, \eqref{eq:dae} is a linear or nonlinear system
-of equations to compute the algebraic variables $y$ and the state
+To summarize, symbolic transformation techniques are needed to transform \eqref{eq:hydrid-dae} into a set of equations which can be numerically solved reliably.
+Most important, the algorithm of Pantelides should to be applied to differentiate certain parts of the equations in order to reduce the index.
+Note, that also explicit integration methods, such as Runge-Kutta algorithms, can be used to solve \eqref{eq:dae}, after the index of \eqref{eq:dae} has been reduced by the Pantelides algorithm: During continuous integration, the integrator provides $x$ and $t$.
 % TODO: Structured formatting of inline "upright 'd' fraction".
-derivatives $\mathrm{d}x/\mathrm{d}t$ and the model returns $\mathrm{d}x/\mathrm{d}t$ to the integrator by
-solving these systems of equations. Often, \eqref{eq:dae} is just a linear system
-of equations in these unknowns, so that the solution is straightforward.
-This procedure is especially useful for real-time simulation where
-usually explicit one-step methods are used.
+Then, \eqref{eq:dae} is a linear or nonlinear system of equations to compute the algebraic variables $y$ and the state derivatives $\mathrm{d}x/\mathrm{d}t$ and the model returns $\mathrm{d}x/\mathrm{d}t$ to the integrator by solving these systems of equations.
+This procedure is especially useful for real-time simulation where usually explicit one-step methods are used.

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -20,7 +20,7 @@ Each \lstinline!operator! class is comprised of functions implementing different
 \item Overloaded constructors, see \cref{overloaded-constructors}:\\ \lstinline!'constructor'!, \lstinline!'0'!
 \item Overloaded string conversions, see \cref{overloaded-string-conversions}:\\ \lstinline!'String'!
 \item Overloaded binary operations, see \cref{overloaded-binary-operations}:\\
-  \lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,\\
+  \lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,
   \lstinline!'=='!, \lstinline!'<='!', \lstinline!'>'!, \lstinline!'<'!,
   \lstinline!'>='!, \lstinline!'<='!, \lstinline!'and'!, \lstinline!'or'!
 \item Overloaded unary operations, see \cref{overloaded-unary-operations}:\\

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -20,40 +20,28 @@ Each \lstinline!operator! class is comprised of functions implementing different
 \item Overloaded constructors, see \cref{overloaded-constructors}:\\ \lstinline!'constructor'!, \lstinline!'0'!
 \item Overloaded string conversions, see \cref{overloaded-string-conversions}:\\ \lstinline!'String'!
 \item Overloaded binary operations, see \cref{overloaded-binary-operations}:\\
-\lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,\\
- \lstinline!'=='!, \lstinline!'<='!', \lstinline!'>'!, \lstinline!'<'!,
-\lstinline!'>='!, \lstinline!'<='!, \lstinline!'and'!, \lstinline!'or'!
+  \lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,\\
+  \lstinline!'=='!, \lstinline!'<='!', \lstinline!'>'!, \lstinline!'<'!,
+  \lstinline!'>='!, \lstinline!'<='!, \lstinline!'and'!, \lstinline!'or'!
 \item Overloaded unary operations, see \cref{overloaded-unary-operations}:\\
-\lstinline!'-'! (negation), \lstinline!'not'!
+  \lstinline!'-'! (negation), \lstinline!'not'!
 \end{itemize}
 
-The functions defined in the operator-class must take at least one
-component of the record class as input, except for the
-constructor-functions which instead must return one component of the
-record class. All of the functions shall return exactly one output.
+The functions defined in the operator-class must take at least one component of the record class as input, except for the constructor-functions which instead must return one component of the record class.
+All of the functions shall return exactly one output.
 
-The functions can be either called as defined in this section, or they
-can be called directly using the hierarchical name. The operator or
-operator function must be encapsulated; this allows direct calls of the
-functions and prohibits the functions from using the elements of
-operator record class.
+The functions can be either called as defined in this section, or they can be called directly using the hierarchical name.
+The operator or operator function must be encapsulated; this allows direct calls of the functions and prohibits the functions from using the elements of operator record class.
 
-The \lstinline!operator record! may also contain additional functions, and
-declarations of components of the record. It is not legal to extend from
-an \lstinline!operator record!, except as a short class definition modifying the
-default attributes for the component elements directly inside the
-operator record.
+The \lstinline!operator record! may also contain additional functions, and declarations of components of the record.
+It is not legal to extend from an \lstinline!operator record!, except as a short class definition modifying the default attributes for the component elements directly inside the operator record.
 
-If an operator record was derived by a short class definition, the
-overloaded operators of this operator record are the operators that are
-defined in its base class, for subtyping see \cref{interface-or-type-relationships}.
+If an operator record was derived by a short class definition, the overloaded operators of this operator record are the operators that are defined in its base class, for subtyping see \cref{interface-or-type-relationships}.
 
-The precedence and associativity of the overloaded operators is
-identical to the one defined in \cref{tab:operator-precedence} in \cref{operator-precedence-and-associativity}.
+The precedence and associativity of the overloaded operators is identical to the one defined in \cref{tab:operator-precedence} in \cref{operator-precedence-and-associativity}.
 
 \begin{nonnormative}
-Note, the operator overloading as defined in this section is
-only a short hand notation for function calls.
+Note, the operator overloading as defined in this section is only a short hand notation for function calls.
 \end{nonnormative}
 
 \section{Matching Function}\label{matching-function}
@@ -84,24 +72,17 @@ A call \lstinline!f($a_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldot
 \end{itemize}
 
 \begin{nonnormative}
-This corresponds to the normal treatment of function calls with
-named arguments, requiring that all inputs have some value given by a
-positional argument, named argument, or a default value (and that
-positional and named arguments do not overlap). Note, that this only
-defines a valid call, but does not explicitly define the set of
-domains.
+This corresponds to the normal treatment of function calls with named arguments, requiring that all inputs have some value given by a positional argument, named argument, or a default value (and that positional and named arguments do not overlap).
+Note, that this only defines a valid call, but does not explicitly define the set of domains.
 \end{nonnormative}
 
 \section{Overloaded Constructors}\label{overloaded-constructors}
 
-Let \lstinline!C! denote an operator record class and consider an expression
-\lstinline!C($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!.
+Let \lstinline!C! denote an operator record class and consider an expression \lstinline!C($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!.
 
 \begin{enumerate}
 \item\label{overloaded-constructor-unique}
-  If there exists a unique function $f$ in \lstinline!C.'constructor'! such that
-  ($A_1$, $a_{2}$, \ldots{}, $a_{k}$, $b_{1}$=$w_{1}$, \ldots{}, $b_{p}$=$w_{p}$)
-  is a valid match for the function $f$, then
+  If there exists a unique function $f$ in \lstinline!C.'constructor'! such that ($A_1$, $a_{2}$, \ldots{}, $a_{k}$, $b_{1}$=$w_{1}$, \ldots{}, $b_{p}$=$w_{p}$) is a valid match for the function $f$, then
   \lstinline!C($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
   is resolved to
   \lstinline!C.'constructor'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!.
@@ -130,12 +111,14 @@ Restrictions:
 \begin{nonnormative}
 By the last restriction the following problem for binary operators is avoided:
 
-Assume there are two operator record classes \lstinline!C! and \lstinline!D! that both have a constructor from \lstinline!Real!.  If we want to extend \lstinline!c + c! and \lstinline!d + d! to support mixed operations, one variant would be to define \lstinline!c + d! and \lstinline!d + c!; but then \lstinline!c + 2! becomes ambiguous (since it is not clear which instance should be converted to).  Without mixed operations expressions such as \lstinline!c + d! are only ambiguous if both conversion from \lstinline!C! to \lstinline!D! and back from \lstinline!D! to \lstinline!C! are both available, and this possibility is not allowed by the restriction above.
+Assume there are two operator record classes \lstinline!C! and \lstinline!D! that both have a constructor from \lstinline!Real!.
+If we want to extend \lstinline!c + c! and \lstinline!d + d! to support mixed operations, one variant would be to define \lstinline!c + d! and \lstinline!d + c!; but then \lstinline!c + 2! becomes ambiguous (since it is not clear which instance should be converted to).
+Without mixed operations expressions such as \lstinline!c + d! are only ambiguous if both conversion from \lstinline!C! to \lstinline!D! and back from \lstinline!D! to \lstinline!C! are both available, and this possibility is not allowed by the restriction above.
 \end{nonnormative}
 
-Additionally there is an operator \lstinline!'0'! defining the zero-value which can also be used to construct an element.  The operator \lstinline!'0'! for an operator record \lstinline!C! can
-contain only one function, having zero inputs and one output of type \lstinline!C! (the called function is therefore unambiguous).  It should return the identity element of addition, and is used for
-generating flow-equations for \lstinline!connect!-equations and zero elements for matrix multiplication.
+Additionally there is an operator \lstinline!'0'! defining the zero-value which can also be used to construct an element.
+The operator \lstinline!'0'! for an operator record \lstinline!C! can contain only one function, having zero inputs and one output of type \lstinline!C! (the called function is therefore unambiguous).
+It should return the identity element of addition, and is used for generating flow-equations for \lstinline!connect!-equations and zero elements for matrix multiplication.
 
 \section{Overloaded String Conversions}\label{overloaded-string-conversions}
 
@@ -143,12 +126,9 @@ Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{
 
 \begin{enumerate}
 \item
-  If \lstinline!A! is a predefined type, i.e., \lstinline!Boolean!, \lstinline!Integer!, \lstinline!Real!, \lstinline!String! or
-  an enumeration, or a type derived from them, then the corresponding
-  built-in operation is performed.
-\item
-  If \lstinline!A! is an operator record class and there exists a unique function
-  $f$ in \lstinline!A.'String'! such that
+  If \lstinline!A! is a predefined type, i.e., \lstinline!Boolean!, \lstinline!Integer!, \lstinline!Real!, \lstinline!String! or an enumeration, or a type derived from them, then the corresponding built-in operation is performed.
+\item\label{operator-record-unique-match}
+  If \lstinline!A! is an operator record class and there exists a unique function $f$ in \lstinline!A.'String'! such that
   \lstinline!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
   is a valid match for $f$, then
   \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
@@ -161,12 +141,9 @@ Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{
 Restrictions:
 \begin{itemize}
 \item
-  The operator \lstinline!A.'String'! shall only contain functions that declare one
-  output component, which shall be of the \lstinline!String! type, and the first
-  input argument shall be of the operator record class \lstinline!A!.
+  The operator \lstinline!A.'String'! shall only contain functions that declare one output component, which shall be of the \lstinline!String! type, and the first input argument shall be of the operator record class \lstinline!A!.
 \item
-  For an operator record class there shall not exist any call that lead
-  to multiple matches in (2) above.
+  For an operator record class there shall not exist any call that lead to multiple matches in \cref{operator-record-unique-match} above.
   \begin{nonnormative}
   How to verify this is not specified.
   \end{nonnormative}
@@ -179,50 +156,45 @@ Restrictions:
 %\newcommand{\theop}{\mathit{op}}
 \newcommand{\theop}{X}
 
-Let $\theop$ denote a binary operator and consider an expression
-\lstinline!a $\theop$ b! where \lstinline!a! is an instance or array of instances of
-class \lstinline!A! and \lstinline!b! is an instance or array of instances of
-class \lstinline!B!.
+Let $\theop$ denote a binary operator and consider an expression \lstinline!a $\theop$ b! where \lstinline!a! is an instance or array of instances of class \lstinline!A! and \lstinline!b! is an instance or array of instances of class \lstinline!B!.
 
 \begin{enumerate}
 \item\label{overloaded-binary-predefined}
   If \lstinline!A! and \lstinline!B! are predefined types of such, then the corresponding built-in operation is performed.
 \item
-  Otherwise, if there exists \emph{exactly one} function $f$ in the
-  union of \lstinline!A.$\theop$! and \lstinline!B.$\theop$! such that
-  \lstinline!$f$(a, b)! is a valid match for the function $f$, then
-  \lstinline!a $\theop$ b! is evaluated using this function. It is an error, if
-  multiple functions match. If \lstinline!A! is not an operator record class, \lstinline!A.$\theop$!
-  is seen as the empty set, and similarly for \lstinline!B!.
+  Otherwise, if there exists \emph{exactly one} function $f$ in the union of \lstinline!A.$\theop$! and \lstinline!B.$\theop$! such that \lstinline!$f$(a, b)! is a valid match for the function $f$, then \lstinline!a $\theop$ b! is evaluated using this function.
+  It is an error, if multiple functions match.
+  If \lstinline!A! is not an operator record class, \lstinline!A.$\theop$! is seen as the empty set, and similarly for \lstinline!B!.
   \begin{nonnormative}
   Having a union of the operators ensures that if \lstinline!A! and \lstinline!B! are the same, each function only appears once.
   \end{nonnormative}
   Note that if the operations take array arguments, they will in this step only match if the number of dimensions match.
 \item
-  Otherwise, consider the set given by $f$ in \lstinline!A.$\theop$!
-  and an operator record class \lstinline!C! (different from \lstinline!B!) with a
-  constructor, $g$, such that \lstinline!C.'constructor'.$g$(b)! is a valid match, and
-  \lstinline!f(a, C.'constructor'.$g$(b))! is a valid match; and another set given by
-  $f$ in \lstinline!B.$\theop$! and an operator record class \lstinline!D!
-  (different from \lstinline!A!) with a constructor, $h$, such that
-  \lstinline!D.'constructor'.$h$(a)! is a valid match and \lstinline!$f$(D.'constructor'.$h$(a), b)!
-  is a valid match. If the sum of the sizes of these sets is one this
-  gives the unique match. If the sum of the sizes is larger than one it
-  is an error.
+  Otherwise, consider the set given by $f$ in \lstinline!A.$\theop$! and an operator record class \lstinline!C! (different from \lstinline!B!) with a constructor, $g$, such that
+  \lstinline!C.'constructor'.$g$(b)!
+  is a valid match, and
+  \lstinline!f(a, C.'constructor'.$g$(b))!
+  is a valid match; and another set given by $f$ in \lstinline!B.$\theop$! and an operator record class \lstinline!D! (different from \lstinline!A!) with a constructor, $h$, such that
+  \lstinline!D.'constructor'.$h$(a)!
+  is a valid match and
+  \lstinline!$f$(D.'constructor'.$h$(a), b)!
+  is a valid match.
+  If the sum of the sizes of these sets is one this gives the unique match.
+  If the sum of the sizes is larger than one it is an error.
   Note that if the operations take array arguments, they will in this step only match if the number of dimensions match.
 \begin{nonnormative}
-  Informally, this means: If there is no direct match of \lstinline!a $\theop$ b!, then it is tried to find a direct match by automatic type casts of \lstinline!a! or \lstinline!b!, by converting either \lstinline!a! or \lstinline!b! to the needed type using an appropriate constructor function from one of the operator record classes used as arguments of the overloaded \lstinline!op! functions.  Example using the \lstinline!Complex!-definition below:
+  Informally, this means:
+  If there is no direct match of \lstinline!a $\theop$ b!, then it is tried to find a direct match by automatic type casts of \lstinline!a! or \lstinline!b!, by converting either \lstinline!a! or \lstinline!b! to the needed type using an appropriate constructor function from one of the operator record classes used as arguments of the overloaded \lstinline!op! functions.
+  Example using the \lstinline!Complex!-definition below:
 \begin{lstlisting}[language=modelica]
 Real a;
 Complex b;
 Complex c = a * b; // interpreted as:
-// Complex.'*'.multiply(Complex.'constructor'.fromReal(a),b);
+// Complex.'*'.multiply(Complex.'constructor'.fromReal(a), b);
 \end{lstlisting}
 \end{nonnormative}
 \item\label{overloaded-binary-arrays}
-  Otherwise, if \lstinline!a! or \lstinline!b! is an array expression, then the expression is
-  conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions} with the
-  following exceptions concerning \cref{matrix-and-vector-multiplication-of-numeric-arrays}:
+  Otherwise, if \lstinline!a! or \lstinline!b! is an array expression, then the expression is conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions} with the following exceptions concerning \cref{matrix-and-vector-multiplication-of-numeric-arrays}:
   \begin{enumerate}
   \def\labelenumii{(\alph{enumii})}
   \item
@@ -238,13 +210,12 @@ Complex c = a * b; // interpreted as:
     It is possible to define a specific product function taking two array arguments handling this case.
     \end{nonnormative}
   \item
-    If the inner dimension for \lstinline!$\mathit{matrix}$ * $\mathit{vector}$! or \lstinline!$\mathit{matrix}$ * $\mathit{matrix}$! is zero, this uses the overloaded \lstinline!'0'! operator of the result array element type.  If the operator \lstinline!'0'! is not defined for that class it is an error if the inner dimension is zero.
+    If the inner dimension for \lstinline!$\mathit{matrix}$ * $\mathit{vector}$! or \lstinline!$\mathit{matrix}$ * $\mathit{matrix}$! is zero, this uses the overloaded \lstinline!'0'! operator of the result array element type.
+    If the operator \lstinline!'0'! is not defined for that class it is an error if the inner dimension is zero.
   \end{enumerate}
 
 \begin{nonnormative}
-For array multiplication it is assumed that the scalar elements
-form a non-commutative ring that does not necessarily have a
-multiplicative identity.
+For array multiplication it is assumed that the scalar elements form a non-commutative ring that does not necessarily have a multiplicative identity.
 \end{nonnormative}
 
 \item\label{overloaded-binary-error}
@@ -256,35 +227,25 @@ For an element-wise operator, \lstinline!a .op b!, items~\ref{overloaded-binary-
 Restrictions:
 \begin{itemize}
 \item
-  A function is allowed for a binary operator if and only if it has at
-  least two inputs; at least one of which is of the operator record
-  class, and the first two inputs shall not have default values, and all
-  inputs after the first two must have default values.
+  A function is allowed for a binary operator if and only if it has at least two inputs; at least one of which is of the operator record class, and the first two inputs shall not have default values, and all inputs after the first two must have default values.
 \item
-  For an operator record class there shall not exist any
-  (potential) call that lead to multiple matches in (2) above.
+  For an operator record class there shall not exist any (potential) call that lead to multiple matches in (2) above.
 \end{itemize}
 
 \section{Overloaded Unary Operations}\label{overloaded-unary-operations}
 
-Let $\theop$ denote a unary operator and consider an expression
-\lstinline!$\theop$ a! where \lstinline!a! is an instance or array of instances of class
-\lstinline!A!. Then \lstinline!$\theop$ a! is evaluated in the following way.
+Let $\theop$ denote a unary operator and consider an expression \lstinline!$\theop$ a! where \lstinline!a! is an instance or array of instances of class \lstinline!A!.
+Then \lstinline!$\theop$ a! is evaluated in the following way.
 
 \begin{enumerate}
 \item
-  If \lstinline!A! is a predefined type, then the corresponding built-in
-  operation is performed.
+  If \lstinline!A! is a predefined type, then the corresponding built-in operation is performed.
 \item
-  If \lstinline!A! is an operator record class and there exists a unique
-  function $f$ in \lstinline!A.$\theop$! such that \lstinline!A.$\theop$.$f$(a)! is a valid
-  match, then \lstinline!$\theop$ a! is evaluated to \lstinline!A.$\theop$.$f$(a)!. It is an
-  error, if there are multiple valid matches.
+  If \lstinline!A! is an operator record class and there exists a unique function $f$ in \lstinline!A.$\theop$! such that \lstinline!A.$\theop$.$f$(a)! is a valid match, then \lstinline!$\theop$ a! is evaluated to \lstinline!A.$\theop$.$f$(a)!.
+  It is an error, if there are multiple valid matches.
   Note that if the operations take array arguments, they will in this step only match if the number of dimensions match.
-\item
-  \label{overloaded-unary-array}
-  Otherwise, if \lstinline!a! is an array expression, then the expression
-  is conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions}.
+\item\label{overloaded-unary-array}
+  Otherwise, if \lstinline!a! is an array expression, then the expression is conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions}.
 \item
   Otherwise the expression is erroneous.
 \end{enumerate}
@@ -292,25 +253,17 @@ Let $\theop$ denote a unary operator and consider an expression
 Restrictions:
 \begin{itemize}
 \item
-  A function is allowed for a unary operator if and only if it has least
-  one input; and the first input is of the record type (or suitable
-  arrays of such) and does not have a default value, and all inputs
-  after the first one must have default values.
+  A function is allowed for a unary operator if and only if it has least one input; and the first input is of the record type (or suitable arrays of such) and does not have a default value, and all inputs after the first one must have default values.
 \item
-  For an operator record class there shall not exist any
-  (potential) call that lead to multiple matches in (2) above.
+  For an operator record class there shall not exist any (potential) call that lead to multiple matches in (2) above.
 \item
-  A binary and/or unary operator-class may only contain functions that
-  are allowed for this binary and/or unary operator-class; and in case
-  of \lstinline!'-'! it is the union of these sets, since it may define both a unary
-  (negation) and binary (subtraction) operator.
+  A binary and/or unary operator-class may only contain functions that are allowed for this binary and/or unary operator-class; and in case of \lstinline!'-'! it is the union of these sets, since it may define both a unary (negation) and binary (subtraction) operator.
 \end{itemize}
 
 \section{Example of Overloading for Complex Numbers}\label{example-of-overloading-for-complex-numbers}
 
 \begin{example}
-The rules in the previous subsections are demonstrated at hand
-of a record class to work conveniently with complex numbers:
+The rules in the previous subsections are demonstrated at hand of a record class to work conveniently with complex numbers:
 \begin{lstlisting}[language=modelica,escapechar=!]
 operator record Complex "Record defining a Complex number"
   Real re "Real part of complex number";
@@ -445,14 +398,14 @@ algorithm
   // c4 = {2.5 + 1.93649j, 2.5 - 1.93649j}
 \end{lstlisting}
 
-How overloaded operators can be symbolically processed. Example:
+How overloaded operators can be symbolically processed.
+Example:
 \begin{lstlisting}[language=modelica]
 Real a;
 Complex b;
 Complex c = a + b;
 \end{lstlisting}
-Due to inlining of functions, the equation for \lstinline!c! is
-transformed to:
+Due to inlining of functions, the equation for \lstinline!c! is transformed to:
 \begin{lstlisting}[language=modelica]
 c = Complex.'+'.add(Complex.'constructor'.fromReal(a), b);
   = Complex.'+'.add(Complex(re = a, im = 0), b)
@@ -487,7 +440,8 @@ p1.v = p3.v;
 p1.i + p2.i + p3.i = Complex.'0'();
 // Complex.'+'(p1.i, Complex.'+'(p2.i, p3.i)) = Complex.'0'();
 \end{lstlisting}
-The restrictions on extends are intended to avoid combining two variants inheriting from the same operator record, but with possibly different operations; thus \lstinline!ComplexVoltage! and \lstinline!ComplexCurrent! still use the operations from \lstinline!Complex!.  The restriction that it is not legal to extend from any of its enclosing scopes implies that:
+The restrictions on extends are intended to avoid combining two variants inheriting from the same operator record, but with possibly different operations; thus \lstinline!ComplexVoltage! and \lstinline!ComplexCurrent! still use the operations from \lstinline!Complex!.
+The restriction that it is not legal to extend from any of its enclosing scopes implies that:
 \begin{lstlisting}[language=modelica]
 package A
   extends Icon; // Ok

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -273,9 +273,9 @@ operator record Complex "Record defining a Complex number"
     function fromReal
       input Real re;
       input Real im := 0;
-      output Complex result(re=re, im=im);
+      output Complex result(re = re, im = im);
     algorithm
-      annotation(Inline=true);
+      annotation(Inline = true);
     end fromReal;
   end 'constructor';
 
@@ -286,7 +286,7 @@ operator record Complex "Record defining a Complex number"
     output Complex result "= c1 + c2";
   algorithm
     result := Complex(c1.re + c2.re, c1.im + c2.im);
-   annotation(Inline=true);
+    annotation(Inline = true);
   end '+';
 
   encapsulated operator '-'
@@ -296,7 +296,7 @@ operator record Complex "Record defining a Complex number"
       output Complex result "= - c";
     algorithm
       result := Complex(-c.re, -c.im);
-      annotation(Inline=true);
+      annotation(Inline = true);
     end negate;
 
     function subtract
@@ -305,7 +305,7 @@ operator record Complex "Record defining a Complex number"
       output Complex result "= c1 - c2";
     algorithm
       result := Complex(c1.re - c2.re, c1.im - c2.im);
-      annotation(Inline=true);
+      annotation(Inline = true);
     end subtract;
   end '-';
 
@@ -315,8 +315,9 @@ operator record Complex "Record defining a Complex number"
     input Complex c2;
     output Complex result "= c1 * c2";
   algorithm
-    result := Complex(c1.re*c2.re - c1.im*c2.im, c1.re*c2.im + c1.im*c2.re);
-    annotation(Inline=true);
+    result :=
+      Complex(c1.re * c2.re - c1.im * c2.im, c1.re * c2.im + c1.im * c2.re);
+    annotation(Inline = true);
   end '*';
 
   encapsulated operator function '/'
@@ -324,10 +325,10 @@ operator record Complex "Record defining a Complex number"
     input Complex c2;
     output Complex result "= c1 / c2";
   algorithm
-    result := Complex(( c1.re*c2.re + c1.im*c2.im)/(c2.re^2 +
-    c2.im^2),
-    (-c1.re*c2.im + c1.im*c2.re)/(c2.re^2 + c2.im^2));
-   annotation(Inline=true);
+    result :=
+      Complex((c1.re*c2.re + c1.im*c2.im) / (c2.re^2 + c2.im^2),
+              (-c1.re*c2.im + c1.im*c2.re) / (c2.re^2 + c2.im^2));
+    annotation(Inline = true);
   end '/';
 
   encapsulated operator function '=='
@@ -337,38 +338,39 @@ operator record Complex "Record defining a Complex number"
     output Boolean result "= c1 == c2";
   algorithm
     result := c1.re == c2.re and c1.im == c2.im;
-   annotation(Inline=true);
+    annotation(Inline = true);
  end '==';
 
   encapsulated operator function 'String'
     import Complex;
     input Complex c;
-    input String name := "j" "Name of variable representing sqrt(-1) in the string";
-    input Integer significantDigits=6 "Number of significant digits to be shown";
+    input String name := "j"
+      "Name of variable representing sqrt(-1) in the string";
+    input Integer significantDigits = 6
+      "Number of significant digits to be shown";
     output String s;
   algorithm
-    s := String(c.re, significantDigits=significantDigits);
+    s := String(c.re, significantDigits = significantDigits);
     if c.im <> 0 then
-      s := if  c.im > 0 then s + " + "
-   else s + " - ";
-      s := s + String(abs(c.im), significantDigits=significantDigits) + name;
-   end if;
+      s := if c.im > 0 then s + " + " else s + " - ";
+      s := s + String(abs(c.im), significantDigits = significantDigits) + name;
+    end if;
   end 'String';
 
   encapsulated function j
     import Complex;
     output Complex c;
   algorithm
-    c := Complex(0,1);
-    annotation(Inline=true);
+    c := Complex(0, 1);
+    annotation(Inline = true);
   end j;
 
   encapsulated operator function '0'
     import Complex;
     output Complex c;
   algorithm
-    c := Complex(0,0);
-    annotation(Inline=true);
+    c := Complex(0, 0);
+    annotation(Inline = true);
   end '0';
 end Complex;
 
@@ -376,22 +378,22 @@ function eigenValues
   input Real A [:,:];
   output Complex ev[size(A, 1)];
   protected
-  Integer nx=size(A, 1);
-  Real eval[nx,2];
+  Integer nx = size(A, 1);
+  Real eval[nx, 2];
   Integer i;
 algorithm
   eval := Modelica.Math.Matrices.eigenValues(A);
-  for i in 1:nx loop
+  for i in 1 : nx loop
     ev[i] := Complex(eval[i, 1], eval[i, 2]);
   end for;
 end eigenValues;
 
 // Usage of Complex number above:
   Complex j = Complex.j();
-  Complex c1 = 2 + 3*j;
-  Complex c2 = 3 + 4*j;
+  Complex c1 = 2 + 3 * j;
+  Complex c2 = 3 + 4 * j;
   Complex c3 = c1 + c2;
-  Complex c4[:] = eigenValues([1,2; -3,4]);
+  Complex c4[:] = eigenValues([1, 2; -3, 4]);
 algorithm
   Modelica.Utilities.Streams.print("c4 = " + String(c4));
   // results in output:
@@ -420,8 +422,8 @@ These equations can be symbolically processed as other equations.
 
 Complex can be used in a connector:
 \begin{lstlisting}[language=modelica]
-  operator record ComplexVoltage = Complex(re(unit="V"),im(unit="V"));
-  operator record ComplexCurrent = Complex(re(unit="A"),im(unit="A"));
+  operator record ComplexVoltage = Complex(re(unit = "V"), im(unit = "V"));
+  operator record ComplexCurrent = Complex(re(unit = "A"), im(unit = "A"));
 
   connector ComplexPin
     ComplexVoltage v;

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -127,7 +127,7 @@ Consider an expression \lstinline!String($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{
 \begin{enumerate}
 \item
   If \lstinline!A! is a predefined type, i.e., \lstinline!Boolean!, \lstinline!Integer!, \lstinline!Real!, \lstinline!String! or an enumeration, or a type derived from them, then the corresponding built-in operation is performed.
-\item\label{operator-record-unique-match}
+\item\label{binary-operator-record-unique-match}
   If \lstinline!A! is an operator record class and there exists a unique function $f$ in \lstinline!A.'String'! such that
   \lstinline!A.'String'.$f$($A_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$=$w_{1}$, $\ldots$, $b_{p}$=$w_{p}$)!
   is a valid match for $f$, then
@@ -143,7 +143,7 @@ Restrictions:
 \item
   The operator \lstinline!A.'String'! shall only contain functions that declare one output component, which shall be of the \lstinline!String! type, and the first input argument shall be of the operator record class \lstinline!A!.
 \item
-  For an operator record class there shall not exist any call that lead to multiple matches in \cref{operator-record-unique-match} above.
+  For an operator record class there shall not exist any call that lead to multiple matches in \cref{binary-operator-record-unique-match} above.
   \begin{nonnormative}
   How to verify this is not specified.
   \end{nonnormative}
@@ -161,7 +161,7 @@ Let $\theop$ denote a binary operator and consider an expression \lstinline!a $\
 \begin{enumerate}
 \item\label{overloaded-binary-predefined}
   If \lstinline!A! and \lstinline!B! are predefined types of such, then the corresponding built-in operation is performed.
-\item
+\item\label{overloaded-binary-unique}
   Otherwise, if there exists \emph{exactly one} function $f$ in the union of \lstinline!A.$\theop$! and \lstinline!B.$\theop$! such that \lstinline!$f$(a, b)! is a valid match for the function $f$, then \lstinline!a $\theop$ b! is evaluated using this function.
   It is an error, if multiple functions match.
   If \lstinline!A! is not an operator record class, \lstinline!A.$\theop$! is seen as the empty set, and similarly for \lstinline!B!.
@@ -222,14 +222,14 @@ For array multiplication it is assumed that the scalar elements form a non-commu
   Otherwise the expression is erroneous.
 \end{enumerate}
 
-For an element-wise operator, \lstinline!a .op b!, items~\ref{overloaded-binary-predefined}, \ref{overloaded-binary-arrays}, and~\ref{overloaded-binary-error} are used; e.g.\ the operator \lstinline!.+! will always be defined in terms of \lstinline!'+'!.
+For an element-wise operator, \lstinline!a .op b!, \cref{overloaded-binary-predefined,overloaded-binary-arrays,overloaded-binary-error} are used; e.g.\ the operator \lstinline!.+! will always be defined in terms of \lstinline!'+'!.
 
 Restrictions:
 \begin{itemize}
 \item
   A function is allowed for a binary operator if and only if it has at least two inputs; at least one of which is of the operator record class, and the first two inputs shall not have default values, and all inputs after the first two must have default values.
 \item
-  For an operator record class there shall not exist any (potential) call that lead to multiple matches in (2) above.
+  For an operator record class there shall not exist any (potential) call that lead to multiple matches in \cref{overloaded-binary-unique} above.
 \end{itemize}
 
 \section{Overloaded Unary Operations}\label{overloaded-unary-operations}
@@ -240,7 +240,7 @@ Then \lstinline!$\theop$ a! is evaluated in the following way.
 \begin{enumerate}
 \item
   If \lstinline!A! is a predefined type, then the corresponding built-in operation is performed.
-\item
+\item\label{unary-operator-record-unique-match}
   If \lstinline!A! is an operator record class and there exists a unique function $f$ in \lstinline!A.$\theop$! such that \lstinline!A.$\theop$.$f$(a)! is a valid match, then \lstinline!$\theop$ a! is evaluated to \lstinline!A.$\theop$.$f$(a)!.
   It is an error, if there are multiple valid matches.
   Note that if the operations take array arguments, they will in this step only match if the number of dimensions match.
@@ -255,7 +255,7 @@ Restrictions:
 \item
   A function is allowed for a unary operator if and only if it has least one input; and the first input is of the record type (or suitable arrays of such) and does not have a default value, and all inputs after the first one must have default values.
 \item
-  For an operator record class there shall not exist any (potential) call that lead to multiple matches in (2) above.
+  For an operator record class there shall not exist any (potential) call that lead to multiple matches in \cref{unary-operator-record-unique-match} above.
 \item
   A binary and/or unary operator-class may only contain functions that are allowed for this binary and/or unary operator-class; and in case of \lstinline!'-'! it is the union of these sets, since it may define both a unary (negation) and binary (subtraction) operator.
 \end{itemize}

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -21,7 +21,7 @@ Each \lstinline!operator! class is comprised of functions implementing different
 \item Overloaded string conversions, see \cref{overloaded-string-conversions}:\\ \lstinline!'String'!
 \item Overloaded binary operations, see \cref{overloaded-binary-operations}:\\
   \lstinline!'+'!, \lstinline!'-'! (subtraction), \lstinline!'*'!, \lstinline!'/'!, \lstinline!'^'!,
-  \lstinline!'=='!, \lstinline!'<='!', \lstinline!'>'!, \lstinline!'<'!,
+  \lstinline!'=='!, \lstinline!'<='!, \lstinline!'>'!, \lstinline!'<'!,
   \lstinline!'>='!, \lstinline!'<='!, \lstinline!'and'!, \lstinline!'or'!
 \item Overloaded unary operations, see \cref{overloaded-unary-operations}:\\
   \lstinline!'-'! (negation), \lstinline!'not'!

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -272,9 +272,7 @@ of the transition with true condition and highest priority or 0.
 \begin{lstlisting}[language=modelica]
 Integer immediate =
   max(
-    if t[i].immediate and t[i].from == selectedState and c[i]
-      then i
-      else 0
+    if t[i].immediate and t[i].from == selectedState and c[i] then i else 0
     for i in 1 : size(t, 1));
 \end{lstlisting}
 
@@ -285,9 +283,7 @@ next clock tick. In this case the from-state needs to be equal to
 \begin{lstlisting}[language=modelica]
 Integer delayed =
   max(
-    if not t[i].immediate and t[i].from == nextState and c[i]
-      then i
-      else 0
+    if not t[i].immediate and t[i].from == nextState and c[i] then i else 0
     for i in 1 : size(t, 1));
 \end{lstlisting}
 
@@ -300,9 +296,7 @@ Integer fired = max(previous(delayed), immediate);
 \begin{lstlisting}[language=modelica]
 Integer nextState =
   if active then
-    (if fired > 0
-      then t[fired].to
-      else selectedState)
+    (if fired > 0 then t[fired].to else selectedState)
   else
     previous(nextState);
 \end{lstlisting}
@@ -371,15 +365,11 @@ model StateMachineSemantics "Semantics of state machines"
   // For strong (immediate) and weak (delayed) transitions
   Integer immediate =
     max(
-      if (t[i].immediate and t[i].from == selectedState and c[i])
-        then i
-        else 0
+      if (t[i].immediate and t[i].from == selectedState and c[i]) then i else 0
       for i in 1 : size(t, 1));
   Integer delayed =
     max(
-      if (not t[i].immediate and t[i].from == nextState and c[i])
-        then i
-        else 0
+      if (not t[i].immediate and t[i].from == nextState and c[i]) then i else 0
       for i in 1 : size(t, 1));
   Integer fired = max(previous(delayed), immediate);
   output Integer activeState =

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -253,9 +253,8 @@ The integer fired is calculated as the index of the transition to be fired by ch
 \begin{lstlisting}[language=modelica]
 Integer fired =
   max(
-    if (if t[i].from == selectedState
-        then (if t[i].immediate then c[i] else previous(c[i]))
-        else false)
+    if t[i].from == selectedState and
+        (if t[i].immediate then c[i] else previous(c[i]))
       then i
       else 0
     for i in 1 : size(t, 1));
@@ -273,9 +272,7 @@ of the transition with true condition and highest priority or 0.
 \begin{lstlisting}[language=modelica]
 Integer immediate =
   max(
-    if (if t[i].immediate and t[i].from == selectedState
-        then c[i]
-        else false)
+    if t[i].immediate and t[i].from == selectedState and c[i]
       then i
       else 0
     for i in 1 : size(t, 1));
@@ -288,9 +285,7 @@ next clock tick. In this case the from-state needs to be equal to
 \begin{lstlisting}[language=modelica]
 Integer delayed =
   max(
-    if (if not t[i].immediate and t[i].from == nextState
-        then c[i]
-        else false)
+    if not t[i].immediate and t[i].from == nextState and c[i]
       then i
       else 0
     for i in 1 : size(t, 1));
@@ -317,8 +312,7 @@ from-transitions and to determine if the state machine is in a final
 state currently:
 \begin{lstlisting}[language=modelica]
 Boolean finalStates[nStates] =
-  {max(if t[j].from == i then 1 else 0 for j in 1 : size(t, 1)) == 0
-    for i in 1 : nStates};
+  {min(t[j].from <> i for j in 1 : size(t, 1)) for i in 1 : nStates};
 Boolean stateMachineInFinalState = finalStates[activeState];
 \end{lstlisting}
 To enable a synchronize transition, all the \lstinline!stateMachineInFinalState! conditions of all state machines within the meta state must be true.  An example is given below in the semantic example model.
@@ -341,14 +335,13 @@ The first reset mechanism is handled by the \lstinline!activeResetStates! and \l
 The state machine reset flag is propagated and maintained to each state individually:
 \begin{lstlisting}[language=modelica]
 output Boolean activeResetStates[nStates] =
-  {if reset then true else previous(nextResetStates[i]) for i in 1 : nStates};
+  {reset or previous(nextResetStates[i]) for i in 1 : nStates};
 \end{lstlisting}
 until a state is eventually executed, then its corresponding reset condition is set to false:
 \begin{lstlisting}[language=modelica]
 Boolean nextResetStates[nStates] =
   if active then
-    {if activeState == i then false else activeResetStates[i]
-      for i in 1 : nStates}
+    {activeState <> i and activeResetStates[i] for i in 1 : nStates}
   else
     previous(nextResetStates)
 \end{lstlisting}
@@ -375,21 +368,17 @@ model StateMachineSemantics "Semantics of state machines"
   input Boolean active "true if the state machine is active";
   input Boolean reset "true when the state machine should be reset";
   Integer selectedState = if reset then 1 else previous(nextState);
-  Boolean selectedReset = if reset then true else previous(nextReset);
+  Boolean selectedReset = reset or previous(nextReset);
   // For strong (immediate) and weak (delayed) transitions
   Integer immediate =
     max(
-      if (if t[i].immediate and t[i].from == selectedState
-          then c[i]
-          else false)
+      if (t[i].immediate and t[i].from == selectedState and c[i])
         then i
         else 0
       for i in 1 : size(t, 1));
   Integer delayed =
     max(
-      if (if not t[i].immediate and t[i].from == nextState
-          then c[i]
-          else false)
+      if (not t[i].immediate and t[i].from == nextState and c[i])
         then i
         else 0
       for i in 1 : size(t, 1));
@@ -397,24 +386,21 @@ model StateMachineSemantics "Semantics of state machines"
   output Integer activeState =
     if reset then 1 elseif fired > 0 then t[fired].to else selectedState;
   output Boolean activeReset =
-    if reset then true elseif fired > 0 then t[fired].reset else selectedReset;
+    reset or (if fired > 0 then t[fired].reset else selectedReset);
 
   // Update states
   Integer nextState = if active then activeState else previous(nextState);
-  Boolean nextReset = if active then false else previous(nextReset);
+  Boolean nextReset = not active and previous(nextReset);
   // Delayed resetting of individual states
   output Boolean activeResetStates[nStates] =
-    {if reset then true else previous(nextResetStates[i])
-      for i in 1 : nStates};
+    {reset or previous(nextResetStates[i]) for i in 1 : nStates};
   Boolean nextResetStates[nStates] =
     if active then
-      {if activeState == i then false else activeResetStates[i]
-        for i in 1 : nStates}
+      {activeState <> i and activeResetStates[i] for i in 1 : nStates}
     else
       previous(nextResetStates);
   Boolean finalStates[nStates] =
-    {max(if t[j].from == i then 1 else 0 for j in 1 : size(t, 1)) == 0
-      for i in 1 : nStates};
+    {min(t[j].from <> i for j in 1 : size(t, 1)) for i in 1 : nStates};
   Boolean stateMachineInFinalState = finalStates[activeState];
 end StateMachineSemantics;
 \end{lstlisting}

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -322,11 +322,10 @@ To enable a synchronize transition, all the \lstinline!stateMachineInFinalState!
 A state can be reset for two reasons:
 \begin{itemize}
 \item
-  The whole state machine has been reset from its context.\\
-  In this case, all states must be reset, and the initial state becomes
-  active.
+  The whole state machine has been reset from its context.
+  In this case, all states must be reset, and the initial state becomes active.
 \item
-  A reset transition has been fired.\\
+  A reset transition has been fired.
   Then, its target state is reset, but not other states.
 \end{itemize}
 


### PR DESCRIPTION
Fixes #3080.

Similar `if`-expressions were also found in some other chapters, so these were also fixed.

Please see individual commits to separate conversion to sentence-based line breaks from actual changes.
