### PR TITLE
Split the restrictions for when-equations into two lists, 

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -291,14 +291,18 @@ The equations within the \lstinline!when!-equation must have one of the followin
   Operators \lstinline!assert!, \lstinline!terminate!, \lstinline!reinit!.
 \item
   The \lstinline!for!- and \lstinline!if!-equations if the equations within the \lstinline!for!- and \lstinline!if!-equations satisfy these requirements.
+\end{itemize}
+Additionally,
+\begin{itemize}
 \item
   The different branches of \lstinline!when!/\lstinline!elsewhen! must have the same set of component references on the left-hand side.
   Here, the destination variable of a \lstinline!reinit! (including when inside a \lstinline!when!-clause activated with \lstinline!initial()!) is not considered a left-hand side, and hence \lstinline!reinit! is unaffected by this requirement (as are \lstinline!assert! and \lstinline!terminate!).
 \item
   The branches of an \lstinline!if!-equation inside \lstinline!when!-equations must have the same set of component references on the left-hand side, unless all switching conditions of the \lstinline!if!-equation are parameter expressions.
+\item
+  Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be parameter expressions.
 \end{itemize}
 
-Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be parameter expressions.
 
 \begin{nonnormative}
 The needed restrictions on equations within a \lstinline!when!-equation becomes apparent with the following example:

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -303,7 +303,6 @@ Additionally,
   Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be parameter expressions.
 \end{itemize}
 
-
 \begin{nonnormative}
 The needed restrictions on equations within a \lstinline!when!-equation becomes apparent with the following example:
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
since they are different forms.
The problem was introduced in Modelica 2.0 when the new restrictions were added.
Closes #3291