### PR TITLE
Fix quoting!

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -2347,7 +2347,7 @@ package can also decrypt it.
 // File MyLibrary\package.mo
 package MyLibrary
   annotation(Protection(License(libraryKey="15783-A39323-498222-444ckk4ll",
-  licenseFile="MyLibraryAuthorization_Tool.mo_lic), $\ldots$));
+  licenseFile="MyLibraryAuthorization_Tool.mo_lic"), $\ldots$));
 end MyLibrary;
 
 // File MyLibrary\MyLibraryAuthorization_Tool.mo\


### PR DESCRIPTION
A string lacked the end-of-string quote messing up the example.