### PR TITLE
Trying to clarify array introduction - covering all cases.

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1,12 +1,10 @@
 \chapter{Arrays}\label{arrays}
 
-A non-record array can be regarded as a collection of type compatible values, \cref{type-compatible-expressions}.
-An array of records may contain scalar record values whose elements differ in their dimension sizes, but apart from that they must be of the same type.
+An array of the specialized classes type, record, and connector can be regarded as a collection of type compatible values, \cref{type-compatible-expressions}.
+Thus an array of the specialized classes record or connector may contain scalar values whose elements differ in their dimension sizes, but apart from that they must be of the same type.
 Such heterogenous arrays may only be used completely, sliced as specified, or indexed.
-An array of arrays must have the same dimension sizes for all of the arrays (with the same exception for records).
-Modelica arrays can be multidimensional and are ``rectangular'',
-which in the case of matrices has the consequence that all rows in a
-matrix have equal length, and all columns have equal length.
+An array of other specialized classes can only be used sliced as specified, or indexed.
+Modelica arrays can be multidimensional and are ``rectangular'', which in the case of matrices has the consequence that all rows in a matrix have equal length, and all columns have equal length.
 
 Each array has a certain dimensionality, i.e., number of dimensions.
 The degenerate case of a \firstuse{scalar} variable is not really an array, but can be regarded as an array with zero dimensions.


### PR DESCRIPTION
Closes #3414

It shouldn't be any real change - and it is non-normative anyway.

Note that:
- Connectors are included at the same level as record.
- Due to the construction of type-compatible, heterogenous records are allowed. (It may be that this is a bit complicated.)
- The reason "type" is excluded in the sentence is that it implies a primitive type without any substructure. Therefore it is not possible for it to contains arrays and thus clearly not heterogenous arrays.
- The first part for "non-record" likely meant primitive component (i.e. of specialized class "type"); not model/block.
- Arrays of models/blocks are added. They are used both for connections, and for accessing specific elements (slicing/indexing).

This starts with the obvious arrays and progresses to the less obvious, but more general.