### PR TITLE
Add missing style markup of class specializations

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1,7 +1,7 @@
 \chapter{Arrays}\label{arrays}
 
-An array of the specialized classes type, record, and connector can be regarded as a collection of type compatible values, \cref{type-compatible-expressions}.
-Thus an array of the specialized classes record or connector may contain scalar values whose elements differ in their dimension sizes, but apart from that they must be of the same type.
+An array of the specialized classes \lstinline!type!, \lstinline!record!, and \lstinline!connector! can be regarded as a collection of type compatible values, \cref{type-compatible-expressions}.
+Thus an array of the specialized classes \lstinline!record! or \lstinline!connector! may contain scalar values whose elements differ in their dimension sizes, but apart from that they must be of the same type.
 Such heterogenous arrays may only be used completely, sliced as specified, or indexed.
 An array of other specialized classes can only be used sliced as specified, or indexed.
 Modelica arrays can be multidimensional and are ``rectangular'', which in the case of matrices has the consequence that all rows in a matrix have equal length, and all columns have equal length.


### PR DESCRIPTION
Amends the recent #3421.