### PR TITLE
Non optional connector

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -460,6 +460,7 @@ The annotation \fmtannotationindex{singleInstance} in a class indicates that the
 The intent is to remove the class when the component is removed and to prevent duplication of the component.
 
 \subsection{Connection Restrictions}\label{connection-restrictions}
+
 A connector component declaration may have the following annotation:
 \begin{lstlisting}[language=modelica]
 annotation(mustBeConnected = "message");
@@ -497,7 +498,7 @@ annotation(mayOnlyConnectOnce = "message");
 It makes it an error if the connector is connected from the outside and:
 \begin{itemize}
 \item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on the \lstinline!min!-attribute).
+\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on evaluation of the \lstinline!min!-attribute).
 \end{itemize}
 For an array of connectors it applies separately to each element.
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1323,9 +1323,9 @@ Note that this annotation is only intended for non-causal connectors, see \cref{
 This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
 \begin{lstlisting}[language=modelica]
 model MultiPort
-  parameter Integer n=0 annotation(Dialog(connectorSizing=true));
-  FluidPort_a port_a(redeclare package Medium=Medium);
-  FluidPorts_b ports_b[n](redeclare each package Medium=Medium)
+  parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
+  FluidPort_a port_a(redeclare package Medium = Medium);
+  FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
     annotation (mayOnlyConnectOnce = "Should only connect once per element!");
   $\ldots$
 end MultiPort;

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1304,10 +1304,12 @@ annotation(mayOnlyConnectOnce = "message");
 \end{lstlisting}%
 \annotationindex{mayOnlyConnectOnce}
 
-If non-empty it indicates that a diagnostics should be given if the connector is connected more than once from the outside.
+If non-empty it indicates that a diagnostics should be given if the connector as outside connector is part of a connection set with more than two members.
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
+The intuitive explanation is that it is as most connected once, but the formulation also handles the case where it is connected to something that it is then connected to another connector.
+Both variants would cause the same problem.
 Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
 \end{nonnormative}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1272,6 +1272,49 @@ end Frame;
 \end{lstlisting}
 \end{example}
 
+A connector component declaration may have the following annotation:
+\begin{lstlisting}[language=modelica]
+annotation(mustBeConnected = "message");
+\end{lstlisting}%
+\annotationindex{mustBeConnected}
+
+If non-empty it indicates that a diagnostics should be given if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
+For an array of connectors it applies separately to each element.
+
+\begin{example}
+This can be used for some optional connectors that should be connected when conditionally enabled.
+\begin{lstlisting}[language=modelica]
+partial model PartialWithSupport
+  Flange_a flange_a;
+  Flange_b flange_b;
+  Support support($\ldots$)
+    if useSupport annotation(mustBeConnected = "Support connector should be connected if activated.");
+  $\ldots$
+end PartialWithSupport;
+\end{lstlisting}
+\end{example}
+
+A connector component declaration may have the following annotation:
+\begin{lstlisting}[language=modelica]
+annotation(mayOnlyConnectOnce = "message");
+\end{lstlisting}%
+\annotationindex{mayOnlyConnectOnce}
+
+If non-empty it indicates that a diagnostics should be given if the connector is connected more than once from the outside.
+For an array of connectors it applies separately to each element.
+
+\begin{example}
+This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
+\begin{lstlisting}[language=modelica]
+model MultiPort
+  FluidPort_a port_a(redeclare package Medium=Medium);
+  FluidPorts_b ports_b[nPorts_b](redeclare each package Medium=Medium)
+    annotation (mayOnlyConnectOnce = "...");
+  $\ldots$
+end MultiPort;
+\end{lstlisting}
+\end{example}
+
 A component declaration or a short replaceable class definition may have the following annotation:
 \begin{lstlisting}[language=modelica]
 record Dialog

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1309,7 +1309,7 @@ If non-empty it indicates that a diagnostics should be given when it is connecte
 \begin{itemize}
 \item For non-stream connectors the connection set has more than two elements.
 \item For stream connectors, \cref{stream-connectors}, the connection set has more than two elements whose flow variable may be negative.
-\item{itemize}
+\end{itemize}
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -447,7 +447,8 @@ This annotation can both be used for models intended as test-cases for implement
 \end{annotationdefinition}
 
 
-\section{Single Use of Class}\label{annotation-for-single-use-of-class}\label{single-use-of-class}
+\section{Usage Restrictions}\label{usage-restrictions}
+\subsection{Single Use of Class}\label{annotation-for-single-use-of-class}\label{single-use-of-class}
 
 For state machines it is useful to have single instances of local classes.
 This can be done using:
@@ -458,6 +459,68 @@ annotation(singleInstance = true)
 The annotation \fmtannotationindex{singleInstance} in a class indicates that there should only be one component instance of the class, and it should be in the same scope as the class is defined.
 The intent is to remove the class when the component is removed and to prevent duplication of the component.
 
+\subsection{Connection Restrictions}\label{connection-restrictions}
+A connector component declaration may have the following annotation:
+\begin{lstlisting}[language=modelica]
+annotation(mustBeConnected = "message");
+\end{lstlisting}%
+\annotationindex{mustBeConnected}
+
+It makes it an error if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
+For an array of connectors it applies separately to each element.
+
+\begin{nonnormative}
+This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+It is particularly suited for stream connectors, see \cref{stream-connectors}.
+\end{nonnormative}
+
+\begin{example}
+This can be used for some optional connectors that should be connected when conditionally enabled.
+\begin{lstlisting}[language=modelica]
+partial model PartialWithSupport
+  Flange_a flange_a;
+  Flange_b flange_b;
+  Support support($\ldots$)
+    if useSupport
+    annotation(
+      mustBeConnected = "Support connector should be connected if activated.");
+  $\ldots$
+end PartialWithSupport;
+\end{lstlisting}
+\end{example}
+
+A connector component declaration may have the following annotation:
+\begin{lstlisting}[language=modelica]
+annotation(mayOnlyConnectOnce = "message");
+\end{lstlisting}%
+\annotationindex{mayOnlyConnectOnce}
+
+It makes it an error if the connector is connected from the outside and:
+\begin{itemize}
+\item For non-stream connectors the connection set has more than two elements.
+\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative.
+\end{itemize}
+For an array of connectors it applies separately to each element.
+
+\begin{nonnormative}
+This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
+The set handling avoids the case where only one of two equivalent models generate diagnostics.
+The stream connector part is primarily intended to exclude sensor-variables, but also excludes non-reversible outgoing flows.
+\end{nonnormative}
+
+\begin{example}
+This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
+\begin{lstlisting}[language=modelica]
+model MultiPort
+  parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
+  FluidPort_a port_a(redeclare package Medium = Medium);
+  FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
+    annotation (mayOnlyConnectOnce = "Should only connect once per element!");
+  $\ldots$
+end MultiPort;
+\end{lstlisting}
+\end{example}
 
 \section{Graphical Objects}\label{annotations-for-graphical-objects}\label{graphical-objects}
 
@@ -1272,67 +1335,7 @@ end Frame;
 \end{lstlisting}
 \end{example}
 
-A connector component declaration may have the following annotation:
-\begin{lstlisting}[language=modelica]
-annotation(mustBeConnected = "message");
-\end{lstlisting}%
-\annotationindex{mustBeConnected}
 
-It makes it an error if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
-For an array of connectors it applies separately to each element.
-
-\begin{nonnormative}
-This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
-It is particularly suited for stream connectors, see \cref{stream-connectors}.
-\end{nonnormative}
-
-\begin{example}
-This can be used for some optional connectors that should be connected when conditionally enabled.
-\begin{lstlisting}[language=modelica]
-partial model PartialWithSupport
-  Flange_a flange_a;
-  Flange_b flange_b;
-  Support support($\ldots$)
-    if useSupport
-    annotation(
-      mustBeConnected = "Support connector should be connected if activated.");
-  $\ldots$
-end PartialWithSupport;
-\end{lstlisting}
-\end{example}
-
-A connector component declaration may have the following annotation:
-\begin{lstlisting}[language=modelica]
-annotation(mayOnlyConnectOnce = "message");
-\end{lstlisting}%
-\annotationindex{mayOnlyConnectOnce}
-
-It makes it an error if the connector is connected from the outside and:
-\begin{itemize}
-\item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative.
-\end{itemize}
-For an array of connectors it applies separately to each element.
-
-\begin{nonnormative}
-This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
-The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
-The set handling avoids the case where only one of two equivalent models generate diagnostics.
-The stream connector part is primarily intended to exclude sensor-variables, but also excludes non-reversible outgoing flows.
-\end{nonnormative}
-
-\begin{example}
-This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
-\begin{lstlisting}[language=modelica]
-model MultiPort
-  parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
-  FluidPort_a port_a(redeclare package Medium = Medium);
-  FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
-    annotation (mayOnlyConnectOnce = "Should only connect once per element!");
-  $\ldots$
-end MultiPort;
-\end{lstlisting}
-\end{example}
 
 A component declaration or a short replaceable class definition may have the following annotation:
 \begin{lstlisting}[language=modelica]

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1278,12 +1278,12 @@ annotation(mustBeConnected = "message");
 \end{lstlisting}%
 \annotationindex{mustBeConnected}
 
-If non-empty it indicates that it is an error if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
+It makes it an error if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
-Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
-It is in particular suited for stream-connectors, \cref{stream-connectors}.
+This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+It is particularly suited for stream connectors, see \cref{stream-connectors}.
 \end{nonnormative}
 
 \begin{example}
@@ -1293,7 +1293,9 @@ partial model PartialWithSupport
   Flange_a flange_a;
   Flange_b flange_b;
   Support support($\ldots$)
-    if useSupport annotation(mustBeConnected = "Support connector should be connected if activated.");
+    if useSupport
+    annotation(
+      mustBeConnected = "Support connector should be connected if activated.");
   $\ldots$
 end PartialWithSupport;
 \end{lstlisting}
@@ -1305,18 +1307,18 @@ annotation(mayOnlyConnectOnce = "message");
 \end{lstlisting}%
 \annotationindex{mayOnlyConnectOnce}
 
-If non-empty it indicates that it is an error if it is connected from the outside and:
+It makes it an error if the connector is connected from the outside and:
 \begin{itemize}
 \item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors, \cref{stream-connectors}, the connection set has more than two elements whose flow variable may be negative.
+\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative.
 \end{itemize}
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
+This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
 The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
 The set handling avoids the case where only one of two equivalent models generate diagnostics.
 The stream connector part is primarily intended to exclude sensor-variables, but also excludes non-reversible outgoing flows.
-Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
 \end{nonnormative}
 
 \begin{example}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1278,7 +1278,7 @@ annotation(mustBeConnected = "message");
 \end{lstlisting}%
 \annotationindex{mustBeConnected}
 
-If non-empty it indicates that a diagnostics should be given if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
+If non-empty it indicates that it is an error if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
@@ -1305,7 +1305,7 @@ annotation(mayOnlyConnectOnce = "message");
 \end{lstlisting}%
 \annotationindex{mayOnlyConnectOnce}
 
-If non-empty it indicates that a diagnostics should be given when it is connected from the outside and:
+If non-empty it indicates that it is an error if it is connected from the outside and:
 \begin{itemize}
 \item For non-stream connectors the connection set has more than two elements.
 \item For stream connectors, \cref{stream-connectors}, the connection set has more than two elements whose flow variable may be negative.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1283,6 +1283,7 @@ For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
 Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+It is in particular suited for stream-connectors, \cref{stream-connectors}.
 \end{nonnormative}
 
 \begin{example}
@@ -1304,12 +1305,17 @@ annotation(mayOnlyConnectOnce = "message");
 \end{lstlisting}%
 \annotationindex{mayOnlyConnectOnce}
 
-If non-empty it indicates that a diagnostics should be given if the connector as outside connector is part of a connection set with more than two members.
+If non-empty it indicates that a diagnostics should be given when it is connected from the outside and:
+\begin{itemize}
+\item For non-stream connectors the connection set has more than two elements.
+\item For stream connectors, \cref{stream-connectors}, the connection set has more than two elements whose flow variable may be negative.
+\item{itemize}
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
-The intuitive explanation is that it is as most connected once, but the formulation also handles the case where it is connected to something that it is then connected to another connector.
-Both variants would cause the same problem.
+The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
+The set handling avoids the case where only one of two equivalent models generate diagnostics.
+The stream connector part is primarily intended to exclude sensor-variables, but also excludes non-reversible outgoing flows.
 Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
 \end{nonnormative}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -489,38 +489,6 @@ end PartialWithSupport;
 The protected components and connections needed to internally handle the support-connector is omitted.
 \end{example}
 
-A connector component declaration may have the following annotation:
-\begin{lstlisting}[language=modelica]
-annotation(mayOnlyConnectOnce = "message");
-\end{lstlisting}%
-\annotationindex{mayOnlyConnectOnce}
-
-It makes it an error if the connector is connected from the outside and:
-\begin{itemize}
-\item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on evaluation of the \lstinline!min!-attribute).
-\end{itemize}
-For an array of connectors it applies separately to each element.
-
-\begin{nonnormative}
-This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
-The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
-The set handling avoids the case where only one of two equivalent models generate diagnostics.
-The stream connector part is primarily intended to exclude sensor-variables, see \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}, but also excludes non-reversible outgoing flows.
-\end{nonnormative}
-
-\begin{example}
-This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
-\begin{lstlisting}[language=modelica]
-partial model MultiPort
-  parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
-  FluidPort_a port_a(redeclare package Medium = Medium);
-  FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
-    annotation (mayOnlyConnectOnce = "Should only connect once per element!");
-end MultiPort;
-\end{lstlisting}
-\end{example}
-
 \section{Graphical Objects}\label{annotations-for-graphical-objects}\label{graphical-objects}
 
 A graphical representation of a class consists of two abstraction

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -478,15 +478,14 @@ It is particularly suited for stream connectors, see \cref{stream-connectors}.
 This can be used for some optional connectors that should be connected when conditionally enabled.
 \begin{lstlisting}[language=modelica]
 partial model PartialWithSupport
