### PR TITLE
Deprecate String formatting of Real as Integer

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -538,7 +538,8 @@ The \lstinline!format! string corresponding to $\langle\mathit{options}\rangle$ 
 The ANSI-C style \lstinline!format! string (which cannot be combined with any of the other named arguments) consists of a single conversion specification without the leading \%.
 It shall not contain a length modifier, and shall not use `\lstinline!*!' for width and/or precision.
 For both \lstinline!Real! and \lstinline!Integer! values, the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
-For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers (for \lstinline!Real! values a tool may round, truncate or use a different format if the integer conversion specifiers are used).
+For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers.
+Using the \lstinline!Integer! conversion specifiers for a \lstinline!Real! value is a deprecated feature without defined result.
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -539,7 +539,7 @@ The ANSI-C style \lstinline!format! string (which cannot be combined with any of
 It shall not contain a length modifier, and shall not use `\lstinline!*!' for width and/or precision.
 For both \lstinline!Real! and \lstinline!Integer! values, the conversion specifiers `\lstinline!f!', `\lstinline!e!', `\lstinline!E!', `\lstinline!g!', `\lstinline!G!' are allowed.
 For \lstinline!Integer! values it is also allowed to use the `\lstinline!d!', `\lstinline!i!', `\lstinline!o!', `\lstinline!x!', `\lstinline!X!', `\lstinline!u!', and `\lstinline!c!' conversion specifiers.
-Using the \lstinline!Integer! conversion specifiers for a \lstinline!Real! value is a deprecated feature without defined result.
+Using the \lstinline!Integer! conversion specifiers for a \lstinline!Real! value is a deprecated feature, where tools are expected to produce a result by either rounding the value, truncating the value, or picking one of the \lstinline!Real! conversion specifiers instead.
 
 The `\lstinline!x!'/`\lstinline!X!' formats (hexa-decimal) and \lstinline!c! (character) for \lstinline!Integer! values give results that do not agree with the Modelica grammar.
 


### PR DESCRIPTION
This is a follow-up to #3262, breaking out a suggestion as proposed by @HansOlsson: https://github.com/modelica/ModelicaSpecification/pull/3262#discussion_r1051983848
