### PR TITLE
Make multiple lines non-normative.

### DIFF
--- a/RationaleMCP/0035/SpecificationText.md
+++ b/RationaleMCP/0035/SpecificationText.md
@@ -50,7 +50,9 @@ Then, the `<context identifier>` behind the keyword `msgctxt` is the full name o
 After the `msgid` keyword the text string which shall be translated follows. It should contain the original string from the Modelica text representation. 
 Since in Modelica control sequences also start with a backslash and another backslash is used to use sequences literally or to hide double quotes, no change is required here. 
 But Modelica allows strings to go over more than one line, gettext does not.
-Therefore, Modelica strings must be split into consecutive strings at the line breaks, and the line breaks must be encoded with a "\n" at the end of each string, e.g.
+Therefore, line breaks in Modelica must be encoded with "\n".
+
+In order to avoid long lines Modelica strings may be split into consecutive strings at the line breaks, and the line breaks encoded with a "\n" at the end of each string, e.g.
 ```
 "A
 B"

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -399,7 +399,7 @@ But Modelica allows strings to go over more than one line, gettext does not.
 Therefore, line breaks in Modelica must be encoded with \lstinline!"\n"!.
 
 \begin{nonnormative}
-In order to avoid long lines Modelica strings may be split into consecutive strings at the line breaks, and the line breaks encoded with a \lstinline!"\n"! at the end of each string, e.g.
+In order to avoid long lines, strings may be split into smaller parts given on consecutive lines, e.g.
 \begin{lstlisting}
 "A
 B"

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -396,7 +396,10 @@ After the `msgid` keyword the text string which shall be translated follows.
 It should contain the original string from the Modelica text representation.
 Since in Modelica control sequences also start with a backslash and another backslash is used to use sequences literally or to hide double quotes, no change is required here.
 But Modelica allows strings to go over more than one line, gettext does not.
-Therefore, Modelica strings must be split into consecutive strings at the line breaks, and the line breaks must be encoded with a \lstinline!"\n"! at the end of each string, e.g.
+Therefore, line breaks in Modelica must be encoded with \lstinline!"\n"!.
+
+\begin{nonnormative}
+In order to avoid long lines Modelica strings may be split into consecutive strings at the line breaks, and the line breaks encoded with a \lstinline!"\n"! at the end of each string, e.g.
 \begin{lstlisting}
 "A
 B"
@@ -407,7 +410,6 @@ is converted to
 "B"
 \end{lstlisting}
 These strings are concatenated when read.
-\begin{nonnormative}
 Please regard that if a \lstinline!msgid! string is given more than once in the same context, all occurrences are translated with the same (last) translation!
 \end{nonnormative}
 


### PR DESCRIPTION
I believe this preserves the right parts of the line-break handling. Can you check?
I didn't make the description of gettext-format non-normative, since I don't know exactly what is part of gettext and what is how it is adapted to Modelica.