### PR TITLE
Use lowercase 'a' and 'b' for connector instances in examples

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -796,30 +796,30 @@ The edges of the virtual connection graph are implicitly defined by \lstinline!c
 Additionally, corresponding nodes of the virtual connection graph have to be defined as roots or as potential roots with functions \lstinline!Connections.root! and \lstinline!Connections.potentialRoot!, respectively.
 
 The overconstrained equation operators for connection graphs are listed below.
-Here, \lstinline!A! and \lstinline!B! are connector instances that may be hierarchically structured, e.g., \lstinline!A! may be an abbreviation for \lstinline!EnginePort.Frame!.
+Here, \lstinline!a! and \lstinline!b! are connector instances that may be hierarchically structured, e.g., \lstinline!a! may be an abbreviation for \lstinline!enginePort.frame_a!.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
 \tablehead{Expression} & \tablehead{Description} & \tablehead{Details}\\
 \hline
 \hline
-{\lstinline!connect(A, B)!} & Optional spanning-tree edge & \Cref{modelica:optional-spanning-tree-edge}\\
-{\lstinline!Connections.branch(A.R, B.R)!} & Required spanning-tree edge & \Cref{modelica:Connections.branch}\\
-{\lstinline!Connections.root(A.R)!} & Definite root node & \Cref{modelica:Connections.root}\\
-{\lstinline!Connections.potentialRoot(A.R, $\ldots$)!} & Potential root node & \Cref{modelica:Connections.potentialRoot}\\
-{\lstinline!Connections.isRoot(A.R)!} & Predicate for being selected as root & \Cref{modelica:Connections.isRoot}\\
-{\lstinline!Connections.rooted(A.R)!} & Predicate for being closer to root & \Cref{modelica:Connections.rooted}\\
+{\lstinline!connect(a, b)!} & Optional spanning-tree edge & \Cref{modelica:optional-spanning-tree-edge}\\
+{\lstinline!Connections.branch(a.R, b.R)!} & Required spanning-tree edge & \Cref{modelica:Connections.branch}\\
+{\lstinline!Connections.root(a.R)!} & Definite root node & \Cref{modelica:Connections.root}\\
+{\lstinline!Connections.potentialRoot(a.R, $\ldots$)!} & Potential root node & \Cref{modelica:Connections.potentialRoot}\\
+{\lstinline!Connections.isRoot(a.R)!} & Predicate for being selected as root & \Cref{modelica:Connections.isRoot}\\
+{\lstinline!Connections.rooted(a.R)!} & Predicate for being closer to root & \Cref{modelica:Connections.rooted}\\
 \hline
 \end{tabular}
 \end{center}
 
 \begin{operatordefinition*}[connect]\label{modelica:optional-spanning-tree-edge}\index{connect@\robustinline{connect}!overconstrained equation operator}
 \begin{synopsis}\begin{lstlisting}
-connect(A, B)
+connect(a, b)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Except for redundant connections it defines an \firstuse{optional spanning-tree edge} from the overdetermined type or record instances in connector \lstinline!A! to the corresponding overdetermined type or record instances in connector \lstinline!B! for a virtual connection graph.
-E.g., from \lstinline!A.R! to \lstinline!B.R!.
+Except for redundant connections it defines an \firstuse{optional spanning-tree edge} from the overdetermined type or record instances in connector \lstinline!a! to the corresponding overdetermined type or record instances in connector \lstinline!b! for a virtual connection graph.
+E.g., from \lstinline!a.R! to \lstinline!b.R!.
 The full explanation will be given in \cref{generation-of-connection-graph-equations}.
 The types of the corresponding overdetermined type or record instances shall be the same.
 \end{semantics}
@@ -827,10 +827,10 @@ The types of the corresponding overdetermined type or record instances shall be 
 
 \begin{operatordefinition}[Connections.branch]
 \begin{synopsis}\begin{lstlisting}
