### PR TITLE
Mandatory ignoring of trailing "1" in defaultComponentName

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1164,9 +1164,8 @@ of the class names, and if no icon is defined, a special information default ico
 \annotationindex{defaultComponentName}
 
 When creating a component of the given class, the recommended component name is \emph{name}.
-If the default name cannot be used (e.g., since it is already in use) another name can be used automatically.
-One way is to append the lowest strictly positive integer suffix giving a usable name - after removing any potential trailing \lstinline!1! from the default name.
-However, see also below under \lstinline!defaultComponentPrefixes!.
+If the default name cannot be used (e.g., since it is already in use) another name based on \lstinline!defaultComponentName! shall be derived automatically, except as described under \lstinline!defaultComponentPrefixes!.
+When automatically deriving a name, any trailing `\lstinline!1!' in the \lstinline!defaultComponentName! shall be disregarded.
 
 \begin{lstlisting}[language=modelica]
 annotation(defaultComponentPrefixes = "prefixes")

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1164,7 +1164,7 @@ of the class names, and if no icon is defined, a special information default ico
 \annotationindex{defaultComponentName}
 
 When creating a component of the given class, the recommended component name is \emph{name}.
-If the default name cannot be used (e.g., since it is already in use) another name based on \lstinline!defaultComponentName! shall be derived automatically, except as described under \lstinline!defaultComponentPrefixes!.
+If the default name cannot be used (e.g., since it is already in use), another name based on \lstinline!defaultComponentName! shall be derived automatically, except as described under \lstinline!defaultComponentPrefixes!.
 When automatically deriving a name, any trailing `\lstinline!1!' in the \lstinline!defaultComponentName! shall be disregarded.
 
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
Fixes #3151.

Please give it some time for input from several tool vendors before merging. (Reviews have been requested from those who have been active in the #3151 conversation.)
