### PR TITLE
Choice restrictions

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1071,7 +1071,8 @@ By starting names with a dot it can be ensured that no transformation of referen
 
 This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclaration, where the string comments on the choice declaration can be used as textual explanations of the choices.
 The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
-Some choices may be invalid in the current context, e.g., a value might violate the min-attribute.
+
+It is allowed to include choices are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
 \begin{nonnormative}
 Tools may avoid including such choices, mark them as invalid, or detect such violations later.
 \end{nonnormative}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1072,7 +1072,7 @@ By starting names with a dot it can be ensured that no transformation of referen
 This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclaration, where the string comments on the choice declaration can be used as textual explanations of the choices.
 The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
 
-It is allowed to include choices are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
+It is allowed to include choices that are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
 (Options for tools encountering such choices include not showing them, marking them as invalid, or detecting the violations later.)
 
 For a \lstinline!Boolean! variable, a \lstinline!choices! annotation may contain the definition \lstinline!checkBox = true!, meaning to display a checkbox to input the values \lstinline!false! or \lstinline!true! in the graphical user interface.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -690,7 +690,7 @@ the component are seen as syntactic sugar for having all arrays sizes on
 the right of the component; and thus can be redeclared in a consistent
 way.
 
-Having annotations on the \lstinline!redeclare! construct in a modifier is deprecated and the annotations have no effect.
+The presence of annotations on the \lstinline!redeclare! construct in a modifier is deprecated, but since none of the annotations in the specification ever had a meaning in this context it only impacts vendor-specific annotations.
 
 \begin{nonnormative}
 Note: The inheritance is from the original declaration. In most

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -690,6 +690,8 @@ the component are seen as syntactic sugar for having all arrays sizes on
 the right of the component; and thus can be redeclared in a consistent
 way.
 
+Having annotations on the \lstinline!redeclare! construct in a modifier is deprecated and the annotations have no effect.
+
 \begin{nonnormative}
 Note: The inheritance is from the original declaration. In most
 cases replaced or original does not matter. It does matter if a user

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1073,9 +1073,8 @@ This is a hint for users of the model, and can also be used by the user interfac
 The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
 
 It is allowed to include choices are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
-\begin{nonnormative}
-Tools may avoid including such choices, mark them as invalid, or detect such violations later.
-\end{nonnormative}
+(Options for tools encountering such choices include not showing them, marking them as invalid, or detecting the violations later.)
+
 For a \lstinline!Boolean! variable, a \lstinline!choices! annotation may contain the definition \lstinline!checkBox = true!, meaning to display a checkbox to input the values \lstinline!false! or \lstinline!true! in the graphical user interface.
 
 The annotation \lstinline!choicesAllMatching = true!\annotationindex{choicesAllMatching} on the following kinds of elements indicates that tools should automatically construct a menu with appropriate choices.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1069,6 +1069,10 @@ By starting names with a dot it can be ensured that no transformation of referen
 
 This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclaration, where the string comments on the choice declaration can be used as textual explanations of the choices.
 The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
+Some choices may be invalid in the current context, e.g., a value might violate the min-attribute.
+\begin{nonnormative}
+Tools may avoid including such choices, mark them as invalid, or detect such violations later.
+\end{nonnormative}
 For a \lstinline!Boolean! variable, a \lstinline!choices! annotation may contain the definition \lstinline!checkBox = true!, meaning to display a checkbox to input the values \lstinline!false! or \lstinline!true! in the graphical user interface.
 
 The annotation \lstinline!choicesAllMatching = true!\annotationindex{choicesAllMatching} on the following kinds of elements indicates that tools should automatically construct a menu with appropriate choices.


### PR DESCRIPTION
Closes #3311
Note that formulation for choices instead focuses on the goal: a model may have include annotation-choices that aren't valid (for the current parameter) - and clearly they shouldn't be used then. Exactly how that is handled is more a tool-choice - and I'm not sure exactly which variant gives the best user experience.

And annotations on redeclare id deprecated. (Could turn into separate PR if needed.)