### PR TITLE
General subscripting

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -948,7 +948,7 @@ The number of dimensions of the expression is reduced by the number of scalar in
 If the number of index arguments is smaller than the number of dimensions of the array, the trailing indices will use `\lstinline!:!'.
 
 It is possible to index a general expression by enclosing it in parenthesis.
-Note that the grammar is left factored and allows indexing of \lstinline[language=grammar]!output-expression-list!, but only indexing of an expression is syntactically valid.
+Note that while the subscripts are applied to a \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
 
 It is also possible to use the array access operator to assign to element/elements of an array in algorithm sections.
 This is called an \firstuse[assignment statement!indexed]{indexed assignment statement}.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -55,7 +55,7 @@ An array indexed by \lstinline!Boolean! or enumeration type can only be used in 
 \item
   Binding equations of the form \lstinline!x1 = x2! are allowed for arrays independent of whether the index types of dimensions are subtypes of \lstinline!Integer!, \lstinline!Boolean!, or enumeration types.
 \end{itemize}
-Operations constructing arrays (e.g., matrix multiplication, indexing, array constructors) only generate arrays index by \lstinline!Integer!.
+Operations constructing arrays (e.g., matrix multiplication, indexing, array constructors) only generate arrays indexed by \lstinline!Integer!.
 
 % IMPROVETOP
 \begin{table}[H]

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -55,6 +55,7 @@ An array indexed by \lstinline!Boolean! or enumeration type can only be used in 
 \item
   Binding equations of the form \lstinline!x1 = x2! are allowed for arrays independent of whether the index types of dimensions are subtypes of \lstinline!Integer!, \lstinline!Boolean!, or enumeration types.
 \end{itemize}
+Operations constructing arrays (e.g., matrix multiplication, indexing, array constructors) only generate arrays index by \lstinline!Integer!.
 
 % IMPROVETOP
 \begin{table}[H]
@@ -945,6 +946,9 @@ A colon (`\lstinline!:!') is used to denote all indices of one dimension.
 A vector expression can be used to pick out selected rows, columns and elements of vectors, matrices, and arrays.
 The number of dimensions of the expression is reduced by the number of scalar index arguments.
 If the number of index arguments is smaller than the number of dimensions of the array, the trailing indices will use `\lstinline!:!'.
+
+It is possible to index a general expression by enclosing it in parenthesis.
+Note that the grammar is left factored and allows indexing of \lstinline[language=grammar]!output-expression-list!, but only indexing of an expression is syntactically valid.
 
 It is also possible to use the array access operator to assign to element/elements of an array in algorithm sections.
 This is called an \firstuse[assignment statement!indexed]{indexed assignment statement}.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -55,7 +55,6 @@ An array indexed by \lstinline!Boolean! or enumeration type can only be used in 
 \item
   Binding equations of the form \lstinline!x1 = x2! are allowed for arrays independent of whether the index types of dimensions are subtypes of \lstinline!Integer!, \lstinline!Boolean!, or enumeration types.
 \end{itemize}
-Operations constructing arrays (e.g., matrix multiplication, indexing, array constructors) only generate arrays indexed by \lstinline!Integer!.
 
 % IMPROVETOP
 \begin{table}[H]

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -976,6 +976,10 @@ Array indexing in assignment statements:
 v[{j, k}] := {2, 3}; // Same as: v[j] := 2; v[k] := 3;
 v[{1, 1}] := {2, 3}; // Same as: v[1] := 3;
 \end{lstlisting}
+Array indexing of general expression:
+\begin{lstlisting}[language=modelica]
+(a*a)[:, j]    // Vector of the j'th column of a*a
+\end{lstlisting}
 If \lstinline!x! is a vector, \lstinline!x[1]! is a scalar, but the slice \lstinline!x[1:5]! is a vector
 (a vector-valued or colon index expression causes a vector to be returned).
 \end{example}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -103,9 +103,10 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 \end{center}
 \end{table}
 
-The postfix array index and postfix access operators are not expression operators in the normal sense that \lstinline!a.b[1]! can be treated as \lstinline!a.(b[1])!.
+The postfix array index and postfix access operators are not merely expression operators in the normal sense that \lstinline!a.b[1]! can be treated as \lstinline!a.(b[1])!.
 Instead, these operators need to be considered jointly to identify an entire \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) which is the smallest unit that can be seen as an expression in itself.
-Postfix array index and postifx access can only be applied immediately to a \lstinline[language=grammar]!component-reference!; not even parentheses around the left operand are allowed.
+Postfix access can only be applied immediately to a \lstinline[language=grammar]!component-reference!; not even parentheses around the left operand are allowed.
+Postfix array index can additionally be applied if there are parentheses around the left operand, see \cref{indexing}.
 
 \begin{example}
 Relative precedence of postfix array index and postfix access.
@@ -130,7 +131,6 @@ a[3]        // OK: Component reference of type R
 \end{lstlisting}
 The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than postfix access.
 Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! expresses, being a component reference of type \lstinline!Real[2]!.
-Note that \lstinline!(a.x)[2]! was illegal in version 3.6 and earlier.
 \end{example}
 
 \begin{example}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -118,16 +118,19 @@ R[3] a;
 \end{lstlisting}
 These are some valid as well as invalid ways to using postfix array index and postfix access:
 \begin{lstlisting}[language=modelica]
-a[3].x[2] // OK: Component reference of type Real
-a[3].x    // OK: Component reference of type Real[2]
-a.x[2]    // OK: Component reference of type Real[3]
-a.x       // OK: Component reference of type Real[3, 2]
-(a.x)[2]  // Error: Invalid use of parentheses
-a[3]      // OK: Component reference of type R
-(a[3]).x  // Error: Invalid use of parentheses
+a[3].x[2]   // OK: Component reference of type Real
+a[3].x      // OK: Component reference of type Real[2]
+a.x[2]      // OK: Component reference of type Real[3]
+a.x[2, :]   // Error.
+a.x         // OK: Component reference of type Real[3, 2]
+(a.x)[2]    // OK: Component reference of type Real[2] - same as a[2].x[:]
+(a.x)[2, :] // OK: Component reference of type Real[2] - same as a[2].x[:]
+a[3]        // OK: Component reference of type R
+(a[3]).x    // Error: Invalid use of parentheses
 \end{lstlisting}
 The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than postfix access.
-Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! tries to express, being a component reference of type \lstinline!Real[2]!.
+Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! expresses, being a component reference of type \lstinline!Real[2]!.
+Note that \lstinline!(a.x)[2]! was illegal in version 3.6 and earlier.
 \end{example}
 
 \begin{example}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -398,7 +398,7 @@ primary :
    | true
    | ( component-reference | der | initial | pure ) function-call-args
    | component-reference
-   | "(" output-expression-list ")"
+   | "(" output-expression-list ")" { array-subscripts }
    | "[" expression-list { ";" expression-list } "]"
    | "{" array-arguments "}"
    | end

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -398,7 +398,7 @@ primary :
    | true
    | ( component-reference | der | initial | pure ) function-call-args
    | component-reference
-   | "(" output-expression-list ")" { array-subscripts }
+   | "(" output-expression-list ")" [ array-subscripts ]
    | "[" expression-list { ";" expression-list } "]"
    | "{" array-arguments "}"
    | end


### PR DESCRIPTION
Add general subscripting also to Modelica.
Closes #2659

As noted in that ticket the previously discussed blocking cases are basically irrelevant.
An alternative to stating that all operations generate arrays indexed by 1...n is to state that general subscripting transforms the arrays to such a form - the downside is that `(a)[1]` isn't the same as `a[1]` - the upside is that` (a)[1]` is valid regardless of how the array is subscripted.
The end effect should be similar.
