### PR TITLE
Revert "Forbid zero delay."

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -768,7 +768,7 @@ delay($\mathit{expr}$, $\mathit{delayTime}$)
 Evaluates to \lstinline!$\mathit{expr}$(time - $\mathit{delayTime}$)! for $\text{\lstinline!time!} > \text{\lstinline!time.start!} + \mathit{delayTime}$ and \lstinline!$\mathit{expr}$(time.start)! for $\text{\lstinline!time!} \leq \text{\lstinline!time.start!} + \mathit{delayTime}$.
 The arguments, i.e., $\mathit{expr}$, $\mathit{delayTime}$ and $\mathit{delayMax}$, need to be subtypes of \lstinline!Real!.
 $\mathit{delayMax}$ needs to be additionally a parameter expression.
-The following relation shall hold: $0 < \mathit{delayTime} \leq \mathit{delayMax}$, otherwise an error occurs.
+The following relation shall hold: $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, otherwise an error occurs.
 If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ needs to be a parameter expression.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 For further details, see \cref{delay}.


### PR DESCRIPTION
This reverts commit 8824abb527e07ce581ed7eef755800f5183482f7.

As discussed in #3287 (and there will be more discussion later).