### PR TITLE
Clarify String named argument combinations

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -531,8 +531,8 @@ The \lstinline!format! string corresponding to \lstinline!<options>! is:
   \lstinline!(if leftJustified then "-" else "") + String(minimumLength) + "d"!
 \end{itemize}
 
-Form of the \lstinline!format! string:
-According to ANSI-C the format string specifies one conversion specifier (excluding the leading \%), shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
+Form of the ANSI-C style \lstinline!format! string:
+The string specifies one conversion specifier (excluding the leading \%), shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
 For all numeric values the format specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' format specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -501,12 +501,12 @@ String($e$, <options>)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Convert a scalar non-\lstinline!String! expression to a \lstinline!String! representation.
-The first argument may be a \lstinline!Boolean! $b$, an \lstinline!Integer! $i$, a \lstinline!Real! $r$ or an enumeration value $e$ (\cref{type-conversion-of-enumeration-values-to-string-or-integer}).
-The other arguments must use named arguments.
-For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
-
-The optional \lstinline!<options>! are:
+The first argument may be a \lstinline!Boolean! $b$, an \lstinline!Integer! $i$, a \lstinline!Real! $r$, or an enumeration value $e$ (\cref{type-conversion-of-enumeration-values-to-string-or-integer}).
+The other arguments can only be passed as named arguments, and the recognized ones are:
 \begin{itemize}
+\item
+  \lstinline!String format!: ANSI-C style format string, see below.
+  Only allowed for formatting of a \lstinline!Real! value, and must not be combined with other named arguments.
 \item
   \lstinline!Integer minimumLength = 0!: Minimum length of the resulting string.
   If necessary, the blank character is used to fill up unused space.
@@ -514,7 +514,10 @@ The optional \lstinline!<options>! are:
   \lstinline!Boolean leftJustified = true!: If true, the converted result is left justified in the string; if false it is right justified in the string.
 \item
   \lstinline!Integer significantDigits = 6!: Number of significant digits in the result string.
+  Required when formatting a \lstinline!Real! value and \lstinline!format! is not provided.
 \end{itemize}
+
+For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
 
 \begin{nonnormative}
 Examples of \lstinline!Real! values formatted with 6 significant digits: \emph{12.3456}, \emph{0.0123456}, \emph{12345600}, \emph{1.23456E-10}.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -531,7 +531,8 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
   \lstinline!(if leftJustified then "-" else "") + String(minimumLength) + "d"!
 \end{itemize}
 
-The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specifier without the leading \%, shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
+The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specifier without the leading \%.
+It shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
 For all numeric values the type field specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' type field specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -534,10 +534,9 @@ The \lstinline!format! string corresponding to \lstinline!<options>! is:
   \lstinline!(if leftJustified then "-" else "") + String(minimumLength) + "d"!
 \end{itemize}
 
-Form of the ANSI-C style \lstinline!format! string:
-The string specifies one conversion specifier (excluding the leading \%), shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
-For all numeric values the format specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
-For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' format specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
+The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specifier without the leading \%, shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
+For all numeric values the type field specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
+For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' type field specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 \end{semantics}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -495,6 +495,7 @@ See also \cref{type-conversion-of-integer-to-enumeration-values}.
 \begin{synopsis}\begin{lstlisting}
 String($b$, $\langle$$\mbox{\emph{options}}$$\rangle$)
 String($i$, $\langle$$\mbox{\emph{options}}$$\rangle$)
+String($i$, format = $s$)
 String($r$, $\langle$$\mbox{\emph{options}}$$\rangle$)
 String($r$, format = $s$)
 String($e$, $\langle$$\mbox{\emph{options}}$$\rangle$)

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -532,7 +532,7 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
 \end{itemize}
 
 The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specification without the leading \%.
-It shall not contain a length field specifier, and shall not use `\lstinline!*!' for width and/or precision.
+It shall not contain a length modifier, and shall not use `\lstinline!*!' for width and/or precision.
 For all numeric values the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -493,20 +493,17 @@ See also \cref{type-conversion-of-integer-to-enumeration-values}.
 
 \begin{operatordefinition*}[String]\label{modelica:to-String}\index{String@\robustinline{String}!conversion operator}
 \begin{synopsis}\begin{lstlisting}
-String($b$, <options>)
-String($i$, <options>)
-String($r$, significantDigits = $d$, <options>)
+String($b$, $\langle$$\mbox{\emph{options}}$$\rangle$)
+String($i$, $\langle$$\mbox{\emph{options}}$$\rangle$)
+String($r$, $\langle$$\mbox{\emph{options}}$$\rangle$)
 String($r$, format = $s$)
