### PR TITLE
Remove "extends FilledShape" from Text-definitions.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -852,13 +852,12 @@ It has the following definition (\emph{it is not equal to the \lstinline!Text! p
 \begin{lstlisting}[language=modelica]
 record Text
   extends GraphicItem;
-  extends FilledShape;
   Extent extent;
   String string;
   Real fontSize = 0 "unit pt";
   String fontName;
   TextStyle textStyle[:];
-  Color textColor = lineColor;
+  Color textColor = Color.Black;
   TextAlignment horizontalAlignment =
     if index < 0 then TextAlignment.Right else TextAligment.Left;
   Integer index;
@@ -988,20 +987,18 @@ A text string is specified as follows:
 \begin{lstlisting}[language=modelica]
 record Text
   extends GraphicItem;
-  extends FilledShape;
   Extent extent;
   String textString;
   Real fontSize = 0 "unit pt";
   String fontName;
   TextStyle textStyle[:];
-  Color textColor = lineColor;
+  Color textColor = Color.Black;
   TextAlignment horizontalAlignment = TextAlignment.Center;
 end Text;
 \end{lstlisting}%
 \annotationindex{Text}
 The \lstinline!textColor! attribute defines the color of the text.
 The text is drawn with transparent background and no border around the text (and without outline).
-The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.
 
 There are a number of common macros that can be used in the text, and they should be replaced when displaying the text as follows (in order such that the earliest ones have precedence, and using the longest sequence of identifier characters -- alphanumeric and underscore):
 \begin{itemize}


### PR DESCRIPTION
Closes# 2157
It has been deprecated for quite some time, and my proposal is that we either do it now or just after releasing 3.6.