### PR TITLE
Limiting connections (simpler)

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -489,6 +489,38 @@ end PartialWithSupport;
 The protected components and connections needed to internally handle the support-connector is omitted.
 \end{example}
 
+A connector component declaration may have the following annotation:
+\begin{lstlisting}[language=modelica]
+annotation(mayOnlyConnectOnce = "message");
+\end{lstlisting}%
+\annotationindex{mayOnlyConnectOnce}
+
+It makes it an error if the connector is connected from the outside and:
+\begin{itemize}
+\item For non-stream connectors the connection set has more than two elements.
+\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on evaluation of the \lstinline!min!-attribute).
+\end{itemize}
+For an array of connectors it applies separately to each element.
+
+\begin{nonnormative}
+This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
+The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
+The set handling avoids the case where only one of two equivalent models generate diagnostics.
+The stream connector part is primarily intended to exclude sensor-variables, see \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}, but also excludes non-reversible outgoing flows.
+\end{nonnormative}
+
+\begin{example}
+This can be used for components that implement mixing of fluids where it is not desired to combine that with the normal stream-connector mixing.
+\begin{lstlisting}[language=modelica]
+partial model MultiPort
+  parameter Integer n = 0 annotation(Dialog(connectorSizing = true));
+  FluidPort_a port_a(redeclare package Medium = Medium);
+  FluidPorts_b ports_b[n](redeclare each package Medium = Medium)
+    annotation (mayOnlyConnectOnce = "Should only connect once per element!");
+end MultiPort;
+\end{lstlisting}
+\end{example}
+
 \section{Graphical Objects}\label{annotations-for-graphical-objects}\label{graphical-objects}
 
 A graphical representation of a class consists of two abstraction

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -495,18 +495,15 @@ annotation(mayOnlyConnectOnce = "message");
 \end{lstlisting}%
 \annotationindex{mayOnlyConnectOnce}
 
-It makes it an error if the connector is connected from the outside and:
-\begin{itemize}
-\item For non-stream connectors the connection set has more than two elements.
-\item For stream connectors (see \cref{stream-connectors}), the connection set has more than two elements whose flow variable may be negative (based on evaluation of the \lstinline!min!-attribute).
-\end{itemize}
+It makes it an error if the connector is connected more than once from the outside.
 For an array of connectors it applies separately to each element.
 
 \begin{nonnormative}
 This annotation is intended for non-causal connectors, see \cref{restrictions-of-connections-and-connectors}.
-The connection handling operates on connection sets, and thus this restriction should also operate on those sets.
-The set handling avoids the case where only one of two equivalent models generate diagnostics.
-The stream connector part is primarily intended to exclude sensor-variables, see \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}, but also excludes non-reversible outgoing flows.
+The connection handling operates on connection sets, but to simplify the semantics this restriction operates on individual connections.
+This makes it straightforward to circumvent this restriction when needed, and it can be used as a replacement for checking \lstinline!cardinality!, see \cref{modelica:cardinality}.
+As a trade-off only one of two otherwise equivalent models may generate diagnostics.
+Additionally a simple check of the connection set does not suffice due to sensors, see \cref{connection-of-3-stream-connectors-where-one-mass-flow-rate-is-identical-to-zero-n-3-and}.
 \end{nonnormative}
 
 \begin{example}


### PR DESCRIPTION
This is one of two complementary PRs for mayOnlyConnectOnce which was split off from #3129 

As I see it there are two possibilities here:
- Have a special case for stream-connectors; #3212 
- Remove all the special cases for stream-connectors (this PR)

Having a vote (until end of August); see below.


My previous thoughts about this:

The question is if the rules for the annotation to restrict maximum number of connections makes sense, as potential replacement for the cardinality-assertions in Modelica.Fluid.

Thinking more I'm a bit unsure. On one hand the new rules make sense, and on the other hand it would mean that an example in MSL is misleading. It's a sort of trade-off: how much effort do we want to spend on avoiding potential pit-falls?

The basic idea with the restriction is to replace cardinality-checks.

And since Modelica mostly deal with connection-sets instead of connections the idea was instead of restricting the number of connections to the connector it restricts the number of connectors in its connection set (excluding sensors for fluid, since otherwise it would break more). That implies that the top-two variants in Modelica.Fluid.Examples.Explanatory.MeasuringTemperature would trigger it (if using the annotation instead of the current cardinality-assert). The bottom one would not - since the junction makes the intention clear.
The sensor-part means that Modelica.Fluid.Examples.HeatingSystem will not trigger this new annotation.

The MeasuringTemperature example is a bit special: since there is no other dynamics we never get flow directly from one tank to the next - but only from/to the mass-flow.

I can see the following possibilities for the check in OpenTank (well, its base-class):

- Remove it completely. Users should know what they do.
- Use new annotation as proposed in #3212 - only one other connector, excluding sensors. Will require junctions in these cases (if we use the new annotation).
- Check that only connected to one other connector (similar to current cardinality; this simpler PR). That means that you can circumvent the cardinality-check by instead of connecting two connectors to a tank-port you add a temperature sensor and connect all of them (and the tank-port) to the sensor.
On one hand using connector-sets seem more correct but:

- The rules are more complicated.
- You still cannot directly connect a sensor graphically to a tank-port due to connectorSizing not considering that case; so in practice it doesn't gain much.