### PR TITLE
Clarify system of equations between different sub-clocks.

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1056,9 +1056,9 @@ equation
   0 = subSample(y, 2)+a;
 \end{lstlisting}
 Here \lstinline!a! and \lstinline!z! are part of one sub-clock, and \lstinline!y! of another, and the system of equations involve both of them.
-Replacing \lstinline!a! by \lstinline!x-z! (and simplifying the equations) solves this issue and gives the next example.
 
-However, it is not required that the sub-clocks can necessarily be sorted as shown by following legal example:
+The following legal example solves the issues in the previous example by replacing \lstinline!a! by \lstinline!x-z! (and simplifying the equations).
+Additionally, it shows that it is not required that the sub-clocks can necessarily be sorted:
 \begin{lstlisting}[language=modelica]
   Real x=sample(time, Clock(1,100));
   Real y=superSample(x, 2);

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1045,7 +1045,7 @@ u = hold(yd2);
 \end{example}
 
 \begin{example}
-Forbidding systems of equations involving different sub-clocks mean that the following is forbidden:
+Forbidding systems of equations involving different sub-clocks means that the following is forbidden:
 \begin{lstlisting}[language=modelica]
   Real x=sample(time, Clock(1,100));
   Real y;
@@ -1054,7 +1054,7 @@ equation
   z=0;
 \end{lstlisting}
 Here \lstinline!x! and \lstinline!z! are part of one sub-clock partition and \lstinline!y! of another.
-The variables \lstinline!y! and \lstinline!z! are part of a system of equations spanning two sub-clocks, that is not legal.
+The variables \lstinline!y! and \lstinline!z! are part of a system of equations spanning two sub-clocks, which is not allowed.
 
 However, it is not required that the sub-clocks can necessarily be sorted as shown by following legal example:
 \begin{lstlisting}[language=modelica]
@@ -1063,8 +1063,10 @@ However, it is not required that the sub-clocks can necessarily be sorted as sho
   Real z=subSample(y, 2)+x;
 \end{lstlisting}
 Here \lstinline!x! and \lstinline!z! are part of one sub-clock partition, and \lstinline!y! of another.
-The equations can be sorted, but not the sub-clock partitions.
-Note that systems of equations within one sub-clock are also legal.
+The equations form three equation systems with one equation in each (hence trivially satisfying the requirement that only variables from one sub-clock partition are being solved).
+The equation systems need to be solved in a strict order, but the first and last equation system belong to one sub-clock, while the second equation system belongs to another sub-clock.
+This illustrates that there is no guarantee that the sub-clock partitions can be ordered in agreement with the equation systems.
+Note that equation systems with more than one equation are also allowed in sub-clock partitions.
 \end{example}
 
 \subsection{Sub-Clock Inferencing}\label{sub-clock-inferencing}

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1047,14 +1047,16 @@ u = hold(yd2);
 \begin{example}
 Forbidding systems of equations involving different sub-clocks means that the following is forbidden:
 \begin{lstlisting}[language=modelica]
-  Real x=sample(time, Clock(1,100));
-  Real y;
-  Real z=subSample(y, 2)+x;
+  Real a;
+  //Real x=a+z;
+  Real y=superSample(a+z, 2);
+  Real z;
 equation
-  z=0;
+  a+z = sample(time, Clock(1,100));
+  0 = subSample(y, 2)+a;
 \end{lstlisting}
-Here \lstinline!x! and \lstinline!z! are part of one sub-clock partition and \lstinline!y! of another.
-The variables \lstinline!y! and \lstinline!z! are part of a system of equations spanning two sub-clocks, which is not allowed.
+Here \lstinline!a! and \lstinline!z! are part of one sub-clock, and \lstinline!y! of another, and the system of equations involve both of them.
+Replacing \lstinline!a! by \lstinline!x-z! (and simplifying the equations) solves this issue and gives the next example.
 
 However, it is not required that the sub-clocks can necessarily be sorted as shown by following legal example:
 \begin{lstlisting}[language=modelica]

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -1010,6 +1010,7 @@ except as first argument of sub-clock conversion operators: \lstinline!subSample
 
 The resulting set of connected components, is the partitioning of the equations and variables, $S_{ij} = \left\langle E_{ij},\, V_{ij} \right\rangle$, according to sub-clocks.
 
+The connected components (corresponding to the sub-clocks) are then further split into strongly connected components corresponding to systems of equations.
 The resulting sets of equations and variables shall be possible to solve separately, meaning that systems of equations cannot involve different sub-clocks.
 
 It can be noted that:
@@ -1041,6 +1042,29 @@ u = hold(yd2);
 0 = f5(der(x3), x3);
 0 = f6(y, x1, u);
 \end{lstlisting}
+\end{example}
+
+\begin{example}
+Forbidding systems of equations involving different sub-clocks mean that the following is forbidden:
+\begin{lstlisting}[language=modelica]
+  Real x=sample(time, Clock(1,100));
+  Real y;
+  Real z=subSample(y, 2)+x;
+equation
+  z=0;
+\end{lstlisting}
+Here \lstinline!x! and \lstinline!z! are part of one sub-clock partition and \lstinline!y! of another.
+The variables \lstinline!y! and \lstinline!z! are part of a system of equations spanning two sub-clocks, that is not legal.
+
+However, it is not required that the sub-clocks can necessarily be sorted as shown by following legal example:
+\begin{lstlisting}[language=modelica]
+  Real x=sample(time, Clock(1,100));
+  Real y=superSample(x, 2);
+  Real z=subSample(y, 2)+x;
+\end{lstlisting}
+Here \lstinline!x! and \lstinline!z! are part of one sub-clock partition, and \lstinline!y! of another.
+The equations can be sorted, but not the sub-clock partitions.
+Note that systems of equations within one sub-clock are also legal.
 \end{example}
 
 \subsection{Sub-Clock Inferencing}\label{sub-clock-inferencing}


### PR DESCRIPTION
I noticed this when looking at #3283 

Currently it is quite subtle - it goes from "sub-clock partition" to "system of equations" without noticing that they are potentially different.