### PR TITLE
Add special text for sample in clocked systems.

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1087,7 +1087,7 @@ The use of the operator \lstinline!sample! from \cref{event-related-operators-wi
 Diagnostics are appropriate especially if it is intended to generate sampling faster than the clocks, and otherwise the sampling should ideally be adjusted to the clock ticks.
 
 \begin{nonnormative}
-Since the goal is that it should be possible to use \emph{every} continuous-time Modelica model in a sampled data control system, it is not forbidden.
+The reason for not disallowing \lstinline!sample! in a clocked partition is to make it possible to include \emph{any} continuous-time Modelica model in a sampled data control system.
 Note that even if the sampling is slower than the clock ticks (or even the same rate) it still introduces the problem of possibly uneven sampling.
 \end{nonnormative}
 

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1084,7 +1084,7 @@ Such a partition has to be solved with a \emph{solver method} of \cref{solver-me
 When \lstinline!previous(x)! is used on a continuous-time state variable \lstinline!x!, then \lstinline!previous(x)! uses the start value of \lstinline!x! as value for the first clock tick.
 
 The use of the operator \lstinline!sample! from \cref{event-related-operators-with-function-syntax} in a clocked partition is problematic.
-Diagnostics are appropriate especially if it is intended to generate sampling faster than the clocks, and otherwise the sampling should ideally be adjusted to the clock ticks.
+A diagnostic is recommended, especially if the operator is intended to generate events faster than the clock ticks, and otherwise the sampling should ideally be adjusted to the clock ticks.
 
 \begin{nonnormative}
 The reason for not disallowing \lstinline!sample! in a clocked partition is to make it possible to include \emph{any} continuous-time Modelica model in a sampled data control system.

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1083,6 +1083,14 @@ If a clocked partition is not a \emph{clocked discrete-time} partition, it is a 
 Such a partition has to be solved with a \emph{solver method} of \cref{solver-methods}.
 When \lstinline!previous(x)! is used on a continuous-time state variable \lstinline!x!, then \lstinline!previous(x)! uses the start value of \lstinline!x! as value for the first clock tick.
 
+The use of the operator \lstinline!sample! from \cref{event-related-operators-with-function-syntax} in a clocked partition is problematic.
+Diagnostics are appropriate especially if it is intended to generate sampling faster than the clocks, and otherwise the sampling should ideally be adjusted to the clock ticks.
+
+\begin{nonnormative}
+Since the goal is that it should be possible to use \emph{every} continuous-time Modelica model in a sampled data control system, it is not forbidden.
+Note that even if the sampling is slower than the clock ticks (or even the same rate) it still introduces the problem of possibly uneven sampling.
+\end{nonnormative}
+
 In a clocked discrete-time partition all event generating mechanisms do no longer apply.
 Especially neither relations, nor any of the built-in operators of \cref{event-triggering-mathematical-functions} (event triggering mathematical functions) will trigger an event.
 


### PR DESCRIPTION
Extract potential controversial change from #3090
Note that the previous text referred to sample in:

> If a clocked partition contains no operator der, delay, spatialDistribution, no event related operators from section 3.7.5 (with exception of noEvent and smooth), and no when-clause with a Boolean condition, it is a clocked discrete-time partition.

As  3.7.5c contatains sample

Revert "RemoveSampleNow"

This reverts commit 32770c0893ab7c7d26b2d3a977a8140b698ab0c5.