### PR TITLE
Remove zero start value and explain alternative.

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1467,7 +1467,7 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
-The fall-back value is the closest value to \lstinline!0! consistent with the bounds.
+The fallback value is the closest value to \lstinline!0! consistent with the \lstinlin!min! and \lstinline!max! bounds.
 
 \subsection{Boolean Type}\label{boolean-type}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1437,7 +1437,7 @@ end Real;
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
-The fall-back value is the closest value to \lstinline!0.0! consistent with the bounds.
+The fallback value is the closest value to \lstinline!0.0! consistent with the \lstinlin!min! and \lstinline!max! bounds.
 
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1407,7 +1407,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
   parameter RealType min = -Inf, max = +Inf; // Inf denotes a large value
-  parameter RealType start    = 0; // Initial value
+  parameter RealType start;            // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
   parameter RealType nominal;            // Nominal value
@@ -1431,6 +1431,8 @@ end Real;
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
+As a fall-back if there is neither value nor start-value then the closest value to \lstinline!0.0! consistent with the bounds (as default \lstinline!0.0!) shall be used.
+
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,
 \lstinline!RealType!/\lstinline[language=C]!double! matches the IEC~60559:1989 (ANSI/IEEE~754-1985) \lstinline[language=C]!double! format.
@@ -1444,7 +1446,7 @@ type Integer // Note: Defined with Modelica syntax although predefined
   IntegerType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter IntegerType min = -Inf, max = +Inf;
-  parameter IntegerType start = 0; // Initial value
+  parameter IntegerType start;         // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
 equation
@@ -1459,6 +1461,8 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
+As a fall-back if there is neither value nor start-value then the closest value to \lstinline!0! consistent with the bounds (as default \lstinline!0!) shall be used.
+
 \subsection{Boolean Type}\label{boolean-type}
 
 The following is the predefined \lstinline!Boolean!\indexinline{Boolean} type:
@@ -1466,7 +1470,7 @@ The following is the predefined \lstinline!Boolean!\indexinline{Boolean} type:
 type Boolean // Note: Defined with Modelica syntax although predefined
   BooleanType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter BooleanType start = false; // Initial value
+  parameter BooleanType start;         // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false, // default for other variables
 end Boolean;
@@ -1475,6 +1479,8 @@ end Boolean;
 \index{start@\robustinline{start}!attribute of \robustinline{Boolean}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{Boolean}}%
 
+As a fall-back if there is neither value nor start-value then \lstinline!false! shall be used.
+
 \subsection{String Type}\label{string-type}
 
 The following is the predefined \lstinline!String!\indexinline{String} type:
@@ -1482,7 +1488,7 @@ The following is the predefined \lstinline!String!\indexinline{String} type:
 type String // Note: Defined with Modelica syntax although predefined
   StringType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter StringType start = "";     // Initial value
+  parameter StringType start;          // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false, // default for other variables
 end String;
@@ -1492,6 +1498,8 @@ end String;
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{String}}
 
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
+
+As a fall-back if there is neither value nor start-value then \lstinline!""! shall be used.
 
 \subsection{Enumeration Types}\label{enumeration-types}
 
@@ -1604,7 +1612,7 @@ type E // Note: Defined with Modelica syntax although predefined
   EnumType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter EnumType min = e1, max = en;
-  parameter EnumType start = e1;       // Initial value
+  parameter EnumType start;             // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
   constant EnumType e1 = $\ldots$;
@@ -1614,6 +1622,8 @@ equation
   assert(min <= $\langle$$\mbox{\emph{value}}$$\rangle$ and $\langle$$\mbox{\emph{value}}$$\rangle$ <= max, "Variable value out of limit");
 end E;
 \end{lstlisting}
