### PR TITLE
Clarify previous parameter expression

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -534,14 +534,14 @@ The previous value of a clocked variable can be accessed with the \lstinline!pre
 \end{tabular}
 \end{center}
 
-A variable to which \lstinline!previous! has been applied is called a \firstuse[clocked!state variable]{clocked state variable}\index{state variable!clocked}.
+A variable (i.e. not parameter) to which \lstinline!previous! has been applied is called a \firstuse[clocked!state variable]{clocked state variable}\index{state variable!clocked}.
 
 \begin{operatordefinition}[previous]
 \begin{synopsis}\begin{lstlisting}
 previous($u$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The input argument $u$ is a component expression (\cref{def:component-expression}) or a parameter expression.
+The input argument $u$ is a component expression (\cref{def:component-expression}), that variable is then a clocked state variable, or a parameter expression.
 The return argument has the same type as the input argument.
 Input and return arguments are on the same clock.
 At the first tick of the clock of $u$ or after a reset transition (see \cref{reset-handling}), the start value of $u$ is returned, see \cref{initialization-of-clocked-partitions}.


### PR DESCRIPTION
Closes #3074
Note: This is a pure clarification - it is not intended to change anything.
