### PR TITLE
Support non-integer exponents to handle the result of square.

### DIFF
--- a/chapters/unitexpressions.tex
+++ b/chapters/unitexpressions.tex
@@ -43,10 +43,14 @@ unit-factor :
 
 unit-exponent :
    [ "+" | "-" ] UNSIGNED-INTEGER
+   | "^" "(" [ "+" | "-" ] UNSIGNED-INTEGER "/" UNSIGNED-INTEGER ")"
 \end{lstlisting}
 
 The SI standard uses super-script for the exponentation, and does thus not define any operator symbol for exponentiation.
-A \lstinline[language=grammar]!unit-factor! consists of a \lstinline[language=grammar]!unit-operand! possibly suffixed by a possibly signed integer number, which is interpreted as an exponent.
+A \lstinline[language=grammar]!unit-factor! normally consists of a \lstinline[language=grammar]!unit-operand! possibly suffixed by a possibly signed integer number, which is interpreted as an exponent.
+Non-integer exponents are needed to fully support the unit for square roots (and can be used for roots in general).
+They are intended to be only be used when needed, and thus the fraction must be simplified and the denominator may not be one (or zero).
+They use an explicit exponentation operator to be easy to recognize.
 There must be no spacing between the \lstinline[language=grammar]!unit-operand! and a possible \lstinline[language=grammar]!unit-exponent!.
 
 \begin{lstlisting}[language=grammar]


### PR DESCRIPTION
One problem with defining the unit for sqrt(x) as proposed in #2127 is that sqrt(1m) is 1m^(1/2).
Obviously in most cases sqrt will return a normal unit, e.g. sqrt(4m^2) is 2m, so we should not consider this as a common case.

There are multiple options - some of the ones I considered and rejected:
- Don't support them at all; as we have seen that doesn't work well enough.
- Support computing them without having a syntax for generating them; this will require work-arounds for constructing them (it's possible) but also mean that each tool will have to find some syntax in error messages, and is thus not ideal. It will also mean that we write the result of unit-inference in standard Modelica.
- Generalize the exponent to be a floating point number. The syntax will be a confusing syntax since "." is normally multiplication, so "m0.5" would be confusingly similar to "m0" times "5"; and cube-roots will be a mess, see https://github.com/modelica/ModelicaSpecification/issues/3359 - thus restricting it to fractions seems safer. (We also use fraction in synchronous to ensure that the math is exact - no "m^(0.00001)" left-overs.)
- Prefix to take a root: there's no good symbol in ascii - and it would be a weird mix (as squaring and square root would be on opposite ends)
- Rational exponents with or without parenthesis: "m(1/2)" or "m1/2". I don't find them easy to understand; even if the syntax may be unambiguous.
- Exponentiation symbol without parenthesis: "m^1/2". Mathematically that doesn't parse well, as one expects it to mean (m^1)/2.

An additional possibility would be also allow the symbol for integers. I can see this in the future, but don't think it is needed at the moment - and by being more restrictive the mapping back from internal unit (including inferred ones) to the unit-syntax is more restricted to ensure that there is no change unless needed. (A similar reason explains why the fraction must be simplified.)