-  Flange_a flange_a;
-  Flange_b flange_b;
-  Support support($\ldots$)
-    if useSupport
+  Flange_b flange;
+  parameter Boolean useSupport;
+  Support support if useSupport
     annotation(
       mustBeConnected = "Support connector should be connected if activated.");
-  $\ldots$
 end PartialWithSupport;
 \end{lstlisting}
+The protected components and connections needed to internally handle the support-connector is omitted.
 \end{example}
 
 A connector component declaration may have the following annotation:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -506,7 +506,7 @@ For an array of connectors it applies separately to each element.
 This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
 The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
 The set handling avoids the case where only one of two equivalent models generate diagnostics.
-The stream connector part is primarily intended to exclude sensor-variables, but also excludes non-reversible outgoing flows.
+The stream connector part is primarily intended to exclude sensor-variables, see \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}, but also excludes non-reversible outgoing flows.
 \end{nonnormative}
 
 \begin{example}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1281,6 +1281,10 @@ annotation(mustBeConnected = "message");
 If non-empty it indicates that a diagnostics should be given if the connector is not connected from the outside (for a conditional connector this check is only active if the connector is enabled).
 For an array of connectors it applies separately to each element.
 
+\begin{nonnormative}
+Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+\end{nonnormative}
+
 \begin{example}
 This can be used for some optional connectors that should be connected when conditionally enabled.
 \begin{lstlisting}[language=modelica]
