### PR TITLE
Make connect-annotation example fit page width

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -953,11 +953,10 @@ The \lstinline!textColor! attribute defines the color of the text.  The text is 
 connect(controlBus.axisControlBus1, axis1.axisControlBus)
   annotation(
     Text(string = "%first", index = -1, extent = [-6, 3; -6, 7]),
-    Line(points =
-      {{-80,-10},{-80,-14.5},{-79,-14.5},{-79,-17},{-65,-17},{-65,-65},{-25,-65}})
+    Line(points = {{41, 30}, {50, 30}, {50, 50}, {58, 50}})
   );
 \end{lstlisting}
-Draws a connection line and adds the text \emph{axisControlBus1} ending at $(-6,\, 3) + (-25,\, -65)$ and 4 vertical units of space for the text.
+Draws a connection line and adds the text \emph{axisControlBus1} ending at $(-6,\, 3) + (58,\, 50)$ and 4 vertical units of space for the text.
 Using a height of zero, such as \lstinline!extent = [-6, 3; -6, 3]! is deprecated, but gives similar result.
 \end{example}
 


### PR DESCRIPTION
Fixes problem with empty line in listing caused by the entire list of points being moved to the next line.