### PR TITLE
Allow extends from empty base-class and define empty class.

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -843,7 +843,15 @@ Real x[:]=foo(time);
 
 \subsection{Combining Base Classes and Other Elements}\label{restriction-on-combining-base-classes-and-other-elements}\label{combining-base-classes-and-other-elements}
 
-It is not legal to combine equations, algorithms, components, non-empty base classes (see \cref{empty-class}), or protected elements with an extends from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, or a simple type.
+It is not legal to combine equations, algorithms, components, non-empty base classes (see below), or protected elements with an extends from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, or a simple type.
+
+\begin{definition}[Empty class]\index{empty-class}
+A class without equations, algorithms, or components, and where any base-classes are themselves empty.
+\end{definition}
+
+\begin{nonnormative}
+An empty class may contain annotations, such as graphics, and can be used more freely as base-class than other classes.
+\end{nonnormative}
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -901,11 +901,6 @@ Flattening of class \lstinline!C2! yields a local class \lstinline!Voltage! with
 The variables \lstinline!v1! and \lstinline!v2! are instances of this local class and thus have a nominal value of 1000.
 \end{example}
 
-\subsection{Empty Class}\label{empty-class}
-An empty class is a class without equations, algorithms, and components, and where any base-classes are themselves empty.
-
-They may contain graphics - and can be used more freely as base-classes than other classes.
-
 \section{Specialized Classes}\label{specialized-classes}
 
 Specialized kinds of classes\index{specialized class} (earlier known as \emph{restricted classes}\index{restricted class|see{specialized class}})

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -843,7 +843,7 @@ Real x[:]=foo(time);
 
 \subsection{Combining Base Classes and Other Elements}\label{restriction-on-combining-base-classes-and-other-elements}\label{combining-base-classes-and-other-elements}
 
-It is not legal to combine equations, algorithms, components, base classes, or protected elements with an extends from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, or a simple type.
+It is not legal to combine equations, algorithms, components, non-empty base classes (see \cref{empty-class}), or protected elements with an extends from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, or a simple type.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -892,6 +892,11 @@ end C2;
 Flattening of class \lstinline!C2! yields a local class \lstinline!Voltage! with \lstinline!nominal! modifier \lstinline!1000!.
 The variables \lstinline!v1! and \lstinline!v2! are instances of this local class and thus have a nominal value of 1000.
 \end{example}
+
+\subsection{Empty Class}\label{empty-class}
+An empty class is a class without equations, algorithms, and components, and where any base-classes are themselves empty.
+
+They may contain graphics - and can be used more freely as base-classes than other classes.
 
 \section{Specialized Classes}\label{specialized-classes}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2797,7 +2797,7 @@ Within Modelica this memory is defined as instance of the predefined class {\lst
   Since the class is partial, it is not possible to define an instance of this class.
   \end{nonnormative}
 \item
-  An external object class shall be directly extended from {\lstinline!ExternalObject!}, shall have exactly two function definitions, called {\lstinline!constructor!} and {\lstinline!destructor!}, and shall not contain other elements.
+  An external object class shall be directly extended from {\lstinline!ExternalObject!}, shall have exactly two function definitions, called {\lstinline!constructor!} and {\lstinline!destructor!}, may extend empty classes (\cref{empty-class}), but not contain any other elements.
   The functions {\lstinline!constructor!} and {\lstinline!destructor!} shall not be replaceable.
   It is not legal to call the {\lstinline!constructor!} and {\lstinline!destructor!} functions explicitly.
 \item

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2797,7 +2797,7 @@ Within Modelica this memory is defined as instance of the predefined class {\lst
   Since the class is partial, it is not possible to define an instance of this class.
   \end{nonnormative}
 \item
-  An external object class shall be directly extended from {\lstinline!ExternalObject!}, shall have exactly two function definitions, called {\lstinline!constructor!} and {\lstinline!destructor!}, may extend empty classes (\cref{empty-class}), but not contain any other elements.
+  An external object class shall be directly extended from {\lstinline!ExternalObject!}, shall have exactly two function definitions, called {\lstinline!constructor!} and {\lstinline!destructor!}, may extend from empty classes (\cref{empty-class}), but not contain any other elements.
   The functions {\lstinline!constructor!} and {\lstinline!destructor!} shall not be replaceable.
   It is not legal to call the {\lstinline!constructor!} and {\lstinline!destructor!} functions explicitly.
 \item

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2824,7 +2824,7 @@ Within Modelica this memory is defined as instance of the predefined class {\lst
 \item
   An external object class shall be of the specialized class {\lstinline!class!}.
   \begin{nonnormative}
-  This is the only use of {\lstinline!class!}.
+  This is the only use of {\lstinline!class!} for a non-empty class, \cref{empty-class}.
   \end{nonnormative}
 \item
   Classes derived from {\lstinline!ExternalObject!} can neither be used in an {\lstinline!extends!}-clause nor in a short class definition.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2824,7 +2824,7 @@ Within Modelica this memory is defined as instance of the predefined class {\lst
 \item
   An external object class shall be of the specialized class {\lstinline!class!}.
   \begin{nonnormative}
-  This is the only use of {\lstinline!class!} for a non-empty class, \cref{empty-class}.
+  Apart from empty classes (\cref{empty-class}), this is the only use of {\lstinline!class!}.
   \end{nonnormative}
 \item
   Classes derived from {\lstinline!ExternalObject!} can neither be used in an {\lstinline!extends!}-clause nor in a short class definition.


### PR DESCRIPTION
As I understand it this corresponds to the decision, but I may have missed something.
Just for external objects for now; the other part would require more complicated grammar changes.