### PR TITLE
Avoid need to define a term.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -388,7 +388,7 @@ The annotations listed below define how models can be checked, translated, and s
 \hline
 \hline
 \lstinline!experiment! & Simulation experiment settings & \Cref{modelica:experiment}\\
-\lstinline!HideResult! & Don't show component's simulator result & \Cref{modelica:HideResult}\\
+\lstinline!HideResult! & Don't show component's simulation result & \Cref{modelica:HideResult}\\
 \lstinline!TestCase! & Information for model used as test case & \Cref{modelica:TestCase}\\
 \hline
 \end{tabular}
@@ -417,7 +417,7 @@ If \lstinline!StartTime! is not specified it is assumed to be \lstinline!0.0!.
 "HideResult" "=" ( false | true )
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-\lstinline!HideResult = true! defines that the model developer proposes to not show the simulator results of the corresponding component.
+\lstinline!HideResult = true! defines that the model developer proposes to not show the simulation results of the corresponding component.
 
 \lstinline!HideResult = false! defines that the developer proposes to show the corresponding component.
 

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -76,7 +76,9 @@ and components, and generation of connection equations from \lstinline!connect!-
 % - translation (for phrases such as "during translation")
 % - deprecated
 % - quality of implementation
-% - simulator
+%
+% Note used:
+% - simulator (the program that computes the simulation)
 
 \section{Notation}\label{notation}
 

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -76,9 +76,6 @@ and components, and generation of connection equations from \lstinline!connect!-
 % - translation (for phrases such as "during translation")
 % - deprecated
 % - quality of implementation
-%
-% Note used:
-% - simulator (the program that computes the simulation)
 
 \section{Notation}\label{notation}
 


### PR DESCRIPTION
The term "simulator" was used twice, and unclear if both were correct.
This was based on looking at #3146 - but this part is independent.

It is just a clean-up no actual change (so it is only the term "simulator" that is removed not the fact you might need a "simulator" to construct the simulation result).

