### PR TITLE
Make conversion example clearer.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1749,7 +1749,7 @@ convertModifiers("Modelica.Blocks.Math.LinearDependency",
 convertClass(
    "My.Library.BadPackage",
    "My.Library.Package");
-convertElement("MyLibrary.BadPackage.PartialBase",
+convertElement("My.Library.BadPackage.PartialBase",
                "bad", "correct");
 convertElement("My.Library.BadPackage.ActualClass",
                "bad", "correct");

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1747,11 +1747,11 @@ convertModifiers("Modelica.Blocks.Math.LinearDependency",
    {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"},
    true);
 convertClass(
-   "My.Library.Pakkage",
+   "My.Library.BadPackage",
    "My.Library.Package");
-convertElement("MyLibrary.Pakkage.PartialBase",
+convertElement("MyLibrary.BadPackage.PartialBase",
                "bad", "corr.ect");
-convertElement("My.Library.Pakkage.ActualClass",
+convertElement("My.Library.BadPackage.ActualClass",
                "bad", "correct");
 \end{lstlisting}
 converts
@@ -1762,7 +1762,7 @@ Modelica.StateGraph.Temporary.NumericValue tempValue(
 Modelica.Blocks.Math.LinearDependency linearDep(y0 = 2, k2 = 1);
 model A
   import My.Library;
-  extends Library.Pakkage.ActualClass;
+  extends Library.BadPackage.ActualClass;
 end A;
 model B
   extends A;

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1750,7 +1750,7 @@ convertClass(
    "My.Library.BadPackage",
    "My.Library.Package");
 convertElement("MyLibrary.BadPackage.PartialBase",
-               "bad", "corr.ect");
+               "bad", "correct");
 convertElement("My.Library.BadPackage.ActualClass",
                "bad", "correct");
 \end{lstlisting}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1747,13 +1747,12 @@ convertModifiers("Modelica.Blocks.Math.LinearDependency",
    {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"},
    true);
 convertClass(
-   "Modelica.Electrical.Machines.BasicMachines.QuasiStationaryDCMachines",
-   "Modelica.Electrical.Machines.BasicMachines.QuasiStaticDCMachines");
-convertElement("Modelica.Electrical.Machines.Interfaces.PartialBasicDCMachine",
-               "quasiStationary", "quasiStatic");
-convertElement("Modelica.Electrical.Machines.BasicMachines." +
-                "QuasiStationaryDCMachines.DC_ElectricalExcited",
-               "quasiStationary", "quasiStatic");
+   "My.Library.Pakkage",
+   "My.Library.Package");
+convertElement("MyLibrary.Pakkage.PartialBase",
+               "bad", "corr.ect");
+convertElement("My.Library.Pakkage.ActualClass",
+               "bad", "correct");
 \end{lstlisting}
 converts
 \begin{lstlisting}[language=modelica]
@@ -1762,12 +1761,12 @@ Modelica.StateGraph.Temporary.NumericValue tempValue(
   Value = 10, hideConnector = true);
 Modelica.Blocks.Math.LinearDependency linearDep(y0 = 2, k2 = 1);
 model A
-  import Modelica.Electrical.Machines.BasicMachines;
-  extends BasicMachines.QuasiStationaryDCMachines.DC_ElectricalExcited;
+  import My.Library;
+  extends Library.Pakkage.ActualClass;
 end A;
 model B
   extends A;
-  Boolean b = quasiStationary;
+  Boolean b = bad;
 end B;
 \end{lstlisting}
 to
@@ -1777,16 +1776,17 @@ Modelica.Blocks.Interaction.Show.RealValue(
   number = 10, use_numberPort = not true);
 Modelica.Blocks.Math.LinearDependency linearDep(y0 = 2, k1 = 0, k2 = 2);
 model A
-  import Modelica.Electrical.Machines.BasicMachines;
-  extends BasicMachines.QuasiStaticDCMachines.DC_ElectricalExcited;
+  import My.Library;
+  extends Library.Package.ActualClass;
 end A;
 model B
   extends A;
-  Boolean b = a.quasiStatic;
+  Boolean b = correct;
 end B;
 \end{lstlisting}
-The \lstinline!convertElement! call for \lstinline!DC_ElectricalExcited! is needed to avoid relying on base classes in the original library where \lstinline!DC_ElectricalExcited! inherits from \lstinline!PartialBasicDCMachine!.
+The \lstinline!convertElement! call for \lstinline!ActualClass! is needed to avoid relying on base classes in the original library where \lstinline!ActualClass! inherits from \lstinline!PartialBase!.
 However, the inheritance among the models to convert (in this case \lstinline!B! inherits from \lstinline!A!) should be handled.
+Note that conversion works regardless of the import of \lstinline!My.Library!.
 \end{example}
 
 \paragraph*{convertMessage("OldClass", "Failed Message")}\label{convertmessageoldclass-failed-message}\annotationindex{convertMessage}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1746,9 +1746,9 @@ convertModifiers("Modelica.StateGraph.Temporary.NumericValue",
 convertModifiers("Modelica.Blocks.Math.LinearDependency",
    {"y0=0", "k1=0", "k2=0"}, {"y0=%y0%", "k1=%y0%*%k1%", "k2=%y0%*%k2%"},
    true);
-convertClass(
-   "My.Library.BadPackage",
-   "My.Library.Package");
+
+convertClass("My.Library.BadPackage",
+             "My.Library.Package");
 convertElement("My.Library.BadPackage.PartialBase",
                "bad", "correct");
 convertElement("My.Library.BadPackage.ActualClass",


### PR DESCRIPTION
Closes #3081

After all I decided to not use MSL-examples, but clearly mark them as coming from a separate library. An example that is similar to the one I _intended_ to use is already included, but this part - similarly as the old one actually has more properties, I also noticed the first one previously:

- Rename of package containing class with renamed elements
- Special care for base-classes (described in existing note)
- Use of import (added note about that).

I couldn't find a short such example in MSL, and the problem with the previous longer names was that it wasn't easy to see all of these aspects.