### PR TITLE
A class is not a specialized class

### DIFF
--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -10,7 +10,7 @@ It provides object-oriented constructs that facilitate reuse of models, and can 
 The semantics of the Modelica language is specified by means of a set of rules for translating any class described in the Modelica language to a flat Modelica structure.
 The semantic specification should be read together with the Modelica grammar.
 
-A class (of specialized class \lstinline!model!, \lstinline!class! or \lstinline!block!) intended to be simulated on its own is called a \firstuse{simulation model}.
+A class (of specialized class \lstinline!model! or \lstinline!block!) intended to be simulated on its own is called a \firstuse{simulation model}.
 
 The flat Modelica structure is also defined for other cases than simulation models; including functions (can be used to provide algorithmic contents), packages (used as a structuring mechanism), and partial models (used as base-models).
 This allows correctness to be verified for those classes, before using them to build the simulation model.


### PR DESCRIPTION
According to https://github.com/modelica/ModelicaStandardLibrary/pull/2500 and section 4.6 a (specialized) class cannot be a simulation model.