-Connections.branch(A.R, B.R)
+Connections.branch(a.R, b.R)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Defines a \firstuse{required spanning-tree edge} from the overdetermined type or record instance \lstinline!R! in connector instance \lstinline!A! to the corresponding overdetermined type or record instance \lstinline!R! in connector instance \lstinline!B! for a virtual connection graph.
+Defines a \firstuse{required spanning-tree edge} from the overdetermined type or record instance \lstinline!R! in connector instance \lstinline!a! to the corresponding overdetermined type or record instance \lstinline!R! in connector instance \lstinline!b! for a virtual connection graph.
 This function can be used at all places where a \lstinline!connect!-equation is allowed.
 
 \begin{nonnormative}
@@ -838,58 +838,58 @@ This function can be used at all places where a \lstinline!connect!-equation is 
 % - https://github.com/brucemiller/LaTeXML/issues/1477
 % Once we cut the MathJax dependency, change to single mathescape for better character spacing.
 E.g., it is not allowed to use this function in a \lstinline!when!-clause.
-This definition shall be used if in a model with connectors \lstinline!A! and \lstinline!B! the overdetermined records \lstinline!A.R! and \lstinline!B.R! are algebraically coupled in the model, e.g., due to \lstinline!B.R = f(A.R, $\langle$$\mbox{\emph{other unknowns}}$$\rangle$)!.
+This definition shall be used if in a model with connectors \lstinline!a! and \lstinline!b! the overdetermined records \lstinline!a.R! and \lstinline!b.R! are algebraically coupled in the model, e.g., due to \lstinline!b.R = f(a.R, $\langle$$\mbox{\emph{other unknowns}}$$\rangle$)!.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
 
 \begin{operatordefinition}[Connections.root]
 \begin{synopsis}\begin{lstlisting}
-Connections.root(A.R)
+Connections.root(a.R)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The overdetermined type or record instance \lstinline!R! in connector instance \lstinline!A! is a \firstuse[definite root node]{(definite) root node}\index{root node!definite} in a virtual connection graph.
+The overdetermined type or record instance \lstinline!R! in connector instance \lstinline!a! is a \firstuse[definite root node]{(definite) root node}\index{root node!definite} in a virtual connection graph.
 
 \begin{nonnormative}
-This definition shall be used if in a model with connector \lstinline!A! the overdetermined record \lstinline!A.R! is (consistently) assigned, e.g., from a parameter expressions.
+This definition shall be used if in a model with connector \lstinline!a! the overdetermined record \lstinline!a.R! is (consistently) assigned, e.g., from a parameter expressions.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
 
 \begin{operatordefinition}[Connections.potentialRoot]
 \begin{synopsis}\begin{lstlisting}
