### PR TITLE
Add cross reference for short class definition 'partial' semantics

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -164,6 +164,7 @@ If the \lstinline[language=grammar]!type-specifier! of the component declaration
 % Seems sufficient to just have \indexinline variant of 'partial' in index.
 A class defined with \lstinline!partial!\indexinline{partial} in the \lstinline[language=grammar]!class-prefixes! is called a \firstuse[---]{partial} class.
 Such a class is allowed to be incomplete, and cannot be instantiated in a simulation model; useful, e.g., as a base class.
+See \cref{short-class-definitions} regarding short class definition semantics of \lstinline!partial!.
 
 If the \lstinline[language=grammar]!type-specifier! of the component does not denote a built-in type, the name of the type is looked up (\cref{static-name-lookup}).
 The found type is flattened with a new environment and the partially flattened enclosing class of the component.


### PR DESCRIPTION
The short class definition semantics of `partial` are important enough to be mentioned where `partial` is defined.
