### PR TITLE
Scalar partial derivative

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1632,7 +1632,7 @@ IDENT "=" der "(" name "," IDENT { "," IDENT } ")" comment
 is the partial derivative of a function, and may only be used as declarations of functions.
 
 The semantics is that a function (and only a function) can be specified in this form, defining that it is the partial derivative of the function to the right of the equal sign (looked up in the same way as a short class definition, and the looked up name must be a function), and partially differentiated with respect to each {\lstinline!IDENT!} in order (starting from the first one).
-The {\lstinline!IDENT!} must be scalar {\lstinline!Real!} inputs to the function.
+Each {\lstinline!IDENT!} must be a scalar {\lstinline!Real!} input to the function.
 
 The comment allows a user to comment the function (in the info-layer and as one-line description, and as icon).
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1631,7 +1631,7 @@ IDENT "=" der "(" name "," IDENT { "," IDENT } ")" comment
 \end{lstlisting}
 is the partial derivative of a function, and may only be used as declarations of functions.
 
-The semantics is that a function (and only a function) can be specified in this form, defining that it is the partial derivative of the function to the right of the equal sign (looked up in the same way as a short class definition, and the looked up name must be a function), and partially differentiated with respect to each {\lstinline!IDENT!} in order (starting from the first one).  The {\lstinline!IDENT!} must be {\lstinline!Real!} inputs to the function.
+The semantics is that a function (and only a function) can be specified in this form, defining that it is the partial derivative of the function to the right of the equal sign (looked up in the same way as a short class definition, and the looked up name must be a function), and partially differentiated with respect to each {\lstinline!IDENT!} in order (starting from the first one).  The {\lstinline!IDENT!} must be scalar {\lstinline!Real!} inputs to the function.
 
 The comment allows a user to comment the function (in the info-layer and as one-line description, and as icon).
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1631,7 +1631,8 @@ IDENT "=" der "(" name "," IDENT { "," IDENT } ")" comment
 \end{lstlisting}
 is the partial derivative of a function, and may only be used as declarations of functions.
 
-The semantics is that a function (and only a function) can be specified in this form, defining that it is the partial derivative of the function to the right of the equal sign (looked up in the same way as a short class definition, and the looked up name must be a function), and partially differentiated with respect to each {\lstinline!IDENT!} in order (starting from the first one).  The {\lstinline!IDENT!} must be scalar {\lstinline!Real!} inputs to the function.
+The semantics is that a function (and only a function) can be specified in this form, defining that it is the partial derivative of the function to the right of the equal sign (looked up in the same way as a short class definition, and the looked up name must be a function), and partially differentiated with respect to each {\lstinline!IDENT!} in order (starting from the first one).
+The {\lstinline!IDENT!} must be scalar {\lstinline!Real!} inputs to the function.
 
 The comment allows a user to comment the function (in the info-layer and as one-line description, and as icon).
 


### PR DESCRIPTION
Just states that the variable we differentiate w.r.t. must be scalar as decided.
Note that we may generalize it later, if we find good use cases.
Closes #3335