### PR TITLE
Undo accidentally removed indentation

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1172,7 +1172,7 @@ globally singular model.
 import Modelica.Units.SI;
 
 partial model BaseProperties
-  "Interface of medium model for all type of media"
+    "Interface of medium model for all type of media"
   parameter Boolean preferredStates = false;
   constant Integer nXi "Number of independent mass fractions";
   InputAbsolutePressure     p;


### PR DESCRIPTION
Undoes what looks like a mistake in #3181.

As I see it, this line belongs to the line above, and should therefore have more indentation than the interior of the model definition.  @tobolar, please indicate if it was intentional to have the description string indented the same as the interior of the model definition.
