### PR TITLE
Avoid bad leading white-space inside strings in StateSelect definition

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1695,14 +1695,14 @@ The predefined \lstinline!StateSelect!\indexinline{StateSelect} enumeration type
 \begin{lstlisting}[language=modelica]
 type StateSelect = enumeration(
   never   "Do not use as state at all.",
-  avoid   "Use as state, if it cannot be avoided (but only if variable appears
-           differentiated and no other potential state with attribute
-           default, prefer, or always can be selected).",
-  default "Use as state if appropriate, but only if variable appears
-           differentiated.",
-  prefer  "Prefer it as state over those having the default value
-           (also variables can be selected, which do not appear
-           differentiated).",
+  avoid   "Use as state, if it cannot be avoided (but only if variable appears "
+        + "differentiated and no other potential state with attribute "
+        + "default, prefer, or always can be selected).",
+  default "Use as state if appropriate, but only if variable appears "
+        + "differentiated.",
+  prefer  "Prefer it as state over those having the default value "
+        + "(also variables can be selected, which do not appear "
+        + "differentiated).",
   always  "Do use it as a state."
 );
 \end{lstlisting}


### PR DESCRIPTION
Further improving a listing changed in #3181.

The reason to fix this is not that it really matters for the `StateSelect` definition itself, but that we should avoid showing listings that could give the wrong impression of how to handle long strings in actual code.
