### PR TITLE
Recommend using most specific resource

### DIFF
--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -290,6 +290,7 @@ For example, if \filename{modelica:/A/Resources} maps to \filename{A/Resources},
 
 \begin{nonnormative}
 The use of a trailing segment separator is recommended when the resource is a directory and the file-system path will be prepended to relative file paths within the directory.
+If possible use URIs for specific files or specific sub-directories instead of appending relative paths to a generic URI such as \filename{modelica:/A/Resources/} as the latter creates a dependency on the entire directory.
 \end{nonnormative}
 
 For a Modelica-package stored as a single file, \filename{A.mo}, the resource \filename{modelica:/A/C.jpg} refers to a file \filename{C.jpg} stored in the same directory as \filename{A.mo}, but using resources in this variant is not recommended since multiple packages will share resources.

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -290,7 +290,7 @@ For example, if \filename{modelica:/A/Resources} maps to \filename{A/Resources},
 
 \begin{nonnormative}
 The use of a trailing segment separator is recommended when the resource is a directory and the file-system path will be prepended to relative file paths within the directory.
-If possible use URIs for specific files or specific sub-directories instead of appending relative paths to a generic URI such as \filename{modelica:/A/Resources/} as the latter creates a dependency on the entire directory.
+If possible, use URIs for specific files or specific sub-directories instead of appending relative paths to a generic URI such as \filename{modelica:/A/Resources/} as the latter creates a dependency on the entire directory.
 \end{nonnormative}
 
 For a Modelica-package stored as a single file, \filename{A.mo}, the resource \filename{modelica:/A/C.jpg} refers to a file \filename{C.jpg} stored in the same directory as \filename{A.mo}, but using resources in this variant is not recommended since multiple packages will share resources.


### PR DESCRIPTION
From comment in #3433
Similarly as recommending using trailing directory separator, we should recommend to not use directories when you only want a specific file.