### PR TITLE
Unit-aware conversion of unit 

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -417,6 +417,7 @@ The mathematical functions and conversion operators are listed below do not gene
 {\lstinline!Integer($e$)!} & Conversion from enumeration to {\lstinline!Integer!} & \Cref{modelica:integer-of-enumeration} \\
 {\lstinline!EnumTypeName($i$)!} & Conversion from {\lstinline!Integer!} to enumeration & \Cref{modelica:enumeration-of-integer} \\
 {\lstinline!String($\ldots$)!} & Conversion to {\lstinline!String!} & \Cref{modelica:to-String} \\
+{\lstinline!inUnit($e$, $u$)!} & Convert to unit & \Cref{modelica:inUnit} \\
 \hline
 \end{tabular}
 \end{center}
@@ -539,6 +540,24 @@ For integral values it is also allowed to use the `\lstinline!d!', `\lstinline!i
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 \end{semantics}
 \end{operatordefinition*}
+
+\begin{functiondefinition}[inUnit]
+\begin{synopsis}\begin{lstlisting}
+inUnit($e$, $u$)
+\end{lstlisting}\end{synopsis}
+\begin{semantics}
+Convert the \lstinline!Real! expression $e$ to unit $u$.
+The unit $u$ shall be a \lstinline!String! parameter expression following the unit string syntax described in \cref{the-syntax-of-unit-expressions}.
+Unit symbols in $u$ shall be interpreted as belonging to a relative quantity when $e$ has a unit corresponding to \lstinline!absoluteValue = false!, and otherwise as belonging to an absolute quantity (see \lstinline!absoluteValue!-annotation in \cref{graphical-user-interface}).
+The unit of $e$ must be compatible with $u$.
+\end{semantics}
+\begin{nonnormative}
+As described in \cref{the-syntax-of-unit-expressions}, there may be user-defined unit symbols in addition to the ones that must be recognized.
+Hence, unit symbols that are recongized in one modeling environment may not be recognized in another.
+Often, this results in an error since it prevents verifying unit compatibility.
+It is a quality of implementation whether conversions that only involve changes of unit symbol prefixes are supported even when some unit symbols are unrecognized.
+\end{nonnormative}
+\end{functiondefinition}
 
 
 \subsection{Event Triggering Mathematical Functions}\label{event-triggering-mathematical-functions}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -543,13 +543,18 @@ The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (ch
 
 \begin{functiondefinition}[inUnit]
 \begin{synopsis}\begin{lstlisting}
-inUnit($e$, $u$)
+inUnit($e$, $u$, absoluteValue = $a$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Convert the \lstinline!Real! expression $e$ to unit $u$.
 The unit $u$ shall be a \lstinline!String! parameter expression following the unit string syntax described in \cref{the-syntax-of-unit-expressions}.
-Unit symbols in $u$ shall be interpreted as belonging to a relative quantity when $e$ has a unit corresponding to \lstinline!absoluteValue = false!, and otherwise as belonging to an absolute quantity (see \lstinline!absoluteValue!-annotation in \cref{graphical-user-interface}).
-The unit of $e$ must be compatible with $u$.
+Unit symbols in $u$ shall be interpreted as belonging to an absolute quantity when $a$, and otherwise as belonging to a relative quantity.
+To specify $a$, the named argument form must be used, and if omitted it is determined based on $e$ as described below.
+
+If $e$ has empty unit, \lstinline!absoluteValue! defaults to \lstinline!true!, and the unit $u$ gets attached to the value of $e$ without conversion.
+
+When $e$ has non-empty unit, \lstinline!absoluteValue! defaults to \lstinline!false! if $e$ is a relative quantity (corresponding to \lstinline!absoluteValue = false!, see \lstinline!absoluteValue!-annotation in \cref{graphical-user-interface}), and to true otherwise.
+The non-empty unit of $e$ must be compatible with $u$.
 \end{semantics}
 \begin{nonnormative}
 As described in \cref{the-syntax-of-unit-expressions}, there may be user-defined unit symbols in addition to the ones that must be recognized.


### PR DESCRIPTION
In the ongoing intense work on unit handling driven by #3255, the need for a unit-aware conversion between units has come up on several occasions.  Applications include:
- Unit conversions without bypassing unit checks as currently hidden away in functions like `Modelica.Units.Conversions.to_degF` (explained below).
- Unit conversions with the safety of the unit handling system.
- A concrete syntax for describing things happening implicitly in unit checking.

Functions like `Modelica.Units.Conversions.to_degF` would become unnecessary except as documented and annotated wrappers around the built-in operator.  It is more interesting to see how a unit conversion block could be defined:
```
partial block PartialConversionBlock "Partial block defining the interface for conversion blocks"
  parameter String fromUnit;
  parameter String toUnit;
  RealInput u(unit = fromUnit) "Connector of Real input signal to be converted";
  RealOutput y(unit = toUnit) "Connector of Real output signal containing input signal u in another unit";
equation
  y = inUnit(u, toUnit);
end PartialConversionBlock;

block To_degF = PartialConversionBlock(fromUnit = "K", toUnit = "degF") "Convert from Kelvin to degFahrenheit";
```

Compare this to the need to introduce a specific block that calls the `to_degF` function, where the function's implementation is a complete mess with regards to units:
```
function to_degF "Convert from kelvin to degree Fahrenheit"
  extends Modelica.Units.Icons.Conversion;
  input SI.Temperature Kelvin "Value in kelvin";
  output Modelica.Units.NonSI.Temperature_degF Fahrenheit "Value in degree Fahrenheit";
algorithm
  Fahrenheit := (Kelvin + Modelica.Constants.T_zero) * (9 / 5) + 32;
end to_degF;
```

(Changing the function so that the result is computed via unit `"1"` would be possible, but it would end up being a very complicated way of expressing something that the unit system should already know how to do.)
