### PR TITLE
Fix11

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1447,14 +1447,16 @@ Multiplication of two empty matrices results in a zero matrix of corresponding n
 \begin{lstlisting}[language=modelica]
 Real[0, m] * Real[m, n] = Real[0, n] // empty matrix
 Real[m, n] * Real[n, 0] = Real[m, 0] // empty matrix
-Real[m, 0] * Real[0, n] = fill(0.0, m, n) // non-empty matrix of zeros
+Real[m, 0] * Real[0, n] = fill(0.0, m, n) // matrix of zeros
+// Note fill(0.0, m, n) will be an empty matrix if m or n is 0
 \end{lstlisting}
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
-Real u[p], x[n], y[q], A[n, n], B[n, p], C[q, n], D[q, p];
-der(x) = A * x + B * u
-y = C * x + D * u
+  Real u[p], x[n], y[q], A[n, n], B[n, p], C[q, n], D[q, p];
+equation
+  der(x) = A * x + B * u
+  y = C * x + D * u
 \end{lstlisting}
 Assume $\text{\lstinline!n!} = 0$, $\text{\lstinline!p!} > 0$, $\text{\lstinline!q!} > 0$: Results in \lstinline!y = D * u!.
 \end{example}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -384,7 +384,7 @@ For every use of the \lstinline!connect!-equation
 \begin{lstlisting}[language=modelica]
 connect(a, b);
 \end{lstlisting}
-one connection set is generated for every pair of corresponding primitive components of \lstinline!a! and \lstinline!b! together with an indication of whether they are from an inside or an outside connector.
+a connection set is generated for each pair of corresponding primitive components of \lstinline!a! and \lstinline!b! together with an indication of whether they are from an inside or an outside connector.
 \begin{definition}[Primitive elements]\label{primitive-elements}\index{primitive element}\index{element!primitive}
 The primitive elements are of simple types or of types defined as \lstinline!operator record! (i.e., a component of an \lstinline!operator record! type is not split into sub-components).
 \end{definition}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -384,7 +384,7 @@ For every use of the \lstinline!connect!-equation
 \begin{lstlisting}[language=modelica]
 connect(a, b);
 \end{lstlisting}
-the primitive components of \lstinline!a! and \lstinline!b! form a connection set, together with an indication of whether they are from an inside or an outside connector.
+each of their primitive components will generate one connection set comprised of the corresponding primitive components of \lstinline!a! and \lstinline!b! form a connection set, together with an indication of whether they are from an inside or an outside connector.
 \begin{definition}[Primitive elements]\label{primitive-elements}\index{primitive element}\index{element!primitive}
 The primitive elements are of simple types or of types defined as \lstinline!operator record! (i.e., a component of an \lstinline!operator record! type is not split into sub-components).
 \end{definition}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -384,7 +384,7 @@ For every use of the \lstinline!connect!-equation
 \begin{lstlisting}[language=modelica]
 connect(a, b);
 \end{lstlisting}
-each of their primitive components will generate one connection set comprised of the corresponding primitive components of \lstinline!a! and \lstinline!b! form a connection set, together with an indication of whether they are from an inside or an outside connector.
+each of their primitive components will generate one connection set comprised of the corresponding primitive components of \lstinline!a! and \lstinline!b! together with an indication of whether they are from an inside or an outside connector.
 \begin{definition}[Primitive elements]\label{primitive-elements}\index{primitive element}\index{element!primitive}
 The primitive elements are of simple types or of types defined as \lstinline!operator record! (i.e., a component of an \lstinline!operator record! type is not split into sub-components).
 \end{definition}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -883,8 +883,7 @@ algorithm
 end Add;
 \end{lstlisting}
 \lstinline!Add(1, [1,2,3])! adds one to each of the elements of the second
-argument giving the result \lstinline![2,3,4]!. However, it is illegal to
-write \lstinline!1 + [1,2,3]!, because the rules for the built-in
+argument giving the result \lstinline![2,3,4]!. For built-in operators one can do this with \lstinline!1 .+ [1,2,3]! but not with \lstinline!1 + [1,2,3]!, because the rules for the built-in
 operators are more restrictive.
 \end{example}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -882,9 +882,8 @@ algorithm
   sum1 := e1 + e2;
 end Add;
 \end{lstlisting}
-\lstinline!Add(1, [1,2,3])! adds one to each of the elements of the second
-argument giving the result \lstinline![2,3,4]!. For built-in operators one can do this with \lstinline!1 .+ [1,2,3]! but not with \lstinline!1 + [1,2,3]!, because the rules for the built-in
-operators are more restrictive.
+\lstinline!Add(1, [1,2,3])! adds one to each of the elements of the second argument giving the result \lstinline![2,3,4]!.
+For built-in operators one can do this with \lstinline!1 .+ [1,2,3]! but not with \lstinline!1 + [1,2,3]!, because the rules for the built-in operators are more restrictive.
 \end{example}
 
 \subsection{Empty Function Calls}\label{empty-function-calls}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -875,14 +875,14 @@ sin([1,2;3,4]) = [sin({1,2}); sin({3,4})]
   = [sin(1), sin(2); sin(3), sin(4)]
 \end{lstlisting}
 \begin{lstlisting}[language=modelica]
-function Add
+function add
   input Real e1, e2;
   output Real sum1;
 algorithm
   sum1 := e1 + e2;
-end Add;
+end add;
 \end{lstlisting}
-\lstinline!Add(1, [1,2,3])! adds one to each of the elements of the second argument giving the result \lstinline![2,3,4]!.
+\lstinline!add(1, [1,2,3])! adds one to each of the elements of the second argument giving the result \lstinline![2,3,4]!.
 For built-in operators one can do this with \lstinline!1 .+ [1,2,3]! but not with \lstinline!1 + [1,2,3]!, because the rules for the built-in operators are more restrictive.
 \end{example}
 


### PR DESCRIPTION
Since we repeatedly find cases where errors that have remained from version 1.1 of the specification I'm going through that version and looking for problems.

I also found that:
https://github.com/modelica/ModelicaSpecification/blob/07ccecd0719e130ad7edfb578f94e72ba5872dbe/chapters/equations.tex#L106
is problematic ("once"? what if the for-equation is nested?), but I couldn't find any good alternative.
