### PR TITLE
Describe common ways of using ModelicaUtilities.h

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2660,7 +2660,8 @@ The following usage patterns are common:
 \end{example}
 
 \begin{nonnormative}
-External libraries can built with the \filename{ModelicaUtilities.h} included within the Modelica Standard Library.
+When building external libraries, it is not possible to rely on the tool mechanism that provides \filename{ModelicaUtilities.h} for \lstinline!Include! annotations.
+Instead, an external library project may contain its own instance of \filename{ModelicaUtilities.h}, for example obtained by making a copy of the instance included within the Modelica Standard Library.
 \end{nonnormative}
 
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2660,9 +2660,7 @@ The following usage patterns are common:
 \end{example}
 
 \begin{nonnormative}
-There is no standardized way to build external libraries using the functions in \filename{ModelicaUtilities.h}.
-For example, there is no standardized way of obtaining a directory where the tool shall provide the \filename{ModelicaUtilities.h}.
-There is also no standardized library to link with to get a tool-specific implementation of the functions.
+External libraries can built with the \filename{ModelicaUtilities.h} included within the Modelica Standard Library.
 \end{nonnormative}
 
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2660,7 +2660,7 @@ The following usage patterns are common:
 \end{example}
 
 \begin{nonnormative}
-When building external libraries, it is not possible to rely on the tool mechanism that provides \filename{ModelicaUtilities.h} for \lstinline!Include! annotations.
+When building external libraries independently of Modelica tools, it is not possible to rely on the tool mechanism that provides \filename{ModelicaUtilities.h} for \lstinline!Include! annotations.
 Instead, an external library project may contain its own instance of \filename{ModelicaUtilities.h}, for example obtained by making a copy of the instance included within the Modelica Standard Library.
 \end{nonnormative}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2645,6 +2645,27 @@ z1 = myfoo(2.4, 3, &i2);
 
 This section describes the utility functions declared in \filename{ModelicaUtilities.h}, which can be called in external Modelica functions written in C.
 
+The tool must ensure that the header is found by \lstinline[language=C]!#include "ModelicaUtilities.h"! within an \lstinline!Include! annotation (see \cref{annotations-for-external-libraries-and-include-files}); no \lstinline!IncludeDirectory! annotation is needed.
+
+\begin{example}
+The following usage patterns are common:
+\begin{itemize}
+\item
+  The \lstinline!Include! annotation may first \lstinline[language=C]!#include "ModelicaUtilities.h"!, and then contain the external function definition where the utility functions may be used.
+\item
+  Like above, but moving the annotation content above to, say, \filename{myExtFun.c}, and then just do \lstinline[language=C]!#include "myExtFun.c"! in the annotation.
+\item
+  After \lstinline[language=C]!#include "ModelicaUtilities.h"!, the \lstinline!Include! annotation can also define a wrapper around a function in a linked library that does the real job, where the wrapper forwards the arguments as well as passes function pointers for a selection of functions from \filename{ModelicaUtilities.h}.
+\end{itemize}
+\end{example}
+
+\begin{nonnormative}
+There is no standardized way to build external libraries using the functions in \filename{ModelicaUtilities.h}.
+For example, there is no standardized way of obtaining a directory where the tool shall provide the \filename{ModelicaUtilities.h}.
+There is also no standardized library to link with to get a tool-specific implementation of the functions.
+\end{nonnormative}
+
+
 \subsubsection{Error Reporting Utility Functions}\label{utility-functions-for-reporting-errors}\label{error-reporting-utility-functions}
 
 The functions listed below produce a message in different ways.


### PR DESCRIPTION
This was factored out of #3452, as promised in https://github.com/modelica/ModelicaSpecification/pull/3452#discussion_r1419690390.

In addition to examples and other non-normative text, this PR makes clear that `#include "ModelicaUtilities.h"` shall work inside an `Include` annotation.