@@ -1303,13 +1307,18 @@ annotation(mayOnlyConnectOnce = "message");
 If non-empty it indicates that a diagnostics should be given if the connector is connected more than once from the outside.
 For an array of connectors it applies separately to each element.
 
+\begin{nonnormative}
+Note that this annotation is only intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+\end{nonnormative}
+
 \begin{example}
 This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
 \begin{lstlisting}[language=modelica]
 model MultiPort
+  parameter Integer n=0 annotation(Dialog(connectorSizing=true));
   FluidPort_a port_a(redeclare package Medium=Medium);
-  FluidPorts_b ports_b[nPorts_b](redeclare each package Medium=Medium)
-    annotation (mayOnlyConnectOnce = "...");
+  FluidPorts_b ports_b[n](redeclare each package Medium=Medium)
+    annotation (mayOnlyConnectOnce = "Should only connect once per element!");
   $\ldots$
 end MultiPort;
 \end{lstlisting}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1335,8 +1335,6 @@ end Frame;
 \end{lstlisting}
 \end{example}
 
-
-
 A component declaration or a short replaceable class definition may have the following annotation:
 \begin{lstlisting}[language=modelica]
 record Dialog

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -511,12 +511,11 @@ The stream connector part is primarily intended to exclude sensor-variables, see
 \begin{example}
 This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
 \begin{lstlisting}[language=modelica]
