### PR TITLE
Support search and copying of ligatures.

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   stage('build') {
     agent {
       docker {
-        image 'modelicaspec/latexml:20220405'
+        image 'modelicaspec/latexml:20221130'
         label 'linux'
         alwaysPull true
       }

--- a/.CI/latexml/Dockerfile
+++ b/.CI/latexml/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i s,http://archive.ubuntu.com/ubuntu/,mirror://mirrors.ubuntu.com/mirro
  && $INSTALL/install-tl --profile texlive.profile \
  && rm texlive.profile \
  && tlmgr update --self --all --reinstall-forcibly-removed \
- && tlmgr install latexmk listings caption cleveref xcolor float multirow tocloft parskip etoolbox index biblatex biber newtxtt txfonts \
+ && tlmgr install latexmk listings caption cleveref xcolor float multirow tocloft parskip etoolbox index biblatex biber newtxtt txfonts cmap \
  && cpanm JSON \
  && cpanm LaTeXML \
  && apt-get autoremove -qy make gcc curl wget git cpanminus libxml2-dev libxslt-dev \

--- a/MLS.tex
+++ b/MLS.tex
@@ -1,4 +1,5 @@
 \documentclass[10pt,a4paper]{report}
+\usepackage{cmap}
 \NeedsTeXFormat{LaTeX2e}
 \usepackage[utf8]{inputenc}
 


### PR DESCRIPTION
Closes #3286
It may be that we need to install additional packages on the docker-image (cmap and one more).

It seems we don't use virtual fonts so the more complicated solution isn't needed. Note that an alternative would be to use mmap, which also adds math-handling. It has the nice benefit that symbols like `\in` and `\bigcup` are automatically handled by copy-paste. However, since it doesn't fully handle fractions it seems unclear if it is worth it.