### PR TITLE
Update 'constsize' example listings

### DIFF
--- a/RationaleMCP/0031/constsize.md
+++ b/RationaleMCP/0031/constsize.md
@@ -7,21 +7,20 @@ This section describes a limitation of the current design, and ways in which it 
 ### Limitation
 The current forms of `constsize` don't allow leaving some leading sizes flexible, while making other sizes constant.  It means that some full Modelica function algorithms cannot be directly converted to Base Modelica:
 ```
-function flexibleTrouble
-protected
-  Real[:, :] a; /* (That the second dimension doesn't have constant size matching 'b' is probably a sign of bad design.) */
-  Real[2] b;
-  Real[:] y;
+function 'flexibleTrouble'
+  Real[:, :] 'a'; /* (That the second dimension doesn't have constant size matching 'b' is probably a sign of bad design.) */
+  Real[2] 'b';
+  Real[:] 'y';
 algorithm
   /* Allowed in full Modelica, but not in Base Modelica.
    * Size mismatch in array multiplication: ':' is not compatible with constant size.
    */
-  y := a * b;
+  'y' := 'a' * 'b';
   /* Trying to address Base Modelica type error.
    * Well-typed, but will generally fail at runtime, as 42 has nothing to do with the first size of 'a'.
    */
-  y := constsize(a, 42, 2) * b;
-end flexibleTrouble;
+  'y' := constsize('a', 42, 2) * 'b';
+end 'flexibleTrouble';
 ```
 
 ### Remedies
@@ -40,32 +39,30 @@ For now, however, we don't expect this to be a problem for real-world examples. 
 
 With a way to specify `:` in the `constsize` expression, one would have to define if a `:` specified for a constant dimension should turn that dimension into a flexible size, or if it should be defined as leaving the size constant.  This could be particularly useful when dealing with dimensions indexed by enumerations:
 ```
-model EnumerationCardinality
-  function f
-    output Real[:, MyEnumType, :] y;
-    ...
-  end f;
-  function h
-  protected
-    Real[:, MyEnumType, 3] z;
-  algorithm
-    /* Cumbersome way to assign the result of f() to z:
-     */
-    z := constsize(f(), :, size(z, 2), 3); /* OK. */
-    /* Trying to just use size(z) doesn't work because size(z) has non-constant
-     * variability due to the flexible size of the first dimension:
-     */
-    z := constsize(f(), size(z)); /* Error. */
-    /* Possible interpretations of specifying a ':' size where the expression
-     * type has constant size (here given by the cardinality of MyEnumType):
-     * - If the resulting size is still the original constant size, this
-     *   is a convenient way to avoid need to figure out cardinality.
-     * - If the resulting size is flexible, it will be a type error to assign
-     *   to 'z' where the size needs to be constant.
-     */
-    z := constsize(f(), :, :, 3); /* Convenient or error depending on design. */
-  end h;
-end EnumerationCardinality;
+function 'f'
+  output Real[:, 'MyEnumType', :] 'y';
+  ...
+end 'f';
+
+function 'h'
+  Real[:, 'MyEnumType', 3] 'z';
+algorithm
+  /* Cumbersome way to assign the result of f() to 'z':
+   */
+  'z' := constsize('f'(), :, size('z', 2), 3); /* OK. */
+  /* Trying to just use size(z) doesn't work because size('z') has non-constant
+   * variability due to the flexible size of the first dimension:
+   */
+  'z' := constsize('f'(), size('z')); /* Error. */
+  /* Possible interpretations of specifying a ':' size where the expression
+   * type has constant size (here given by the cardinality of 'MyEnumType'):
+   * - If the resulting size is still the original constant size, this
+   *   is a convenient way to avoid need to figure out cardinality.
+   * - If the resulting size is flexible, it will be a type error to assign
+   *   to 'z' where the size needs to be constant.
+   */
+  'z' := constsize('f'(), :, :, 3); /* Convenient or error depending on design. */
+end 'h';
 ```
 
 As long as there are no known use cases for turning a constant size into flexible using a `constsize` expression, choosing the design where a `:` doesn't turn a constant size into flexible seems attractive.  However, more experience is needed in order to determine the need for turning constant sizes into flexible.  It should be noted that turning constant into flexible is rather easy even without `constsize` inside a function; all one has to do is assign to a helper variable where the dimension in question has flexible size.
@@ -73,13 +70,13 @@ As long as there are no known use cases for turning a constant size into flexibl
 Finally, note that a very cumbersome workaround that doesn't require generalization of `constsize` is to introduce a new function to do the job:
 ```
 function _constsize_Real_flexible_2
-  input Real[:, :] x;
-  output Real[size(x, 1), 2] y;
+  input Real[:, :] 'x';
+  output Real[size(x, 1), 2] 'y';
 algorithm
-  assert(size(x, 2) == 2, "Expected second array dimension to have size 2.");
-  for i in 1 : size(y, 1) loop
-    for j in 1 : size(y, 2) loop
-      y[i, j] := x[i, j];
+  assert(size('x', 2) == 2, "Expected second array dimension to have size 2.");
+  for 'i' in 1 : size('y', 1) loop
+    for 'j' in 1 : size('y', 2) loop
+      y['i', 'j'] := x['i', 'j'];
     end for;
   end for;
 end _constsize_Real_flexible_2;
@@ -100,11 +97,12 @@ Pros and cons leading to the current decision of going with the function call sy
 
 Example (compare [example using current design](differences.md#the-constsize-expression)):
 ```
-model M
-  function f
-    output Real[Boolean, :] y;
-    ...
-  end f;
-  Real[Boolean, 3] b = constsize[Boolean, 3](f()); /*  */
-end M;
+function 'f'
+  output Real[Boolean, :] 'y';
+  ...
+end 'f';
+
+model 'M'
+  Real[Boolean, 3] b = constsize[Boolean, 3]('f'()); /*  */
+end 'M';
 ```

--- a/RationaleMCP/0031/differences.md
+++ b/RationaleMCP/0031/differences.md
@@ -538,22 +538,22 @@ When determining the type of a function call, the sizes of output array variable
 
 Example:
 ```
-model M
-  function f
-    input Integer n;
-    input Real[:] x;
-    output Real[n + size(x, 1)] y;
-  protected
-    Real[:] a;
-  algorithm
-    a := {0.5}; /* OK: Constant size can be assigned to flexible size. */
-    ...
-  end f;
-  parameter Integer p = 2;
-  constant Integer c = 3;
-  Real[2] a = fill(1.0, p); /* Error: expression has flexible size. */
-  Real[5] b = f(c, a); /* OK. */
-end M;
+function 'f'
+  input Integer 'n';
+  input Real[:] 'x';
+  output Real['n' + size('x', 1)] 'y';
+  Real[:] 'a';
+algorithm
+  'a' := {0.5}; /* OK: Constant size can be assigned to flexible size. */
+  ...
+end 'f';
+
+model 'M'
+  parameter Integer 'p' = 2;
+  constant Integer 'c' = 3;
+  Real[2] 'a' = fill(1.0, 'p'); /* Error: expression has flexible size. */
+  Real[5] 'b' = f('c', 'a'); /* OK. */
+end 'M';
 ```
 
 #### Change and reason for the change


### PR DESCRIPTION
Addresses the issue with `protected` being present in the listings, pointed out by @casella in https://github.com/modelica/ModelicaSpecification/pull/3162#issuecomment-1908727141.

Should we also fix it in a maintenance-version of the conference paper?