-Connections.potentialRoot(A.R)
-Connections.potentialRoot(A.R, priority=$p$)
+Connections.potentialRoot(a.R)
+Connections.potentialRoot(a.R, priority=$p$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The overdetermined type or record instance \lstinline!R! in connector instance \lstinline!A! is a \firstuse{potential root node}\index{root node!potential} in a virtual connection graph with priority \lstinline!p! ($p \geq 0$).
+The overdetermined type or record instance \lstinline!R! in connector instance \lstinline!a! is a \firstuse{potential root node}\index{root node!potential} in a virtual connection graph with priority \lstinline!p! ($p \geq 0$).
 If no second argument is provided, the priority is zero.
 \lstinline!p! shall be a parameter expression of type \lstinline!Integer!.
 In a virtual connection subgraph without a \lstinline!Connections.root! definition, one of the potential roots with the lowest priority number is selected as root.
 
 \begin{nonnormative}
-This definition may be used if in a model with connector \lstinline!A! the overdetermined record \lstinline!A.R! appears differentiated -- \lstinline!der(A.R)! -- together with the \emph{constraint equations} of \lstinline!A.R!, i.e., a non-redundant subset of \lstinline!A.R! maybe used as states.
+This definition may be used if in a model with connector \lstinline!a! the overdetermined record \lstinline!a.R! appears differentiated -- \lstinline!der(a.R)! -- together with the \emph{constraint equations} of \lstinline!a.R!, i.e., a non-redundant subset of \lstinline!a.R! maybe used as states.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
 
 \begin{operatordefinition}[Connections.isRoot]
 \begin{synopsis}\begin{lstlisting}
-Connections.isRoot(A.R)
+Connections.isRoot(a.R)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Returns true, if the overdetermined type or record instance \lstinline!R! in connector instance \lstinline!A! is selected as a root in the virtual connection graph.
+Returns true, if the overdetermined type or record instance \lstinline!R! in connector instance \lstinline!a! is selected as a root in the virtual connection graph.
 \end{semantics}
 \end{operatordefinition}
 
 \begin{operatordefinition}[Connections.rooted]
 \begin{synopsis}\begin{lstlisting}
-Connections.rooted(A.R)
-rooted(A.R) // deprecated!
+Connections.rooted(a.R)
+rooted(a.R) // deprecated!
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-If the operator \lstinline!Connections.rooted(A.R)! is used, or the equivalent but deprecated operator \lstinline!rooted(A.R)!, then there must be exactly one \lstinline!Connections.branch(A.R, B.R)! involving \lstinline!A.R! (the argument of \lstinline!Connections.rooted! must be the first argument of \lstinline!Connections.branch!).
-In that case \lstinline!Connections.rooted(A.R)! returns true, if \lstinline!A.R! is closer to the root of the spanning tree than \lstinline!B.R!; otherwise false is returned.
+If the operator \lstinline!Connections.rooted(a.R)! is used, or the equivalent but deprecated operator \lstinline!rooted(a.R)!, then there must be exactly one \lstinline!Connections.branch(a.R, b.R)! involving \lstinline!a.R! (the argument of \lstinline!Connections.rooted! must be the first argument of \lstinline!Connections.branch!).
+In that case \lstinline!Connections.rooted(a.R)! returns true, if \lstinline!a.R! is closer to the root of the spanning tree than \lstinline!b.R!; otherwise false is returned.
 
 \begin{nonnormative}
 This operator can be used to avoid equation systems by providing analytic inverses, see\linebreak[4] \lstinline!Modelica.Mechanics.MultiBody.Parts.FixedRotation!.
@@ -957,10 +957,10 @@ After this analysis, the \firstuse{connection graph equations}\index{connection 
 \begin{enumerate}
 \item
   For every remaining optional spanning-tree edge in any of the spanning trees, the connection equations are generated according to \cref{generation-of-connection-equations}.
-  For \lstinline!connect(A, B)! with overdetermined connector \lstinline!R!, this corresponds to the optional spanning-tree edge between \lstinline!A.R! and \lstinline!B.R! generating the equation \lstinline!A.R = B.R!.
+  For \lstinline!connect(a, b)! with overdetermined connector \lstinline!R!, this corresponds to the optional spanning-tree edge between \lstinline!a.R! and \lstinline!b.R! generating the equation \lstinline!a.R = b.R!.
 \item
   For every remaining optional spanning-tree edge not in any of the spanning trees, the connection equations are generated according to \cref{generation-of-connection-equations}, except for overdetermined type or record instances \lstinline!R!.
-  Here the equations \lstinline!0 = R.equalityConstraint(A.R, B.R)! are generated instead of \lstinline!A.R = B.R!.
+  Here the equations \lstinline!0 = R.equalityConstraint(a.R, b.R)! are generated instead of \lstinline!a.R = b.R!.
 \end{enumerate}
 
 \subsection{Examples}\label{examples-of-overconstrained-connectors}
@@ -1076,7 +1076,7 @@ connector Frame "3-dimensional mechanical connector"
   flow SI.Torque t[3] "Cut-torque resolved in Frame";
 end Frame;
 \end{lstlisting}
-A fixed translation from a frame \lstinline!A! to a frame \lstinline!B! may be defined as:
+A fixed translation from a frame \lstinline!a! to a frame \lstinline!b! may be defined as:
 \begin{lstlisting}[language=modelica]
 model FixedTranslation
   parameter Modelica.Units.SI.Position r[3];


### PR DESCRIPTION
This is the planned follow-up to https://github.com/modelica/ModelicaSpecification/pull/3385 mentioned in https://github.com/modelica/ModelicaSpecification/pull/3385#pullrequestreview-1840061395.
