### PR TITLE
Specify attributes of built-in types that are evaluable

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1544,7 +1544,7 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
-The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, \lstinline!unbounded!, and \lstinline!stateSelect!.
+The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 
 The \lstinline!unit! and \lstinline!displayUnit! attributes may be either the empty string or a string matching \lstinline[language=grammar]!unit-expression! in \cref{unit-expressions}.
 The meaning of the empty string depends on the context.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1544,6 +1544,8 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
+The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, \lstinline!unbounded!, and \lstinline!stateSelect!.
+
 The \lstinline!unit! and \lstinline!displayUnit! attributes may be either the empty string or a string matching \lstinline[language=grammar]!unit-expression! in \cref{unit-expressions}.
 The meaning of the empty string depends on the context.
 For the input and output components of a function, the empty string allows different units to be used in different calls to the function.
@@ -1580,6 +1582,8 @@ end Integer;
 \index{start@\robustinline{start}!attribute of \robustinline{Integer}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{Integer}}
 
+The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
+
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
 The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.
@@ -1600,6 +1604,8 @@ end Boolean;
 \index{start@\robustinline{start}!attribute of \robustinline{Boolean}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{Boolean}}%
 
+The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
+
 The fallback value is \lstinline!false!.
 
 \subsection{String Type}\label{string-type}
@@ -1617,6 +1623,8 @@ end String;
 \index{quantity@\robustinline{quantity}!attribute of \robustinline{String}}%
 \index{start@\robustinline{start}!attribute of \robustinline{String}}%
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{String}}
+
+The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
 
@@ -1743,6 +1751,8 @@ equation
   assert(min <= $\langle$$\mbox{\emph{value}}$$\rangle$ and $\langle$$\mbox{\emph{value}}$$\rangle$ <= max, "Variable value out of limit");
 end E;
 \end{lstlisting}
+
+The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
 The fallback value is the \lstinline!min! bound.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1551,6 +1551,11 @@ The meaning of the empty string depends on the context.
 For the input and output components of a function, the empty string allows different units to be used in different calls to the function.
 For a non-function component, the empty string allows the unit (or display unit) to be inferred by the tool.
 
+\begin{nonnormative}
+That \lstinline!displayUnit! is evaluable allows tools to verify that the default display unit is consistent with the \lstinline!unit!.
+Unlike the \lstinline!unit!, \lstinline!displayUnit! is just a default and unless given by a final modification, tools may allow overriding the default with other compatible display units in a translated model.
+\end{nonnormative}
+
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to
 define tolerances in relative terms, see \cref{attributes-start-fixed-nominal-and-unbounded}.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1553,7 +1553,7 @@ For a non-function component, the empty string allows the unit (or display unit)
 
 \begin{nonnormative}
 That \lstinline!displayUnit! is evaluable allows tools to verify that the default display unit is consistent with the \lstinline!unit!.
-Unlike the \lstinline!unit!, \lstinline!displayUnit! is just a default and unless given by a final modification, tools may allow overriding the default with other compatible display units in a translated model.
+Unlike the \lstinline!unit!, \lstinline!displayUnit! is just a default, tools may allow using other compatible display units for a translated model.
 \end{nonnormative}
 
 The \lstinline!nominal! attribute is meant to be used for scaling purposes and to


### PR DESCRIPTION
Related to, but independent of, #3383.
