### PR TITLE
Missing type specifier in example

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1271,3 +1271,4 @@ end C;
 In this case the deselection removes all of the connect-statements.
 \end{example}
 \end{nonnormative}
+

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1271,4 +1271,3 @@ end C;
 In this case the deselection removes all of the connect-statements.
 \end{example}
 \end{nonnormative}
-

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -608,7 +608,7 @@ Replace a given parameter value by an initial computation:
 \begin{lstlisting}
 model A
   parameter Real diameter  = 1;
-  final parameter radius = diameter / 2;
+  final parameter Real radius = diameter / 2;
 end A;
 
 model B "Initial equation for diameter"


### PR DESCRIPTION
Missing type specifier in the example for Removing modifiers.

Trying out if I can create a pull request from the source without a local copy.