### PR TITLE
Don't say that end is a function call, and be a bit clearer.

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1527,7 +1527,7 @@ Evaluable expressions\index{evaluable expression}\index{expression variability!e
 \item
   Except for the special built-in operators \lstinline!initial!, \lstinline!terminal!, \lstinline!der!, \lstinline!edge!, \lstinline!change!, \lstinline!sample!, and \lstinline!pre!, a function or operator with evaluable subexpressions is an evaluable expression.
 \item
-  The sub-expression \lstinline!end! used in \lstinline!A[$\ldots$ end $\ldots$]! if \lstinline!A! is variable declared in a non-\lstinline!function! class.
+  The sub-expression \lstinline!end! used in \lstinline!A[$\ldots$ end $\ldots$]! if \lstinline!A! is a variable declared in a non-\lstinline!function! class.
 \item
   Some function calls are evaluable expressions even if the arguments are not:
   \begin{itemize}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1527,12 +1527,12 @@ Evaluable expressions\index{evaluable expression}\index{expression variability!e
 \item
   Except for the special built-in operators \lstinline!initial!, \lstinline!terminal!, \lstinline!der!, \lstinline!edge!, \lstinline!change!, \lstinline!sample!, and \lstinline!pre!, a function or operator with evaluable subexpressions is an evaluable expression.
 \item
+  The sub-expression \lstinline!end! used in \lstinline!A[$\ldots$ end $\ldots$]! if \lstinline!A! is variable declared in a non-\lstinline!function! class.
+\item
   Some function calls are evaluable expressions even if the arguments are not:
   \begin{itemize}
   \item
     \lstinline!cardinality(c)!, see restrictions for use in \cref{cardinality-deprecated}.
-  \item
-    \lstinline!end! in \lstinline!A[$\ldots$ end $\ldots$]! if \lstinline!A! is variable declared in a non-\lstinline!function! class.
   \item
     \lstinline!size(A)! (including \lstinline!size(A, j)! where \lstinline!j! is an evaluable expression) if \lstinline!A! is variable declared in a non-function class.
   \item


### PR DESCRIPTION
Closes #3351

Note that `end` in functions will generally be a discrete-time expression (as everything else in functions).

An alternative would have been to view `end` in `A[...end...]` as syntactic sugar for the function call `size(A, i)` with suitable `i`, which maybe would reduce the number of special cases.