### PR TITLE
Don't use \emph for content of lesser importance

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -925,7 +925,7 @@ connect(a.x, b.x)
 \end{example}
 
 The optional \lstinline!Text!\index{Text@\robustinline{Text}!\robustinline{connect} annotation} primitive defines a text that will be written on the connection line.
-It has the following definition (\emph{it is not equal to the \lstinline!Text! primitive as part of graphics -- the differences are marked after Note in the description-strings}):
+It has the following definition (it is not equal to the \lstinline!Text! primitive as part of graphics -- the differences are marked after \emph{Note} in the description-strings):
 \begin{lstlisting}[language=modelica]
 record Text
   extends GraphicItem;


### PR DESCRIPTION
This is a small follow-up to #3372, addressing [comment](https://github.com/modelica/ModelicaSpecification/pull/3372#discussion_r1194351260).

It it was considered important, it shouldn't have been put in a parenthesis in the first place.

Also putting \emph where it should be used to quote words in the listing.