### PR TITLE
Replace stray 'c' in definition of clocked sample

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -585,7 +585,7 @@ sample($u$, $\mathit{clock}$)
 \begin{semantics}
 Input argument $u$ is a continuous-time expression according to \cref{continuous-time-expressions}.
 The optional input argument $\mathit{clock}$ is of type \lstinline!Clock!, and can in a call be given as a named argument (with the name $\mathit{clock}$), or as positional argument.
-The operator returns a clocked variable that has $\mathit{clock}$ as associated clock and has the value of the left limit of $u$ when $\mathit{clock}$ is active (that is the value of $u$ just before the event of \lstinline!c! is triggered).
+The operator returns a clocked variable that has $\mathit{clock}$ as associated clock and has the value of the left limit of $u$ when $\mathit{clock}$ is active (that is the value of $u$ just before the event of $\mathit{clock}$ is triggered).
 If $\mathit{clock}$ is not provided, it is inferred, see \cref{sub-clock-inferencing}.
 \begin{nonnormative}
 Since the operator returns the left limit of $u$, it introduces an infinitesimal small delay between the continuous-time and the clocked partition.  This corresponds to the reality, where a sampled data system cannot act infinitely fast and even for a very idealized simulation, an infinitesimal small delay is present.  The consequences for the sorting are discussed below.


### PR DESCRIPTION
This looks like a leftover from an earlier presentation where the clock was denoted `c`.

Discovered when preparing #3367.