-model MultiPort
+partial model MultiPort
   parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
   FluidPort_a port_a(redeclare package Medium = Medium);
   FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
     annotation (mayOnlyConnectOnce = "Should only connect once per element!");
-  $\ldots$
 end MultiPort;
 \end{lstlisting}
 \end{example}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -498,7 +498,7 @@ annotation(mayOnlyConnectOnce = "message");
 It makes it an error if the connector is connected from the outside and:
 \begin{itemize}
 \item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative.
+\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on the \lstinline!min!-attribute).
 \end{itemize}
 For an array of connectors it applies separately to each element.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -551,14 +551,8 @@ A component declared with a condition-attribute can only be modified and/or used
 Adding the component and then removing it ensures that the component is valid.
 
 If a connect equation defines the connection of a non-conditional component \lstinline!c1! with a conditional component \lstinline!c2! and \lstinline!c2! is de-activated, then \lstinline!c1! must still be a declared element.
-\end{nonnormative}
 
-If the condition is true for a public connector containing flow
-variables the connector must be connected from the outside.
-
-\begin{nonnormative}
-The reason for this restriction is that the default flow equation is probably incorrect (since it could otherwise
-be an unconditional connector) and the model cannot check that connector is connected.
+There are annotations to handle the case where the connector should be connected when activated, see \cref{annotations-for-the-graphical-user-interface}.
 \end{nonnormative}
 
 \section{Class Declarations}\label{class-declarations}


### PR DESCRIPTION
Closes #3117 (see that ticket for more information).
This needs to be discussed in the group, but the main idea is to revert #178 and instead have annotations for indicating restrictions on connections.

For MSL (and other libraries) the change has two main benefits:

- Reverting #178 that simply doesn't work: activating the diagnostics would generate errors for many examples, and there is no good solution for them.
- Possibility to reduce the use of cardinality.