-String($e$, <options>)
+String($e$, $\langle$$\mbox{\emph{options}}$$\rangle$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Convert a scalar non-\lstinline!String! expression to a \lstinline!String! representation.
 The first argument may be a \lstinline!Boolean! $b$, an \lstinline!Integer! $i$, a \lstinline!Real! $r$, or an enumeration value $e$ (\cref{type-conversion-of-enumeration-values-to-string-or-integer}).
-The other arguments can only be passed as named arguments, and the recognized ones are:
+The $\langle\mathit{options}\rangle$ represent zero or more of the following named arguments (that cannot be passed as positional arguments):
 \begin{itemize}
-\item
-  \lstinline!String format!: ANSI-C style format string, see below.
-  Only allowed for formatting of a \lstinline!Real! value, and must not be combined with other named arguments.
 \item
   \lstinline!Integer minimumLength = 0!: Minimum length of the resulting string.
   If necessary, the blank character is used to fill up unused space.
@@ -514,7 +511,7 @@ The other arguments can only be passed as named arguments, and the recognized on
   \lstinline!Boolean leftJustified = true!: If true, the converted result is left justified in the string; if false it is right justified in the string.
 \item
   \lstinline!Integer significantDigits = 6!: Number of significant digits in the result string.
-  Required when formatting a \lstinline!Real! value and \lstinline!format! is not provided.
+  Only allowed when formatting a \lstinline!Real! value (and \lstinline!format! is not provided).
 \end{itemize}
 
 For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
@@ -523,7 +520,7 @@ For \lstinline!Real! expressions the output shall be according to the Modelica g
 Examples of \lstinline!Real! values formatted with 6 significant digits: \emph{12.3456}, \emph{0.0123456}, \emph{12345600}, \emph{1.23456E-10}.
 \end{nonnormative}
 
-The \lstinline!format! string corresponding to \lstinline!<options>! is:
+The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ is:
 \begin{itemize}
 \item
   For \lstinline!Real!:\\

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -515,6 +515,9 @@ The $\langle\mathit{options}\rangle$ represent zero or more of the following nam
   Only allowed when formatting a \lstinline!Real! value.
 \end{itemize}
 
+The standard type coercion described in \cref{standard-type-coercion} shall not be applied for the first argument of \lstinline!String!.
+Hence, specifying \lstinline!significantDigits! is an error when the first argument of \lstinline!String! is an \lstinline!Integer! expression.
+
 For \lstinline!Real! expressions the output shall be according to the Modelica grammar.
 
 \begin{nonnormative}
@@ -538,6 +541,10 @@ For both \lstinline!Real! and \lstinline!Integer! values, the conversion specifi
 For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for \lstinline!Real! values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
+
+\begin{nonnormative}
+Since no automatic type coerction takes place for the first argument of \lstinline!String(4, format = ".5f")!, an implementation the \lstinline!Integer! case of \lstinline!String! may internally convert the value to floating point and then fall back on the \lstinline!Real! case implementation of \lstinline!format = ".5f"!.
+\end{nonnormative}
 \end{semantics}
 \end{operatordefinition*}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -511,7 +511,7 @@ The $\langle\mathit{options}\rangle$ represent zero or more of the following nam
   \lstinline!Boolean leftJustified = true!: If true, the converted result is left justified in the string; if false it is right justified in the string.
 \item
   \lstinline!Integer significantDigits = 6!: Number of significant digits in the result string.
-  Only allowed when formatting a \lstinline!Real! value (and \lstinline!format! is not provided).
+  Only allowed when formatting a \lstinline!Real! value.
 \end{itemize}
 
 For \lstinline!Real! expressions the output shall be according to the Modelica grammar.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -532,7 +532,7 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
 \end{itemize}
 
 The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specifier without the leading \%.
-It shall not contain length modifiers, and shall not use `\lstinline!*!' for width and/or precision.
+It shall not contain a length field specifier, and shall not use `\lstinline!*!' for width and/or precision.
 For all numeric values the type field specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' type field specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -533,8 +533,8 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
 
 The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specification without the leading \%.
 It shall not contain a length field specifier, and shall not use `\lstinline!*!' for width and/or precision.
-For all numeric values the type field specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
-For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' type field specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).
+For all numeric values the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
+For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 \end{semantics}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -534,8 +534,8 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
 
 The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specification without the leading \%.
 It shall not contain a length modifier, and shall not use `\lstinline!*!' for width and/or precision.
-For all numeric values the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
-For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
+For both \lstinline!Real! and \lstinline!Integer! values, the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
+For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for \lstinline!Real! values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 \end{semantics}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -542,9 +542,19 @@ For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 
-\begin{nonnormative}
-Since no automatic type coerction takes place for the first argument of \lstinline!String(4, format = ".5f")!, an implementation the \lstinline!Integer! case of \lstinline!String! may internally convert the value to floating point and then fall back on the \lstinline!Real! case implementation of \lstinline!format = ".5f"!.
-\end{nonnormative}
+\begin{example}
+Some situations worth a remark:
+\begin{itemize}
+\item
+  \lstinline!String(4.0, format = "g")! produces \emph{4} which is not a valid \lstinline!Real! literal.
+  However, it is an \lstinline!Integer! literal that can be used almost anywhere in Modelica code instead of the \lstinline!Real! literal \lstinline{4.0} (with the first argument to \lstinline!String! being a notable exception here).
+\item
+  \lstinline!String(4, format = ".3f")! uses the \lstinline!Integer! case of \lstinline!String! since no automatic type coerction takes place for the first argument.
+  An implementation may internally convert the value to floating point and then fall back on the \lstinline!Real! case implementation of \lstinline!format = ".3f"!.
+\item
+  \lstinline!String(4611686018427387648, format = ".0f")! (a valid \lstinline!Integer! value in an implementation with 64 bit \lstinline!IntegerType!) may produce \emph{4611686018427387904} (not equal to input value), in case internal conversion to a 64 bit \lstinline[language=C]!double! is applied.
+\end{itemize}
+\end{example}
 \end{semantics}
 \end{operatordefinition*}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -531,7 +531,7 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
   \lstinline!(if leftJustified then "-" else "") + String(minimumLength) + "d"!
 \end{itemize}
 
-The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specifier without the leading \%.
+The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specification without the leading \%.
 It shall not contain a length field specifier, and shall not use `\lstinline!*!' for width and/or precision.
 For all numeric values the type field specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' type field specifiers (for non-integral values a tool may round, truncate or use a different format if the integer conversion characters are used).


### PR DESCRIPTION
The current specification of `String` applied for formatting of a `Real` value gives some room for interpretation regarding `significantDigits`: It's both given separately in the synopsis, but then said to be optional.  This PR is meant to remove any ambiguity, and if the intention isn't to have `significantDigits` mandatory for `Real`, I'll update the PR accordingly.
