### PR TITLE
Clarify role of protected components passed to external functions

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1942,11 +1942,10 @@ end IDENT;
 \end{lstlisting}%
 \indexinline{external}
 
-Components in the public part of an external function declaration shall be declared either as {\lstinline!input!} or {\lstinline!output!}.
+Just as for any other function, components in the public part of an external function declaration shall be declared either as {\lstinline!input!} or {\lstinline!output!}.
 
-\begin{nonnormative}
-This is just as for any other function.  The components in the protected part allow local variables for temporary storage to be declared.
-\end{nonnormative}
+Protected components can be passed to the external function without being initialized by means of a declaration equation, which is useful for passing workspace memory to functions with FORTRAN style memory management, and the reason for passing them in the same (writable) way as output components (see \cref{argument-type-mapping}).
+The value of a protected component passed to the external function should be considered undefined (destroyed) after the external function call.
 
 The {\lstinline[language=grammar]!language-specification!} must currently be one of {\lstinline!"builtin"!} (deprecated), {\lstinline!"C"!}, {\lstinline!"C$\ldots$"!} (for one of the specific C standards like C89, C99, and C11 -- specifying
 that it relies on the C standard library of that version) or {\lstinline!"FORTRAN 77"!}.


### PR DESCRIPTION
Closes #3188.  Note that the resolution is not according to the generalization that was first proposed in the issue, but on the contrary clearly rules out such a generalization.