### PR TITLE
Clean up quadrature listings

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -501,12 +501,14 @@ end Integrand;
 
 A functional argument can be provided in one of the following forms to be passed to a scalar formal parameter of function type in a function call:
 \begin{enumerate}
-\def\labelenumi{\alph{enumi})}
-\item
+% Don't mess with item style while enumitem.sty is not in use (or we'd have to also fix the \ref commands to produce the correct item labels).
+% Check preamble.tex for current status.
+%\def\labelenumi{\alph{enumi})}
+\item\label{functional-argument:type-specifier}
   as a function type-specifier (\lstinline!Parabola! example below),
 \item
   as a function partial application (\cref{function-partial-application} below),
-\item
+\item\label{functional-argument:component}
   as a function that is a component (i.e., a formal parameter of function type of the enclosing function),
 \item
   as a function partial application of a function that is a component (example in \cref{function-partial-application} below).
@@ -515,7 +517,7 @@ A functional argument can be provided in one of the following forms to be passed
 In all cases the provided function must be function-compatible (\cref{function-compatibility}) with the corresponding formal parameter of function type.
 
 \begin{example}
-A function as a positional input argument according to case (a):
+A function as a positional input argument according to case~\ref{functional-argument:type-specifier}:
 \begin{lstlisting}[language=modelica]
 function Parabola
   extends Integrand;
@@ -524,7 +526,7 @@ algorithm
 end Parabola;
 area = quadrature(0, 1, Parabola);
 \end{lstlisting}
-The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a component as input argument according to case (c):
+The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a component as input argument according to case~\ref{functional-argument:component}:
 \begin{lstlisting}[language=modelica]
 function quadrature2 "Integrate function y = integrand(x) from x1 to x2"
   input Real x1;

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -503,7 +503,7 @@ A functional argument can be provided in one of the following forms to be passed
 \begin{enumerate}
 % Don't mess with item style while enumitem.sty is not in use (or we'd have to also fix the \ref commands to produce the correct item labels).
 % Check preamble.tex for current status.
-%\def\labelenumi{\alph{enumi})}
+%\def\labelenumi{\alph{enumi}.}
 \item\label{functional-argument:type-specifier}
   as a function type-specifier (\lstinline!Parabola! example below),
 \item

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -486,16 +486,14 @@ value.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-function quadrature "Integrate function y=integrand(x) from x1 to x2"
+function quadrature "Integrate function y = integrand(x) from x1 to x2"
   input Real x1;
   input Real x2;
-  input Integrand integrand; // Integrand is a partial function,
-  see below
-  // With default: input Integrand integrand =
-  Modelica.Math.sin;
+  input Integrand integrand; // Integrand is a partial function, see below
+  // With default: input Integrand integrand = Modelica.Math.sin;
   output Real integral;
 algorithm
-  integral :=(x2-x1)*(integrand(x1) + integrand(x2))/2;
+  integral := (x2 - x1) * (integrand(x1) + integrand(x2)) / 2;
 end quadrature;
 
 partial function Integrand
@@ -529,14 +527,14 @@ A function as a positional input argument according to case (a):
 function Parabola
   extends Integrand;
 algorithm
-  y := x*x;
+  y := x * x;
 end Parabola;
 area = quadrature(0, 1, Parabola);
 \end{lstlisting}
 The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a
 component as input argument according to case (c):
 \begin{lstlisting}[language=modelica]
-function quadrature2 "Integrate function y=integrand(x) from x1 to x2"
+function quadrature2 "Integrate function y = integrand(x) from x1 to x2"
   input Real x1;
   input Real x2;
   input Integrand integrand; // Integrand is a partial function type

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -475,14 +475,10 @@ RealToString(2.0, 6, precision=6); // error: slot is used twice
 
 \subsection{Functional Input Arguments}\label{functional-input-arguments-to-functions}
 
-A functional input argument to a function is an argument of function
-type. The declared type of such an input formal parameter in a function
-can be the type-specifier of a partial function that has no replaceable
-elements. It cannot be the type-specifier of a record or enumeration
-(i.e., record constructor functions and enumeration type
-conversions are not allowed in this context). Such an input formal
-parameter of function type can also have an optional functional default
-value.
+A functional input argument to a function is an argument of function type.
+The declared type of such an input formal parameter in a function can be the type-specifier of a partial function that has no replaceable elements.
+It cannot be the type-specifier of a record or enumeration (i.e., record constructor functions and enumeration type conversions are not allowed in this context).
+Such an input formal parameter of function type can also have an optional functional default value.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -503,9 +499,7 @@ end Integrand;
 \end{lstlisting}
 \end{example}
 
-A functional argument can be provided in one of the following forms to
-be passed to a scalar formal parameter of function type in a function
-call:
+A functional argument can be provided in one of the following forms to be passed to a scalar formal parameter of function type in a function call:
 \begin{enumerate}
 \def\labelenumi{\alph{enumi})}
 \item
@@ -515,8 +509,7 @@ call:
 \item
   as a function that is a component (i.e., a formal parameter of function type of the enclosing function),
 \item
-  as a function partial application of a function that is a component
-  (example in \cref{function-partial-application} below).
+  as a function partial application of a function that is a component (example in \cref{function-partial-application} below).
 \end{enumerate}
 
 In all cases the provided function must be function-compatible (\cref{function-compatibility}) with the corresponding formal parameter of function type.
@@ -531,8 +524,7 @@ algorithm
 end Parabola;
 area = quadrature(0, 1, Parabola);
 \end{lstlisting}
-The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a
-component as input argument according to case (c):
+The \lstinline!quadrature2! example below uses a function \lstinline!integrand! that is a component as input argument according to case (c):
 \begin{lstlisting}[language=modelica]
 function quadrature2 "Integrate function y = integrand(x) from x1 to x2"
   input Real x1;

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -196,7 +196,7 @@ Complex c = a * b; // interpreted as:
 \item\label{overloaded-binary-arrays}
   Otherwise, if \lstinline!a! or \lstinline!b! is an array expression, then the expression is conceptually evaluated according to the rules of \cref{scalar-vector-matrix-and-array-operator-functions} with the following exceptions concerning \cref{matrix-and-vector-multiplication-of-numeric-arrays}:
   \begin{enumerate}
-  \def\labelenumii{(\alph{enumii})}
+  \def\labelenumii{\alph{enumii}.}
   \item
     \lstinline!$\mathit{vector}$ * $\mathit{vector}$! is not automatically defined based on the scalar multiplication.
     \begin{nonnormative}


### PR DESCRIPTION
This fixes issues with line breaks inside rest-of-line comments.
