### PR TITLE
Clarify complicated sentence about 'input' prefix exception in functions

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -222,7 +222,7 @@ A \firstuse{prefix} is property of an element of a class definition which can be
 Type prefixes (that is, \lstinline!flow!, \lstinline!stream!, \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!) shall only be applied for type, record, operator record, and connector components -- see also record specialized class, \cref{specialized-classes}.
 This is further restricted below; some of these combinations of type prefixes and specialized classes are not legal.
 
-An exception is \lstinline!input! for components whose type is of the special class function type (these can only be used for function formal parameters and has special semantics, see \cref{functional-input-arguments-to-functions}).
+An exception is \lstinline!input! for components whose type is of the specialized class \lstinline!function! (these can only be used for function formal parameters and has special semantics, see \cref{functional-input-arguments-to-functions}).
 In this case, the \lstinline!input! prefix is not applied to the elements of the component, and the prefix is allowed even if the elements of the component have \lstinline!input! or \lstinline!output! prefix.
 
 In addition, instances of classes extending from \lstinline!ExternalObject! may have type prefixes \lstinline!parameter! and \lstinline!constant!, and in functions also type prefixes \lstinline!input! and \lstinline!output!, see \cref{external-objects}.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -222,7 +222,8 @@ A \firstuse{prefix} is property of an element of a class definition which can be
 Type prefixes (that is, \lstinline!flow!, \lstinline!stream!, \lstinline!discrete!, \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!) shall only be applied for type, record, operator record, and connector components -- see also record specialized class, \cref{specialized-classes}.
 This is further restricted below; some of these combinations of type prefixes and specialized classes are not legal.
 
-An exception is \lstinline!input! for components whose type is of the special class function type (these can only be used for function formal parameters and has special semantics, see \cref{functional-input-arguments-to-functions}), and the \lstinline!input! prefix is not applied to the elements of the component and is allowed even if the elements have \lstinline!input! or \lstinline!output! prefix.
+An exception is \lstinline!input! for components whose type is of the special class function type (these can only be used for function formal parameters and has special semantics, see \cref{functional-input-arguments-to-functions}).
+In this case, the \lstinline!input! prefix is not applied to the elements of the component, and the prefix is allowed even if the elements of the component have \lstinline!input! or \lstinline!output! prefix.
 
 In addition, instances of classes extending from \lstinline!ExternalObject! may have type prefixes \lstinline!parameter! and \lstinline!constant!, and in functions also type prefixes \lstinline!input! and \lstinline!output!, see \cref{external-objects}.
 


### PR DESCRIPTION
The previous formulation didn't make sense grammatically to me, as I expected another condition for the exception to apply following the _and_.  This PR fixes this along with writing out a few more things that make the rule easier to parse.
