### PR TITLE
Introduce nthRoot

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -476,7 +476,7 @@ Square root of $v$, equivalent to \lstinline!nthRoot(v, 2)!.
 nthRoot($v$, $n$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-$n$th root of $v$, where $v$ shall be a \lstinline!Real! expression, and $n > 0$ shall be an evaluable \lstinline!Integer! expression.
+$n$th root of $v$, where $v$ shall be a \lstinline!Real! expression, and $n > 0$ shall be an \lstinline!Integer! expression.
 The result $y$ is a real root of the equation $y^{n} = v$.
 If $n$ is even, $v$ must be non-negative and $y$ shall be the non-negative root.
 (If $n$ is odd, there is no constraint on $v$ and $y$ will have the same sign as $v$.)

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -467,7 +467,7 @@ Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
 sqrt($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Square root of $v$, equvalent to \lstinline!nthRoot(v, 2)!.
+Square root of $v$, equivalent to \lstinline!nthRoot(v, 2)!.
 \end{semantics}
 \end{functiondefinition}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -417,6 +417,7 @@ The mathematical functions and conversion operators listed below do not generate
 {\lstinline!abs($v$)!} & Absolute value (event-free) & \Cref{modelica:abs} \\
 {\lstinline!sign($v$)!} & Sign of argument (event-free) & \Cref{modelica:sign} \\
 {\lstinline!sqrt($v$)!} & Square root & \Cref{modelica:sqrt} \\
+{\lstinline!nthRoot($v$, $n$)!} & $n$th root & \Cref{modelica:nthRoot} \\
 {\lstinline!Integer($e$)!} & Conversion from enumeration to {\lstinline!Integer!} & \Cref{modelica:integer-of-enumeration} \\
 {\lstinline!EnumTypeName($i$)!} & Conversion from {\lstinline!Integer!} to enumeration & \Cref{modelica:enumeration-of-integer} \\
 {\lstinline!String($\ldots$)!} & Conversion to {\lstinline!String!} & \Cref{modelica:to-String} \\
@@ -466,8 +467,19 @@ Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
 sqrt($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-Square root of $v$ if $v \geq 0$, otherwise an error occurs.
-Argument $v$ needs to be an \lstinline!Integer! or \lstinline!Real! expression.
+Square root of $v$, equvalent to \lstinline!nthRoot(v, 2)!.
+\end{semantics}
+\end{functiondefinition}
+
+\begin{functiondefinition}[nthRoot]
+\begin{synopsis}\begin{lstlisting}
+nthRoot($v$, $n$)
+\end{lstlisting}\end{synopsis}
+\begin{semantics}
+$n$th root of $v$, where $v$ shall be a \lstinline!Real! expression, and $n > 0$ shall be an evaluable \lstinline!Integer! expression.
+The result $y$ is a real root of the equation $y^{n} = v$.
+If $n$ is even, $v$ must be non-negative and $y$ shall be the non-negative root.
+(If $n$ is odd, there is no constraint on $v$ and $y$ will have the same sign as $v$.)
 \end{semantics}
 \end{functiondefinition}
 


### PR DESCRIPTION
Closes #3359.

The proposal avoids negative roots, like `nthRoot(0.0, -3)` to avoid a special case when the first argument is zero.