+
+As a fall-back if there is neither value nor start-value then the smallest value consistent with the bounds shall be used (as default \lstinline!e1!) shall be used.
 
 \begin{nonnormative}
 Since the attributes and enumeration literals are on the same

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1437,7 +1437,7 @@ end Real;
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
-The fallback value is the closest value to \lstinline!0.0! consistent with the \lstinlin!min! and \lstinline!max! bounds.
+The fallback value is the closest value to \lstinline!0.0! consistent with the \lstinline!min! and \lstinline!max! bounds.
 
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1398,7 +1398,7 @@ The definitions use \lstinline!RealType!\indexinline{RealType}, \lstinline!Integ
 These are called the \firstuse[primitive type]{primitive types}.
 
 \begin{definition}[Fallback value]\label{def:fallback-value}\index{fallback value}
-In situations where the \lstinline!start!-attribute would apply if provided, but the attribute is not provided, the \emph{fallback} shall be used instead.
+In situations where the \lstinline!start!-attribute would apply if provided, but the attribute is not provided, the \emph{fallback value} shall be used instead.
 Tools are recommended to give diagnostics when the fallback value is used.
 The fallback values for variables of the different predefined types are defined below.
 \end{definition}
@@ -1629,7 +1629,7 @@ equation
 end E;
 \end{lstlisting}
 
-The fallback value is the smallest value consistent with the \lstinline!min! and \lstinline!max! bounds.
+The fallback value is the \lstinline!min! bound.
 
 \begin{nonnormative}
 Since the attributes and enumeration literals are on the same

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1398,8 +1398,8 @@ The definitions use \lstinline!RealType!\indexinline{RealType}, \lstinline!Integ
 These are called the \firstuse[primitive type]{primitive types}.
 
 \begin{definition}[Fallback value]\label{def:fallback-value}\index{fallback value}
-When the start-value is needed and the \lstinline!start!-attribute is not provided, the fallback value is used instead.
-The fallback value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
+In situations where the \lstinline!start!-attribute would apply if provided, but the attribute is not provided, the \emph{fallback} shall be used instead.
+Tools are recommended to give diagnostics when the fallback value is used.
 The fallback values for variables of the different predefined types are defined below.
 \end{definition}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1398,8 +1398,8 @@ The definitions use \lstinline!RealType!\indexinline{RealType}, \lstinline!Integ
 These are called the \firstuse[primitive type]{primitive types}.
 
 \begin{definition}[Fallback value]\label{def:fallback-value}\index{fallback value}
-When the start-value is needed and the \lstinline!start!-attribute is not provided, the fall-back value is used instead.
-The fall-back value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
+When the start-value is needed and the \lstinline!start!-attribute is not provided, the fallback value is used instead.
+The fallback value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
 The fallback values for variables of the different predefined types are defined below.
 \end{definition}
 
@@ -1437,7 +1437,7 @@ end Real;
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
-The fallback value is the closest value to \lstinline!0.0! consistent with the \lstinline!min! and \lstinline!max! bounds.
+The fallback value is the closest value to $0.0$ consistent with the \lstinline!min! and \lstinline!max! bounds.
 
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,
@@ -1467,7 +1467,7 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
-The fallback value is the closest value to \lstinline!0! consistent with the \lstinlin!min! and \lstinline!max! bounds.
+The fallback value is the closest value to $0$ consistent with the \lstinlin!min! and \lstinline!max! bounds.
 
 \subsection{Boolean Type}\label{boolean-type}
 
@@ -1485,7 +1485,7 @@ end Boolean;
 \index{start@\robustinline{start}!attribute of \robustinline{Boolean}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{Boolean}}%
 
-The fall-back value is \lstinline!false!.
+The fallback value is \lstinline!false!.
 
 \subsection{String Type}\label{string-type}
 
@@ -1505,7 +1505,7 @@ end String;
 
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
 
-The fall-back value is \lstinline!""!.
+The fallback value is \lstinline!""!.
 
 \subsection{Enumeration Types}\label{enumeration-types}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1629,7 +1629,7 @@ equation
 end E;
 \end{lstlisting}
 
