### PR TITLE
Changed y into x in spatialDistribution() definitions

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -810,18 +810,18 @@ In this case, the internal state of the operator is hidden from the ODE solver.
 
 \lstinline!spatialDistribution! allows the infinite-dimensional problem below to be solved efficiently with good accuracy
 \begin{align*}
-\frac{\partial z(y,t)}{\partial t}+v(t)\frac{\partial z(y,t)}{\partial y} &= 0.0\\
+\frac{\partial z(x,t)}{\partial t}+v(t)\frac{\partial z(x,t)}{\partial x} &= 0.0\\
 z(0.0, t) &= \mathrm{in}_0(t) \text{ if $v\geq 0$}\\
 z(1.0, t) &= \mathrm{in}_1(t) \text{ if $v<0$}
 \end{align*}
-where $z(y, t)$ is the transported quantity, $y$ is the normalized spatial coordinate ($0.0 \le y \le 1.0$), $t$ is the time, $v(t)=\mathrm{der}(x)$ is the normalized transport velocity and the boundary conditions are set at either $y=0.0$ or $y=1.0$, depending on the sign of the velocity.
+where $z(x, t)$ is the transported quantity, $x$ is the normalized spatial coordinate ($0.0 \le x \le 1.0$), $t$ is the time, $v(t)=\mathrm{der}(x)$ is the normalized transport velocity and the boundary conditions are set at either $x=0.0$ or $x=1.0$, depending on the sign of the velocity.
 The calling syntax is:
 \begin{lstlisting}[language=modelica]
 (out0, out1) = spatialDistribution(in0, in1, x, positiveVelocity,
                                    initialPoints = {0.0, 1.0},
                                    initialValues = {0.0, 0.0});
 \end{lstlisting}
-where \lstinline!in0!, \lstinline!in1!, \lstinline!out0!, \lstinline!out1!, \lstinline!x!, \lstinline!v! are all subtypes of \lstinline!Real!, \lstinline!positiveVelocity! is a \lstinline!Boolean!, \lstinline!initialPoints! and \lstinline!initialValues! are arrays of subtypes of \lstinline!Real! of equal size, containing the y coordinates and the $z$ values of a finite set of points describing the initial distribution of $z(y, \mathit{t0})$.
+where \lstinline!in0!, \lstinline!in1!, \lstinline!out0!, \lstinline!out1!, \lstinline!x!, \lstinline!v! are all subtypes of \lstinline!Real!, \lstinline!positiveVelocity! is a \lstinline!Boolean!, \lstinline!initialPoints! and \lstinline!initialValues! are arrays of subtypes of \lstinline!Real! of equal size, containing the x coordinates and the $z$ values of a finite set of points describing the initial distribution of $z(x, \mathit{t0})$.
 The \lstinline!out0! and \lstinline!out1! are given by the solutions at $z(0.0, t)$ and $z(1.0, t)$; and \lstinline!in0! and \lstinline!in1! are the boundary conditions at $z(0.0, t)$ and $z(1.0, t)$ (at each point in time only one of \lstinline!in0! and \lstinline!in1! is used).
 Elements in the \lstinline!initialPoints! array must be sorted in non-descending order.
 The operator can not be vectorized according to the vectorization rules described in \cref{scalar-functions-applied-to-array-arguments}.
@@ -829,7 +829,7 @@ The operator can be vectorized only with respect to the arguments \lstinline!in0
 
 The solution, $z$, can be described in terms of characteristics:
 \begin{equation*}
-z(y+\int_{t}^{t+\beta} v(\alpha) \mathrm{d}\alpha, t+\beta) = z(y, t),\quad\text{for all $\beta$ as long as staying inside the domain}
+z(x+\int_{t}^{t+\beta} v(\alpha) \mathrm{d}\alpha, t+\beta) = z(x, t),\quad\text{for all $\beta$ as long as staying inside the domain}
 \end{equation*}
 
 This allows the direct computation of the solution based on interpolating the boundary conditions.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -821,7 +821,7 @@ The calling syntax is:
                                    initialPoints = {0.0, 1.0},
                                    initialValues = {0.0, 0.0});
 \end{lstlisting}
-where \lstinline!in0!, \lstinline!in1!, \lstinline!out0!, \lstinline!out1!, \lstinline!x!, \lstinline!v! are all subtypes of \lstinline!Real!, \lstinline!positiveVelocity! is a \lstinline!Boolean!, \lstinline!initialPoints! and \lstinline!initialValues! are arrays of subtypes of \lstinline!Real! of equal size, containing the x coordinates and the $z$ values of a finite set of points describing the initial distribution of $z(x, \mathit{t0})$.
+where \lstinline!in0!, \lstinline!in1!, \lstinline!out0!, \lstinline!out1!, and \lstinline!x! are all subtypes of \lstinline!Real!, \lstinline!positiveVelocity! is a \lstinline!Boolean!, \lstinline!initialPoints! and \lstinline!initialValues! are arrays of subtypes of \lstinline!Real! of equal size, containing the x coordinates and the $z$ values of a finite set of points describing the initial distribution of $z(x, \mathit{t0})$.
 The \lstinline!out0! and \lstinline!out1! are given by the solutions at $z(0.0, t)$ and $z(1.0, t)$; and \lstinline!in0! and \lstinline!in1! are the boundary conditions at $z(0.0, t)$ and $z(1.0, t)$ (at each point in time only one of \lstinline!in0! and \lstinline!in1! is used).
 Elements in the \lstinline!initialPoints! array must be sorted in non-descending order.
 The operator can not be vectorized according to the vectorization rules described in \cref{scalar-functions-applied-to-array-arguments}.


### PR DESCRIPTION
Addresses the issue raised by @eshmoylova in #3111