### PR TITLE
Size t

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2373,8 +2373,8 @@ They can all specify either a scalar value or an array of values as indicated be
   In case calls to several external functions are generated in the same translation unit, the \lstinline!Include! annotations of the different functions must not define the same function -- except when relying on the deprecated behavior.
 
   The included code should be valid C89 code.
-  If the code uses arrays the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before this code.
-  The user is responsible for ensuring that the C-code can be compiled separately -- with \lstinline[language=C]!#include <stddef.h>! prepended if using any array.
+  If the \lstinline[language=grammar]!external-function-call! contains any `size`-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
+  The \lstinline!"insertedCode"! (following the inclusion of a header for \lstinline[language=C]!size_t! when this would be a tool responsibility) shall be possible to compile separately.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2374,6 +2374,7 @@ They can all specify either a scalar value or an array of values as indicated be
 
   The included code should be valid C89 code.
   If the code uses arrays the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before this code.
+  The user is responsible for ensuring that the C-code can be compiled separately -- with \lstinline[language=C]!#include <stddef.h>! prepended if using any array.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2374,7 +2374,8 @@ They can all specify either a scalar value or an array of values as indicated be
 
   The included code should be valid C89 code.
   If the \lstinline[language=grammar]!external-function-call! contains any `size`-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
-  The \lstinline!"insertedCode"! (following the inclusion of a header for \lstinline[language=C]!size_t! when this would be a tool responsibility) shall be possible to compile separately.
+This gives a code fragment \lstinline!"insertedCode"! conditionally preceded by a header for \lstinline[language=C]!size_t!.
+It must be possible to compile this code fragment separately.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2015,7 +2015,8 @@ Enumeration type & {\lstinline[language=C]!int!} & {\lstinline[language=C]!int *
 \end{tabular}
 \end{center}
 
-An exception is made when the argument is of the form {\lstinline!size($\ldots$, $\ldots$)!}. In this case the corresponding C type is {\lstinline!size_t!}.
+An exception is made when the argument is of the form {\lstinline!size($\ldots$, $\ldots$)!}.
+In this case the corresponding C type is {\lstinline!size_t!}.
 
 Strings are \textsc{nul}-terminated (i.e., terminated by {\lstinline[language=C]!'\0'!}) and are encoded using UTF-8 (assuming {\lstinline[language=C]!CHAR_BIT==8!} in C) to facilitate calling of C functions.
 The valid return values for an external function returning a {\lstinline!String!} are:

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2374,8 +2374,7 @@ They can all specify either a scalar value or an array of values as indicated be
 
   The included code should be valid C89 code.
   If the \lstinline[language=grammar]!external-function-call! contains any `size`-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
-This gives a code fragment \lstinline!"insertedCode"! conditionally preceded by a header for \lstinline[language=C]!size_t!.
-It must be possible to compile this code fragment separately.
+The \lstinline!"insertedCode"!, conditionally preceded by a header for \lstinline[language=C]!size_t!, must be a valid translation unit.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2373,6 +2373,7 @@ They can all specify either a scalar value or an array of values as indicated be
   In case calls to several external functions are generated in the same translation unit, the \lstinline!Include! annotations of the different functions must not define the same function -- except when relying on the deprecated behavior.
 
   The included code should be valid C89 code.
+  If the code uses arrays the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before this code.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 


### PR DESCRIPTION
Closes #3456 

Note that I realized that there is one minor problem with the discussion in #3456 - compiling _only_ the include-part on its own doesn't make much sense as it is intended to be a header-definition of the external function, as the call of the function is missing!

I believe the current text still works for this case:
- Separately compiling a header should be possible. It doesn't produce anything useful and linking with it will not do provide anything, but it should still work.
- The call of the function (generated by the tool in some way) should be _after_ the include-part and the text only discusses what is _before_ the include. This is similar to the usual advice of having `#include "code.h"` first in `code.cpp` to ensure that the header doesn't depend on any other header-files.