-The fall-back value is the smallest value consistent with the bounds.
+The fallback value is the smallest value consistent with the \lstinlin!min! and \lstinline!max! bounds.
 
 \begin{nonnormative}
 Since the attributes and enumeration literals are on the same

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1467,7 +1467,7 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
-The fallback value is the closest value to $0$ consistent with the \lstinlin!min! and \lstinline!max! bounds.
+The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.
 
 \subsection{Boolean Type}\label{boolean-type}
 
@@ -1629,7 +1629,7 @@ equation
 end E;
 \end{lstlisting}
 
-The fallback value is the smallest value consistent with the \lstinlin!min! and \lstinline!max! bounds.
+The fallback value is the smallest value consistent with the \lstinline!min! and \lstinline!max! bounds.
 
 \begin{nonnormative}
 Since the attributes and enumeration literals are on the same

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1400,7 +1400,7 @@ These are called the \firstuse[primitive type]{primitive types}.
 \begin{definition}[Fallback value]\label{def:fallback-value}\index{fallback value}
 When the start-value is needed and the \lstinline!start!-attribute is not provided, the fall-back value is used instead.
 The fall-back value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
-The fall-back value for variables of the different predefined types are defined below.
+The fallback values for variables of the different predefined types are defined below.
 \end{definition}
 
 \subsection{Real Type}\label{real-type}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1397,7 +1397,7 @@ It also follows that the only way to declare a subtype of e.g.\ \lstinline!Real!
 The definitions use \lstinline!RealType!\indexinline{RealType}, \lstinline!IntegerType!\indexinline{IntegerType}, \lstinline!BooleanType!\indexinline{BooleanType}, \lstinline!StringType!\indexinline{StringType}, \lstinline!EnumType!\indexinline{EnumType} as mnemonics corresponding to machine representations.
 These are called the \firstuse[primitive type]{primitive types}.
 
-\begin{definition}[Fall-back value]\label{def:fall-back-value}\index{fall-back value}
+\begin{definition}[Fallback value]\label{def:fallback-value}\index{fallback value}
 When the start-value is needed and the \lstinline!start!-attribute is not provided, the fall-back value is used instead.
 The fall-back value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
 The fall-back value for variables of the different predefined types are defined below.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1397,6 +1397,12 @@ It also follows that the only way to declare a subtype of e.g.\ \lstinline!Real!
 The definitions use \lstinline!RealType!\indexinline{RealType}, \lstinline!IntegerType!\indexinline{IntegerType}, \lstinline!BooleanType!\indexinline{BooleanType}, \lstinline!StringType!\indexinline{StringType}, \lstinline!EnumType!\indexinline{EnumType} as mnemonics corresponding to machine representations.
 These are called the \firstuse[primitive type]{primitive types}.
 
+\begin{definition}[Fall-back value]\label{def:fall-back-value}\index{fall-back value}
+When the start-value is needed and the \lstinline!start!-attribute is not provided, the fall-back value is used instead.
+The fall-back value can be be used as guess-value in system of equations and when initializing variables in algorithm sections.
+The fall-back value for variables of the different predefined types are defined below.
+\end{definition}
+
 \subsection{Real Type}\label{real-type}
 
 The following is the predefined \lstinline!Real!\indexinline{Real} type:
@@ -1431,7 +1437,7 @@ end Real;
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 
-As a fall-back if there is neither value nor start-value then the closest value to \lstinline!0.0! consistent with the bounds (as default \lstinline!0.0!) shall be used.
+The fall-back value is the closest value to \lstinline!0.0! consistent with the bounds.
 
 \begin{nonnormative}
 For external functions in C89, \lstinline!RealType! maps to \lstinline[language=C]!double!.  In the mapping proposed in Annex~F of the C99 standard,
@@ -1461,7 +1467,7 @@ end Integer;
 
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
-As a fall-back if there is neither value nor start-value then the closest value to \lstinline!0! consistent with the bounds (as default \lstinline!0!) shall be used.
+The fall-back value is the closest value to \lstinline!0! consistent with the bounds.
 
 \subsection{Boolean Type}\label{boolean-type}
 
@@ -1479,7 +1485,7 @@ end Boolean;
 \index{start@\robustinline{start}!attribute of \robustinline{Boolean}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{Boolean}}%
 
