### PR TITLE
Improve definition of exponentiation.

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1268,7 +1268,7 @@ This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical 
 
 \subsection{Element-wise Exponentiation}\label{element-wise-exponentiation}
 
-Exponentiation \lstinline!a ^ b! always return a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! values.
+Exponentiation \lstinline!a ^ b! always returns a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! values.
 The result should correspond to mathematical exponentiation (ideally the correctly rounded result based on the inputs) with the following special cases:
 \begin{itemize}
 \item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $0.0$.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1268,10 +1268,19 @@ This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical 
 
 \subsection{Element-wise Exponentiation}\label{element-wise-exponentiation}
 
-Exponentiation \lstinline!a ^ b! is defined as \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library if both \lstinline!a! and \lstinline!b! are
-\lstinline!Real! scalars. A \lstinline!Real! scalar value is returned.  If \lstinline!a! or \lstinline!b! are \lstinline!Integer! scalars, they are
-automatically promoted to \lstinline!Real!.  Consequences of exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} \leq 0.0$,
-$\text{\lstinline!a!} < 0$ and \lstinline!b! is not an integer) or overflow are undefined.
+Exponentiation \lstinline!a ^ b! always return a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! values.
+The result should correspond to mathematical exponentiation (ideally the correctly rounded result based on the inputs) with the following special cases:
+\begin{itemize}
+\item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $0.0$.
+\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer! or a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
+\item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!,
+$\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
+\end{itemize}
+Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
+\begin{nonnormative}
+The result is always \lstinline!Real! due to the potential for integer overflow and negative exponents.
+Treating an \lstinline!Integer! exponent special imply that we can freely use $x^n$ in a power-series.
+\end{nonnormative}
 
 Element-wise exponentiation \lstinline!a .^ b! of numeric scalars, vectors, matrices, or arrays \lstinline!a! and \lstinline!b! requires a numeric type class for
 \lstinline!a! and \lstinline!b! and either \lstinline!size(a) = size(b)! or scalar \lstinline!a! or scalar \lstinline!b!.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1273,8 +1273,7 @@ The result should correspond to mathematical exponentiation (ideally the correct
 \begin{itemize}
 \item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $0.0$.
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer! or a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
-\item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!,
-$\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
+\item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}
 Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
 \begin{nonnormative}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1279,7 +1279,7 @@ The result should correspond to mathematical exponentiation (ideally the correct
 \begin{nonnormative}
 Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
 The result is always \lstinline!Real! due to the potential for integer overflow and negative exponents.
-Treating an \lstinline!Integer! exponent special makes it possible to use $x^n$ in a power series.
+The special treatment of \lstinline!Integer! exponents makes it possible to use $x^n$ in a power series.
 \end{nonnormative}
 
 Element-wise exponentiation \lstinline!a .^ b! of numeric scalars, vectors, matrices, or arrays \lstinline!a! and \lstinline!b! requires a numeric type class for

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1275,8 +1275,9 @@ The result should correspond to mathematical exponentiation (ideally the correct
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer! or a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
 \item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}
-Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
+
 \begin{nonnormative}
+Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
 The result is always \lstinline!Real! due to the potential for integer overflow and negative exponents.
 Treating an \lstinline!Integer! exponent special imply that we can freely use $x^n$ in a power-series.
 \end{nonnormative}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1274,7 +1274,10 @@ The result should correspond to mathematical exponentiation with the following s
 \item For any value of \lstinline!a! (including $0.0$) and an \lstinline!Integer! $\text{\lstinline!b!} = 0$, the result is $1.0$.
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer!, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
 \item A deprecated semantics is to treat $\text{\lstinline!a!} < 0$ and a \lstinline!Real! \lstinline!b! having a non-zero integer value as if \lstinline!b! were an \lstinline!Integer!.
-\item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
+\item For $\text{\lstinline!a!} = 0$ and $\text{\lstinline!b!} > 0$, the result is $0.0$.
+\item
+  Other exceptional situations are illegal.
+  For example: $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value.
 \end{itemize}
 
 \begin{nonnormative}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1271,7 +1271,7 @@ This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical 
 Exponentiation \lstinline!a ^ b! always returns a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! values.
 The result should correspond to mathematical exponentiation (ideally the correctly rounded result based on the inputs) with the following special cases:
 \begin{itemize}
-\item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $0.0$.
+\item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $1.0$.
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer! or a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
 \item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1279,7 +1279,7 @@ The result should correspond to mathematical exponentiation (ideally the correct
 \begin{nonnormative}
 Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
 The result is always \lstinline!Real! due to the potential for integer overflow and negative exponents.
-Treating an \lstinline!Integer! exponent special imply that we can freely use $x^n$ in a power-series.
+Treating an \lstinline!Integer! exponent special makes it possible to use $x^n$ in a power series.
 \end{nonnormative}
 
 Element-wise exponentiation \lstinline!a .^ b! of numeric scalars, vectors, matrices, or arrays \lstinline!a! and \lstinline!b! requires a numeric type class for

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1268,18 +1268,18 @@ This is a consequence of the parsing rules, since `\lstinline!2.!' is a lexical 
 
 \subsection{Element-wise Exponentiation}\label{element-wise-exponentiation}
 
-Exponentiation \lstinline!a ^ b! always returns a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! values.
-The result should correspond to mathematical exponentiation (ideally the correctly rounded result based on the inputs) with the following special cases:
+Exponentiation \lstinline!a ^ b! always returns a \lstinline!Real! scalar value, and it is required that \lstinline!a! and \lstinline!b! are scalar \lstinline!Real! or \lstinline!Integer! expressions.
+The result should correspond to mathematical exponentiation with the following special cases:
 \begin{itemize}
-\item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $1.0$.
+\item For any value of \lstinline!a! (including $0.0$) and an \lstinline!Integer! $\text{\lstinline!b!} = 0$, the result is $1.0$.
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer!, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
-\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is a \lstinline!Real! having a non-zero integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative). This case is deprecated, and tools may warn once during a simulation if this occurs.
+\item A deprecated semantics is to treat $\text{\lstinline!a!} < 0$ and a \lstinline!Real! \lstinline!b! having a non-zero integer value as if \lstinline!b! were an \lstinline!Integer!.
 \item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}
 
 \begin{nonnormative}
 Except for defining the special case of $0.0^0$ it corresponds to \lstinline[language=C]!pow(double a, double b)! in the ANSI~C library.
-The result is always \lstinline!Real! due to the potential for integer overflow and negative exponents.
+The result is always \lstinline!Real! as negative exponents can give non-integer results also when both operands are \lstinline!Integer!.
 The special treatment of \lstinline!Integer! exponents makes it possible to use $x^n$ in a power series.
 \end{nonnormative}
 

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1272,7 +1272,8 @@ Exponentiation \lstinline!a ^ b! always returns a \lstinline!Real! scalar value,
 The result should correspond to mathematical exponentiation (ideally the correctly rounded result based on the inputs) with the following special cases:
 \begin{itemize}
 \item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $1.0$.
-\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer! or a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
+\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer!, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
+\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative). This case is deprecated, and tools may warn once during a simulation if this occurs.
 \item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}
 

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1273,7 +1273,7 @@ The result should correspond to mathematical exponentiation (ideally the correct
 \begin{itemize}
 \item If $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0$ for an \lstinline!Integer! expression \lstinline!b! the result is $1.0$.
 \item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is an \lstinline!Integer!, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative).
-\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is a \lstinline!Real! having an integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative). This case is deprecated, and tools may warn once during a simulation if this occurs.
+\item If $\text{\lstinline!a!} < 0$ and \lstinline!b! is a \lstinline!Real! having a non-zero integer value, the result is defined as $\pm |a|^b$, with sign depending on whether \lstinline!b! is even (positive) or odd (negative). This case is deprecated, and tools may warn once during a simulation if this occurs.
 \item Consequences of other exceptional situations, such as ($\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} = 0.0$ for a \lstinline!Real b!, $\text{\lstinline!a!} = 0.0$ and $\text{\lstinline!b!} < 0$, or $\text{\lstinline!a!} < 0$ and \lstinline!b! does not have an integer value) or overflow are undefined.
 \end{itemize}
 


### PR DESCRIPTION
I propose this instead of #2955 (to avoid introducing IEEE).

**However**, it also solves the old issue with 0 ^ 0 in an acceptable way (#101 and #2246), **and** is consistent with having special unit-rules for integer exponents.

This means it is not just a clarification, but actually changes the semantics.