### PR TITLE
Generalize calling functions through instances

### DIFF
--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -94,7 +94,7 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
   If not found, and if the first identifier denotes a component and the composite name is used as a function call, the lookup is also performed among the declared elements of the component, and must find a non-operator function.
   Each leading element, including the first one, must in this case be a scalar component, or \lstinline!component[j]! where \lstinline!component! is an array of components and the indices \lstinline!j! can be evaluated at translation time and \lstinline!component[j]! is a scalar.
   All identifiers of the rest of the name (e.g., \lstinline!B! and \lstinline!B.C!) must be classes.
-  Therefore the composite name is comprised of one or more component names (optionally with indexing), followed by one or more class names.
+  That is, the composite name is comprised of one or more component names (optionally with indexing), followed by one or more class names.
 \item
   If the identifier denotes a class, that class is temporarily flattened (as if instantiating a component without modifiers of this class, see \cref{modification-environment}) and using the enclosing classes of the denoted class.
   The rest of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the declared named elements of the temporary flattened class.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -91,8 +91,10 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
 \item
   If the first identifier denotes a component, the rest of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the declared named component elements of the component.
 \item
-  If not found, and if the first identifier denotes a scalar component, or \lstinline!component[j]! where \lstinline!component! is an array of components and the indices \lstinline!j! can be evaluated at translation time and \lstinline!component[j]! is a scalar; and if the composite name is used as a function call, the lookup is also performed among the declared named class elements of the scalar component, and must find a non-operator function.
+  If not found, and if the first identifier denotes a component and the composite name is used as a function call, the lookup is also performed among the declared elements of the component, and must find a non-operator function.
+  Each leading element, including the first one, must in this case be a scalar component, or \lstinline!component[j]! where \lstinline!component! is an array of components and the indices \lstinline!j! can be evaluated at translation time and \lstinline!component[j]! is a scalar.
   All identifiers of the rest of the name (e.g., \lstinline!B! and \lstinline!B.C!) must be classes.
+  Therefore the composite name is comprised of one or more component names (optionally with indexing), followed by one or more class names.
 \item
   If the identifier denotes a class, that class is temporarily flattened (as if instantiating a component without modifiers of this class, see \cref{modification-environment}) and using the enclosing classes of the denoted class.
   The rest of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the declared named elements of the temporary flattened class.


### PR DESCRIPTION
Instead of just having `c1.A.B.function` we now allow `c1.c2.c3.A.B.function`
Closes #3089 

I believe we should get the group involved, since it is an enhancement - not significant enough for an MCP, but still not something that we should hide as a 'clarification'