-As a fall-back if there is neither value nor start-value then \lstinline!false! shall be used.
+The fall-back value is \lstinline!false!.
 
 \subsection{String Type}\label{string-type}
 
@@ -1499,7 +1505,7 @@ end String;
 
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
 
-As a fall-back if there is neither value nor start-value then \lstinline!""! shall be used.
+The fall-back value is \lstinline!""!.
 
 \subsection{Enumeration Types}\label{enumeration-types}
 
@@ -1623,7 +1629,7 @@ equation
 end E;
 \end{lstlisting}
 
-As a fall-back if there is neither value nor start-value then the smallest value consistent with the bounds shall be used (as default \lstinline!e1!) shall be used.
+The fall-back value is the smallest value consistent with the bounds.
 
 \begin{nonnormative}
 Since the attributes and enumeration literals are on the same

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -778,7 +778,7 @@ If a parameter has a value for the \lstinline!start!-attribute, does not have \l
 In this case a diagnostic message is recommended in a simulation model.
 
 \begin{nonnormative}
-This is used in libraries to give acceptable defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
+This is used in libraries to give rudimentary defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that should be set properly.
 \end{nonnormative}
 
 All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e.\ there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -774,7 +774,7 @@ For other variables, \lstinline!fixed! defaults to \lstinline!false!.
 In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but which only have the default value of the \lstinline!start!-attribute as defined in \cref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
 \end{nonnormative}
 
-If a parameter has a modifier for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the modifier for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.
+If a parameter has a value for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the value for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.
 In this case a diagnostic message is recommended in a simulation model.
 
 \begin{nonnormative}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -771,14 +771,14 @@ For other variables, \lstinline!fixed! defaults to \lstinline!false!.
 \lstinline!start!-values of variables having \lstinline!fixed = false! can be used as initial guesses, in case iterative solvers are used in the initialization phase.
 
 \begin{nonnormative}
-In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but which only have the default value of the \lstinline!start!-attribute as defined in \cref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
+In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but which only have the default value as defined in \cref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
 \end{nonnormative}
 
 If a parameter has a value for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the value for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.
 In this case a diagnostic message is recommended in a simulation model.
 
 \begin{nonnormative}
-This is used in libraries to give non-zero defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
+This is used in libraries to give appropriate defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
 \end{nonnormative}
 
 All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e.\ there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -771,7 +771,7 @@ For other variables, \lstinline!fixed! defaults to \lstinline!false!.
 \lstinline!start!-values of variables having \lstinline!fixed = false! can be used as initial guesses, in case iterative solvers are used in the initialization phase.
 
 \begin{nonnormative}
-In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but which only have the default value as defined in \cref{predefined-types-and-classes}, since the lack of appropriate initial guesses is a likely cause of the solver failure.
+In case of iterative solver failure, it is recommended to specially report those variables for which the solver needs an initial guess, but where the fallback value (see \cref{predefined-types-and-classes}) has been applied, since the lack of appropriate initial guesses is a likely cause of the solver failure.
 \end{nonnormative}
 
 If a parameter has a value for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the value for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -778,7 +778,7 @@ If a parameter has a value for the \lstinline!start!-attribute, does not have \l
 In this case a diagnostic message is recommended in a simulation model.
 
 \begin{nonnormative}
-This is used in libraries to give appropriate defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
+This is used in libraries to give acceptable defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that need to be set.
 \end{nonnormative}
 
 All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e.\ there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.


### PR DESCRIPTION
Remove the default start-value of 0.0 (and similarly for other types).

The reasons are:

- It is not necessarily consistent with min/max - which just causes unnecessary problems. In case some value is needed that is now handled.
- For parameters it is problematic as the current rule https://specification.modelica.org/master/equations.html#initialization-initial-equation-and-initial-algorithm indicates that modified start-values are special. This is somewhat weird in itself (when is start set but not modified?) but with the MCP for removing modifiers it would become a complete mess. Instead it can now state that it uses the value for the start-attribute if it has any.
