### PR TITLE
Clarify odd cases of IconMap and DiagramMap 'extent'

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -742,11 +742,16 @@ If the \lstinline!primitivesVisible! attribute is false, components and connecti
 
 \begin{itemize}
 \item
-  If the extent of the \lstinline!extends!-clause defines a null region (the default), the base class contents is mapped to the same coordinates in the derived class, and the coordinate system (including \lstinline!preserveAspectRatio!) can be inherited as described in \cref{coordinate-systems}.
+  If the \lstinline!extent! is \lstinline!{{0, 0}, {0, 0}}! (the default), the base class contents is mapped to the same coordinates in the derived class, and the coordinate system (including \lstinline!preserveAspectRatio!) can be inherited as described in \cref{coordinate-systems}.
 \item
-  If the extent of the \lstinline!extends!-clause defines a non-null region, the base class coordinate system is mapped to the region specified by the attribute extent, if \lstinline!preserveAspectRatio! is true for the base class the mapping shall preserve the aspect ratio.
+  For any other \lstinline!extent!, the base class coordinate system is mapped to this region, with the exception that \lstinline!preserveAspectRatio = true! in the base class requires that the mapping shall preserve the aspect ratio.
   The base class coordinate system (and \lstinline!preserveAspectRatio!) is not inherited.
 \end{itemize}
+
+\begin{nonnormative}
+A zero area \lstinline!extent! other than \lstinline!{{0, 0}, {0, 0}}! will result in the base class contents not being visible.
+Reversed corners of the \lstinline!extent! will result in mirrored (rotated if reversed in both direction) base class contents.
+\end{nonnormative}
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -749,7 +749,9 @@ If the \lstinline!primitivesVisible! attribute is false, components and connecti
 \end{itemize}
 
 \begin{nonnormative}
-A zero area \lstinline!extent! other than \lstinline!{{0, 0}, {0, 0}}! will result in the base class contents not being visible.
+A zero area \lstinline!extent! other than \lstinline!{{0, 0}, {0, 0}}! will result in none of the base class contents being visible.
+By affecting components and connections as well as graphical primitives, this is different from setting \lstinline!primitivesVisible = false!.
+
 Reversed corners of the \lstinline!extent! will result in mirrored (rotated if reversed in both direction) base class contents.
 \end{nonnormative}
 


### PR DESCRIPTION
Fixes #3150.

According to [phone meeting decision](https://github.com/modelica/ModelicaSpecification/issues/3150#issuecomment-1109892842).
