### PR TITLE
Avoid using the word "public variable section" since it does not exist.

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -152,7 +152,7 @@ Modelica functions have the following restrictions compared to a general
 Modelica \lstinline!class!:
 \begin{itemize}
 \item
-  All public components must have prefixes input or output.
+  Each public component must have the prefix input or output.
 \item
   Input formal parameters are read-only after being bound to the actual
   arguments or default values, i.e., they shall not be assigned values in

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -152,7 +152,7 @@ Modelica functions have the following restrictions compared to a general
 Modelica \lstinline!class!:
 \begin{itemize}
 \item
-  Only input and output formal parameters are allowed in the function's public variable section.
+  All public components must have prefixes input or output.
 \item
   Input formal parameters are read-only after being bound to the actual
   arguments or default values, i.e., they shall not be assigned values in


### PR DESCRIPTION
Additionally avoid "formal parameters" as it is unclear as well.
Closes #3437

The issue with "formal parameters" is that 
- The start of the chapter says: `Formal parameters are specified using the \lstinline!input!\indexinline{input} keyword, whereas results are denoted using the \lstinline!output!\indexinline{output} keyword.`
- Later there is discussion of `input or output formal parameter`

The first would indicate that outputs are called "results" not "output formal parameters".
Looking more closely it seems that "results" often mean the result-values instead of "result-variables"; that should be clarified.