### PR TITLE
Variability rule for multiple return assignment

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1348,6 +1348,8 @@ While many invalid models can be rejected based on the declared variabilities of
 \item
   For an assignment \lstinline!v := expr! or binding equation \lstinline!v = expr!, \lstinline!v! must be declared to be at least as variable as \lstinline!expr!.
 \item
+  For multiple return assignment \lstinline!(x1, $\ldots$, xn) := expr! (see \cref{assignments-from-called-functions-with-multiple-results}), all of \lstinline!x1!, \ldots, \lstinline!xn! must be declared to be at least as variable as \lstinline!expr!.
+\item
   When determining whether an equation can contribute to solving for a variable \lstinline!v! (for instance, when applying the perfect matching rule, see \cref{synchronous-data-flow-principle-and-single-assignment-rule}), the equation can only be considered contributing if the resulting solution would be at most as variable as \lstinline!v!.
 \item
   The right-hand side expression in a binding equation (that is, \lstinline!expr!) of a parameter component and of the base type attributes (such as \lstinline!start!) needs to be a parameter or constant expression.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1348,15 +1348,11 @@ While many invalid models can be rejected based on the declared variabilities of
 \item
   For an assignment \lstinline!v := expr! or binding equation \lstinline!v = expr!, \lstinline!v! must be declared to be at least as variable as \lstinline!expr!.
 \item
-  When determining whether an equation can contribute to solving for a variable \lstinline!v! (for instance,
-  when applying the perfect matching rule, see \cref{synchronous-data-flow-principle-and-single-assignment-rule}),
-  the equation can only be considered contributing if the resulting solution would be at most as variable as \lstinline!v!.
+  When determining whether an equation can contribute to solving for a variable \lstinline!v! (for instance, when applying the perfect matching rule, see \cref{synchronous-data-flow-principle-and-single-assignment-rule}), the equation can only be considered contributing if the resulting solution would be at most as variable as \lstinline!v!.
 \item
-  The right-hand side expression in a binding equation (that is, \lstinline!expr!) of a parameter component and of the base type attributes
-  (such as \lstinline!start!) needs to be a parameter or constant expression.
+  The right-hand side expression in a binding equation (that is, \lstinline!expr!) of a parameter component and of the base type attributes (such as \lstinline!start!) needs to be a parameter or constant expression.
 \item
-  If \lstinline!v! is a discrete-time component then \lstinline!expr! needs to be a
-  discrete-time expression.
+  If \lstinline!v! is a discrete-time component then \lstinline!expr! needs to be a discrete-time expression.
 \end{itemize}
 
 \begin{example}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1351,10 +1351,6 @@ While many invalid models can be rejected based on the declared variabilities of
   For multiple return assignment \lstinline!(x1, $\ldots$, xn) := expr! (see \cref{assignments-from-called-functions-with-multiple-results}), all of \lstinline!x1!, \ldots, \lstinline!xn! must be declared to be at least as variable as \lstinline!expr!.
 \item
   When determining whether an equation can contribute to solving for a variable \lstinline!v! (for instance, when applying the perfect matching rule, see \cref{synchronous-data-flow-principle-and-single-assignment-rule}), the equation can only be considered contributing if the resulting solution would be at most as variable as \lstinline!v!.
-\item
-  The right-hand side expression in a binding equation (that is, \lstinline!expr!) of a parameter component and of the base type attributes (such as \lstinline!start!) needs to be a parameter or constant expression.
-\item
-  If \lstinline!v! is a discrete-time component then \lstinline!expr! needs to be a discrete-time expression.
 \end{itemize}
 
 \begin{example}


### PR DESCRIPTION
This is a pretty obvious generalization of the variability rule for single variable assignments.

As far as I can tell, we don't need anything extra for the case of multiple return equations.
