### PR TITLE
Remove deprecated assignment modification and declaration assignment

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -190,7 +190,6 @@ Modelica functions have the following enhancements compared to a general Modelic
   A function can be \emph{recursive}.
 \item
   A formal parameter or local variable may be initialized through a \emph{binding} (=) of a default value in its declaration, see \cref{initialization-and-binding-equations-of-components-in-functions}.
-  Using assignment (:=) is deprecated.
   If a non-input component in the function uses a record class that contain one or more binding equations they are viewed as initialization of those component of the record component.
 \item
   A function is dynamically instantiated when it is called rather than being statically instantiated by an instance declaration, which is the case for other kinds of classes.
@@ -668,9 +667,6 @@ Components in a function can be divided into three groups:
 
 When a function is called, components of the function do not have \lstinline!start!-attributes.
 However, a binding equation\index{binding equation!in function} (\lstinline!= expression!) with an expression may be present for a component.
-\begin{nonnormative}
-\firstuse[declaration assignment (deprecated)]{Declaration assignments} of the form \lstinline!:= expression! are deprecated, but otherwise identical to binding equations.
-\end{nonnormative}
 
 A binding equation for a non-input component initializes the component to this \lstinline!expression! at the start of every function invocation (before executing the algorithm section or calling the external function).
 These bindings must be executed in an order where a variable is not used before its binding equations has been executed; it is an error if no such order exists (i.e., the binding must be acyclic).

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -10,8 +10,7 @@ Formal parameters are specified using the \lstinline!input!\indexinline{input} k
 This makes the syntax of function definitions quite close to Modelica class definitions, but using the keyword \lstinline!function! instead of \lstinline!class!.
 
 \begin{nonnormative}
-The structure of a typical function declaration is sketched by
-the following schematic function example:
+The structure of a typical function declaration is sketched by the following schematic function example:
 % TODO: Can't have angle brackets and \emph in the same mathescape due to LaTeXML issue:
 % - https://github.com/brucemiller/LaTeXML/issues/1477
 % Once we cut the MathJax dependency, change to single mathescape for better character spacing.
@@ -34,8 +33,8 @@ end $\mathit{functionname}$;
 \end{lstlisting}
 \end{nonnormative}
 
-Optional explicit default values can be associated with any input or output formal parameter through binding equations.  Comment strings
-and annotations can be given for any formal parameter declaration, as usual in Modelica declarations.
+Optional explicit default values can be associated with any input or output formal parameter through binding equations.
+Comment strings and annotations can be given for any formal parameter declaration, as usual in Modelica declarations.
 
 \begin{nonnormative}
 Explicit default values are shown for the third input parameter and the second output parameter in the example above.
@@ -51,14 +50,9 @@ end $\mathit{functionname}$;
 
 \subsection{Ordering of Formal Parameters}\label{ordering-of-formal-parameters}
 
-The relative ordering between input formal parameter declarations is
-significant since that determines the matching between actual arguments
-and formal parameters at function calls with positional parameter
-passing. Likewise, the relative ordering between the declarations of the
-outputs is significant since that determines the matching with receiving
-variables at function calls of functions with multiple results. However,
-the declarations of the inputs and outputs can be intermixed as long as
-these internal orderings are preserved.
+The relative ordering between input formal parameter declarations is significant since that determines the matching between actual arguments and formal parameters at function calls with positional parameter passing.
+Likewise, the relative ordering between the declarations of the outputs is significant since that determines the matching with receiving variables at function calls of functions with multiple results.
+However, the declarations of the inputs and outputs can be intermixed as long as these internal orderings are preserved.
 
 \begin{nonnormative}
 Mixing declarations in this way is not recommended, however, since it makes the code hard to read.
@@ -109,8 +103,7 @@ end findValue;
 
 \subsection{Inheritance of Functions}\label{inheritance-of-functions}
 
-It is allowed for a function to inherit and/or modify another function
-following the usual rules for inheritance of classes (\cref{inheritance-modification-and-redeclaration}).
+It is allowed for a function to inherit and/or modify another function following the usual rules for inheritance of classes (\cref{inheritance-modification-and-redeclaration}).
 
 \begin{nonnormative}
 For example, it is possible to modify and extend a \lstinline!function! class to add default values for input variables.
@@ -144,26 +137,20 @@ end M;
 The function concept in Modelica is a specialized class (\cref{specialized-classes}).
 
 \begin{nonnormative}
-The syntax and semantics of a function have many similarities to those of the \lstinline!block! specialized class. A function has many of the properties
-of a general class, e.g., being able to inherit other functions, or to redeclare or modify elements of a function declaration.
+The syntax and semantics of a function have many similarities to those of the \lstinline!block! specialized class.
+A function has many of the properties of a general class, e.g., being able to inherit other functions, or to redeclare or modify elements of a function declaration.
 \end{nonnormative}
 
-Modelica functions have the following restrictions compared to a general
-Modelica \lstinline!class!:
+Modelica functions have the following restrictions compared to a general Modelica \lstinline!class!:
 \begin{itemize}
 \item
   Each public component must have the prefix \lstinline!input! or \lstinline!output!.
 \item
-  Input formal parameters are read-only after being bound to the actual
-  arguments or default values, i.e., they shall not be assigned values in
-  the body of the function.
+  Input formal parameters are read-only after being bound to the actual arguments or default values, i.e., they shall not be assigned values in the body of the function.
 \item
-  A function shall \emph{not be used in connections}, shall not have
-  \emph{equations}, shall not have \emph{initial algorithms}.
+  A function shall \emph{not be used in connections}, shall not have \emph{equations}, shall not have \emph{initial algorithms}.
 \item
-  A function can have at most \emph{one algorithm} section or \emph{one
-  external function interface} (not both), which, if present, is the
-  body of the function.
+  A function can have at most \emph{one algorithm} section or \emph{one external function interface} (not both), which, if present, is the body of the function.
 \item
   A function may only contain components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!function!; and it must not contain, e.g., \lstinline!model!, \lstinline!block!, \lstinline!operator! or \lstinline!connector! components.
 \item
@@ -171,15 +158,10 @@ Modelica \lstinline!class!:
 \item
   The elements of a function shall not have prefixes \lstinline!inner!, or \lstinline!outer!.
 \item
-  A function may have zero or one external function interface, which, if
-  present, is the external definition of the function.
+  A function may have zero or one external function interface, which, if present, is the external definition of the function.
 \item
-  For a function to be called in a simulation model, the function shall
-  not be partial, and the output variables must be assigned inside the
-  function either in binding equations or in an algorithm section,
-  or have an external function interface as its body, or be defined as a
-  function partial derivative. The output variables of a function should
-  be computed.
+  For a function to be called in a simulation model, the function shall not be partial, and the output variables must be assigned inside the function either in binding equations or in an algorithm section, or have an external function interface as its body, or be defined as a function partial derivative.
+  The output variables of a function should be computed.
   \begin{nonnormative}
   It is a quality of implementation how much analysis a tool performs in order to determine if the output variables are computed.
   \end{nonnormative}
@@ -189,20 +171,16 @@ Modelica \lstinline!class!:
 \item
   For initialization of local variables of a function see \cref{initialization-and-binding-equations-of-components-in-functions}).
 \item
-  Components of a function will inside the function behave as though
-  they had discrete-time variability.
+  Components of a function will inside the function behave as though they had discrete-time variability.
 \end{itemize}
 
-Modelica functions have the following enhancements compared to a general
-Modelica \lstinline!class!:
+Modelica functions have the following enhancements compared to a general Modelica \lstinline!class!:
 \begin{itemize}
 \item
   Functions can be called, \cref{function-call}.
-
   \begin{itemize}
   \item
-    The calls can use a mix of positional and named arguments, see
-    \cref{positional-or-named-input-arguments-of-functions}.
+    The calls can use a mix of positional and named arguments, see \cref{positional-or-named-input-arguments-of-functions}.
   \item
     Instances of functions have a special meaning, see \cref{functional-input-arguments-to-functions}.
   \item
@@ -211,48 +189,34 @@ Modelica \lstinline!class!:
 \item
   A function can be \emph{recursive}.
 \item
-  A formal parameter or local variable may be initialized through a
-  \emph{binding} (=) of a default value in its declaration,
-  see \cref{initialization-and-binding-equations-of-components-in-functions}.
-  Using assignment (:=) is deprecated. If a non-input component in the
-  function uses a record class that contain one or more binding
-  equations they are viewed as initialization of those component of the
-  record component.
+  A formal parameter or local variable may be initialized through a \emph{binding} (=) of a default value in its declaration, see \cref{initialization-and-binding-equations-of-components-in-functions}.
+  Using assignment (:=) is deprecated.
+  If a non-input component in the function uses a record class that contain one or more binding equations they are viewed as initialization of those component of the record component.
 \item
-  A function is dynamically instantiated when it is called rather than
-  being statically instantiated by an instance declaration, which is the
-  case for other kinds of classes.
+  A function is dynamically instantiated when it is called rather than being statically instantiated by an instance declaration, which is the case for other kinds of classes.
 \item
-  A function may have an external function interface specifier as its
-  body.
+  A function may have an external function interface specifier as its body.
 \item
   A function may have a \lstinline!return!-statement in its algorithm section body.
 \item
   A function allows dimension sizes declared with colon (\lstinline!:!) to be resized for non-input array variables, see \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 \item
-  A function may be defined in a short function definition to be a
-  function partial derivative.
+  A function may be defined in a short function definition to be a function partial derivative.
 \end{itemize}
 
 \section{Pure Modelica Functions}\label{pure-modelica-functions}
 
-Modelica functions are normally \emph{pure} which makes it easy for
-humans to reason about the code since they behave as mathematical
-functions, and possible for compilers to optimize.
+Modelica functions are normally \emph{pure} which makes it easy for humans to reason about the code since they behave as mathematical functions, and possible for compilers to optimize.
 
 \begin{itemize}
 \item
-  \emph{Pure} Modelica functions always give the same output values or
-  errors for the same input values and only the output values influence
-  the simulation result, i.e., is seen as equivalent to a mathematical
-  map from input values to output values. Some input values may map to
-  errors. Pure functions are thus allowed to fail by calling \lstinline!assert!, or
-  \lstinline[language=C]!ModelicaError! in C code, or dividing by zero. Such errors will only be
-  reported when and if the function is called.  \emph{Pure} Modelica
-  functions are not assumed to be thread-safe.
+  \emph{Pure} Modelica functions always give the same output values or errors for the same input values and only the output values influence the simulation result, i.e., is seen as equivalent to a mathematical map from input values to output values.
+  Some input values may map to errors.
+  Pure functions are thus allowed to fail by calling \lstinline!assert!, or \lstinline[language=C]!ModelicaError! in C code, or dividing by zero.
+  Such errors will only be reported when and if the function is called.
+  \emph{Pure} Modelica functions are not assumed to be thread-safe.
 \item
-  A Modelica function which does not have the \emph{pure} function
-  properties is \emph{impure}.
+  A Modelica function which does not have the \emph{pure} function properties is \emph{impure}.
 \end{itemize}
 
 The declaration of functions follow these rules:
@@ -272,38 +236,26 @@ The declaration of functions follow these rules:
   Except for the function \lstinline!Modelica.Utilities.Streams.print!, a diagnostic must be given if called in a simulation model.
 \end{itemize}
 
-Calls of pure functions used inside expression may be skipped if the
-resulting expression will not depend on the possible returned value;
-ignoring the possibility of the function generating an error.
+Calls of pure functions used inside expression may be skipped if the resulting expression will not depend on the possible returned value; ignoring the possibility of the function generating an error.
 
-A call to a function with no declared outputs is assumed to have desired
-side-effects or assertion checks.
+A call to a function with no declared outputs is assumed to have desired side-effects or assertion checks.
 
 \begin{nonnormative}
-A tool shall thus not remove such function calls, with exception of non-triggered assert calls.  A pure function, used in an expression or used with
-a non-empty left hand side, need not be called if the output from the function call do not mathematically influence the simulation result, even if
-errors would be generated if it were called.
+A tool shall thus not remove such function calls, with exception of non-triggered assert calls.
+A pure function, used in an expression or used with a non-empty left hand side, need not be called if the output from the function call do not mathematically influence the simulation result, even if errors would be generated if it were called.
 \end{nonnormative}
 
 \begin{nonnormative}
-Comment 1: This property enables writing declarative
-specifications using Modelica. It also makes it possible for Modelica
-compilers to freely perform algebraic manipulation of expressions
-containing function calls while still preserving their semantics. For
-example, a tool may use common subexpression elimination to call a pure
-function just once, if it is called several times with identical input
-arguments. However, since functions may fail we can, e.g., only move a
-common function call from inside a loop to outside the loop if the loop
-is run at least once.
+Comment 1: This property enables writing declarative specifications using Modelica.
+It also makes it possible for Modelica compilers to freely perform algebraic manipulation of expressions containing function calls while still preserving their semantics.
+For example, a tool may use common subexpression elimination to call a pure function just once, if it is called several times with identical input arguments.
+However, since functions may fail we can, e.g., only move a common function call from inside a loop to outside the loop if the loop is run at least once.
 \end{nonnormative}
 
 \begin{nonnormative}
-Comment 2: The Modelica translator is responsible for
-maintaining this property for pure non-external functions. Regarding
-external functions, the external function implementor is responsible.
-Note that external functions can have side-effects as long as they do
-not influence the internal Modelica simulation state, e.g., caching
-variables for performance or printing trace output to a log file.
+Comment 2: The Modelica translator is responsible for maintaining this property for pure non-external functions.
+Regarding external functions, the external function implementor is responsible.
+Note that external functions can have side-effects as long as they do not influence the internal Modelica simulation state, e.g., caching variables for performance or printing trace output to a log file.
 \end{nonnormative}
 
 With the prefix keyword \lstinline!impure!\indexinline{impure} it is stated that a Modelica function is \emph{impure} and it is only allowed to call such a function from within:
@@ -376,8 +328,8 @@ model M // Assume sin, cos, asin are pure functions with normal derivatives.
   Real a = 0 * asin(w);
 end M;
 \end{lstlisting}
-A tool only needs to generate one call of the pure function \lstinline!cos(w)! in the model \lstinline!M! -- a single call used for both the two elements of the matrix, as well as for the derivative
-of that matrix.  A tool may also skip the possible error for \lstinline!asin(w)! and assume that \lstinline!a! is zero.
+A tool only needs to generate one call of the pure function \lstinline!cos(w)! in the model \lstinline!M! -- a single call used for both the two elements of the matrix, as well as for the derivative of that matrix.
+A tool may also skip the possible error for \lstinline!asin(w)! and assume that \lstinline!a! is zero.
 
 Examples of restrictions on optimizing pure functions:
 \begin{lstlisting}[language=modelica]
@@ -434,25 +386,22 @@ named-argument: IDENT "=" function-argument
 function-argument : function-partial-application | expression
 \end{lstlisting}
 
-The interpretation of a function call is as follows: First, a list of unfilled slots is created for all formal input parameters.  If there are $N$ positional arguments, they are placed in the first
-$N$ slots, where the order of the parameters is given by the order of the component declarations in the function definition.  Next, for each named argument \lstinline!identifier = expression!, the
-\lstinline!identifier! is used to determine the corresponding slot.  The value of the argument is placed in the slot, filling it (it is an error if this slot is already filled).  When all arguments
-have been processed, the slots that are still unfilled are filled with the corresponding default value of the function definition.  The default values may depend on other inputs (these dependencies
-must be acyclical in the function) -- the values for those other inputs will then be substituted into the default values (this process may be repeated if the default value for that input depend on another input).  The default values for inputs shall not depend on non-input variables in the function.  The list of filled slots is used as the argument list for the call (it is an error if any
-unfilled slots still remain).
+The interpretation of a function call is as follows: First, a list of unfilled slots is created for all formal input parameters.
+If there are $N$ positional arguments, they are placed in the first $N$ slots, where the order of the parameters is given by the order of the component declarations in the function definition.
+Next, for each named argument \lstinline!identifier = expression!, the \lstinline!identifier! is used to determine the corresponding slot.
+The value of the argument is placed in the slot, filling it (it is an error if this slot is already filled).
+When all arguments have been processed, the slots that are still unfilled are filled with the corresponding default value of the function definition.
+The default values may depend on other inputs (these dependencies must be acyclical in the function) -- the values for those other inputs will then be substituted into the default values (this process may be repeated if the default value for that input depend on another input).
+The default values for inputs shall not depend on non-input variables in the function.
+The list of filled slots is used as the argument list for the call (it is an error if any unfilled slots still remain).
 
-Special purpose operators with function syntax defined in the
-specification shall not be called with named arguments, unless otherwise
-noted.
+Special purpose operators with function syntax defined in the specification shall not be called with named arguments, unless otherwise noted.
 
-The type of each argument must agree with the type of the corresponding
-parameter, except where the standard type coercion, \cref{standard-type-coercion}, can be used to make
-the types agree. (See also \cref{scalar-functions-applied-to-array-arguments} on applying scalar functions
-to arrays.)
+The type of each argument must agree with the type of the corresponding parameter, except where the standard type coercion, \cref{standard-type-coercion}, can be used to make the types agree.
+(See also \cref{scalar-functions-applied-to-array-arguments} on applying scalar functions to arrays.)
 
 \begin{example}
-Assume a function \lstinline!RealToString! is defined as follows to
-convert a \lstinline!Real! number to a \lstinline!String!:
+Assume a function \lstinline!RealToString! is defined as follows to convert a \lstinline!Real! number to a \lstinline!String!:
 \begin{lstlisting}[language=modelica]
 function RealToString
   input Real number;
@@ -543,25 +492,15 @@ end quadrature2;
 
 \subsubsection{Function Partial Application}\label{function-partial-application}
 
-A function partial application is similar to a function call with
-certain formal parameters bound to expressions, the specific rules are
-specified in this section and are not identical to the ones for function
-call in \cref{positional-or-named-input-arguments-of-functions}. A function partial application returns a partially
-evaluated function that is also a function, with the remaining not bound
-formal parameters still present in the same order as in the original
-function declaration. A function partial application is specified by the
-\lstinline!function! keyword followed by a function call to \lstinline!func_name!
-giving named formal parameter associations for the formal parameters to
-be bound, e.g.:
+A function partial application is similar to a function call with certain formal parameters bound to expressions, the specific rules are specified in this section and are not identical to the ones for function call in \cref{positional-or-named-input-arguments-of-functions}.
+A function partial application returns a partially evaluated function that is also a function, with the remaining not bound formal parameters still present in the same order as in the original function declaration.
+A function partial application is specified by the \lstinline!function! keyword followed by a function call to \lstinline!func_name! giving named formal parameter associations for the formal parameters to be bound, e.g.:
 \begin{lstlisting}[language=modelica]
 function func_name($\ldots$, formal_parameter_name = expr, $\ldots$)
 \end{lstlisting}
 
 \begin{nonnormative}
-Note that the keyword \lstinline!function! in a function partial
-application differentiates the syntax from a normal function call
-where some parameters have been left out, and instead supplied via
-default values.
+Note that the keyword \lstinline!function! in a function partial application differentiates the syntax from a normal function call where some parameters have been left out, and instead supplied via default values.
 \end{nonnormative}
 
 The function created by the function partial application acts as the original function but with the bound formal input parameters(s) removed, i.e., they cannot be supplied arguments at function call.
@@ -656,39 +595,26 @@ end surfaceQuadrature;
 
 \subsection{Output Formal Parameters}\label{output-formal-parameters-of-functions}
 
-A function may have more than one output component, corresponding to
-multiple return values. The only way to use more than the first return
-value of such a function is to make the function call the right hand
-side of an equation or assignment. In this case, the left hand side of
-the equation or assignment shall contain a list of component references
-within parentheses:
+A function may have more than one output component, corresponding to multiple return values.
+The only way to use more than the first return value of such a function is to make the function call the right hand side of an equation or assignment.
+In this case, the left hand side of the equation or assignment shall contain a list of component references within parentheses:
 
 \lstinline!(out1, out2, out3) = f($\ldots$);!
 
-The component references are associated with the output components
-according to their position in the list. Thus output component i is set
-equal to, or assigned to, component reference i in the list, where the
-order of the output components is given by the order of the component
-declarations in the function definition. The type of each component
-reference in the list must agree with the type of the corresponding
-output component.
+The component references are associated with the output components according to their position in the list.
+Thus output component $i$ is set equal to, or assigned to, component reference $i$ in the list, where the order of the output components is given by the order of the component declarations in the function definition.
+The type of each component reference in the list must agree with the type of the corresponding output component.
 
-A function application may be used as expression whose value and type is
-given by the value and type of the first output component, if at least
-one return result is provided.
+A function application may be used as expression whose value and type is given by the value and type of the first output component, if at least one return result is provided.
 
-It is possible to omit left hand side component references and/or
-truncate the left hand side list in order to discard outputs from a
-function call.
+It is possible to omit left hand side component references and/or truncate the left hand side list in order to discard outputs from a function call.
 
 \begin{nonnormative}
-Optimizations to avoid computation of unused output results can
-be automatically deduced by an optimizing compiler.
+Optimizations to avoid computation of unused output results can be automatically deduced by an optimizing compiler.
 \end{nonnormative}
 
 \begin{example}
-Function \lstinline!eigen! to compute eigenvalues and optionally
-eigenvectors may be called in the following ways:
+Function \lstinline!eigen! to compute eigenvalues and optionally eigenvectors may be called in the following ways:
 \begin{lstlisting}[language=modelica]
 ev = eigen(A); // calculate eigenvalues
 x = isStable(eigen(A)); // used in an expression
@@ -715,10 +641,7 @@ end eigen;
 \end{lstlisting}
 \end{example}
 
-The only permissible use of an expression in the form of a list of
-expressions in parentheses, is when it is used as the left hand side of
-an equation or assignment where the right hand side is an application of
-a function.
+The only permissible use of an expression in the form of a list of expressions in parentheses, is when it is used as the left hand side of an equation or assignment where the right hand side is an application of a function.
 
 \begin{example}
 The following are illegal:
@@ -749,12 +672,8 @@ However, a binding equation\index{binding equation!in function} (\lstinline!= ex
 \firstuse[declaration assignment (deprecated)]{Declaration assignments} of the form \lstinline!:= expression! are deprecated, but otherwise identical to binding equations.
 \end{nonnormative}
 
-A binding equation for a non-input component initializes the
-component to this \lstinline!expression! at the start of every function invocation
-(before executing the algorithm section or calling the external
-function). These bindings must be executed in an order where a variable
-is not used before its binding equations has been executed; it is
-an error if no such order exists (i.e., the binding must be acyclic).
+A binding equation for a non-input component initializes the component to this \lstinline!expression! at the start of every function invocation (before executing the algorithm section or calling the external function).
+These bindings must be executed in an order where a variable is not used before its binding equations has been executed; it is an error if no such order exists (i.e., the binding must be acyclic).
 
 % The first sentence below needs clarification: clearly, binding equation can also be used for components outside functions.
 Binding equations can only be used for components of a function.
@@ -832,17 +751,17 @@ For each passed argument, the type of the argument is checked against the type o
 \item\label{argument-type-check-match}
   If the types match, nothing is done.
 \item
-  If the types do not match, and a type conversion can be applied, it is
-  applied. Continue with step~\ref{argument-type-check-match}.
+  If the types do not match, and a type conversion can be applied, it is applied.
+  Continue with step~\ref{argument-type-check-match}.
 \item
-  If the types do not match, and no type conversion is applicable, the passed argument type is checked to see if it is an $n$-dimensional array of the formal parameter type.  If it is not, the function call is invalid.  If it is, we call this a \emph{foreach argument}.
+  If the types do not match, and no type conversion is applicable, the passed argument type is checked to see if it is an $n$-dimensional array of the formal parameter type.
+  If it is not, the function call is invalid.
+  If it is, we call this a \emph{foreach argument}.
 \item
-  For all foreach arguments, the number and sizes of dimensions must
-  match. If they do not match, the function call is invalid.
+  For all foreach arguments, the number and sizes of dimensions must match.
+  If they do not match, the function call is invalid.
 \item
-  If no foreach argument exists, the function is applied in the normal
-  fashion, and the result has the type specified by the function
-  definition.
+  If no foreach argument exists, the function is applied in the normal fashion, and the result has the type specified by the function definition.
 \item
   The result of the function call expression is an $n$-dimensional array \lstinline!e! with the same dimension sizes as the foreach arguments.
   Each element \lstinline!e[$i$, $\ldots$, $j$]! is the result of applying \lstinline!f! to arguments constructed from the original arguments in the following way:
@@ -854,8 +773,7 @@ For each passed argument, the type of the argument is checked against the type o
 \end{itemize}
 \end{enumerate}
 
-If more than one argument is an array, all of them have to be the same
-size, and they are traversed in parallel.
+If more than one argument is an array, all of them have to be the same size, and they are traversed in parallel.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -863,12 +781,9 @@ sin({a, b, c}) = {sin(a), sin(b), sin(c)} // argument is a vector
 sin([a, b, c]) = [sin(a), sin(b), sin(c)] // argument may be a matrix
 atan2({a, b, c}, {d, e, f}) = {atan2(a, d), atan2(b, e), atan2(c, f)}
 \end{lstlisting}
-This works even if the function is declared to take an array as
-one of its arguments. If \lstinline!pval! is defined as a function that takes
-one argument that is a \lstinline!Real! vector and returns a \lstinline!Real!, then it can
-be used with an actual argument which is a two-dimensional array (a
-vector of vectors). The result type in this case will be a vector of
-\lstinline!Real!.
+This works even if the function is declared to take an array as one of its arguments.
+If \lstinline!pval! is defined as a function that takes one argument that is a \lstinline!Real! vector and returns a \lstinline!Real!, then it can be used with an actual argument which is a two-dimensional array (a vector of vectors).
+The result type in this case will be a vector of \lstinline!Real!.
 \begin{lstlisting}[language=modelica]
 pval([1,2;3,4]) = [pval([1,2]); pval([3,4])]
 sin([1,2;3,4]) = [sin({1,2}); sin({3,4})]
@@ -928,9 +843,7 @@ There are basically four groups of built-in functions in Modelica:
 
 \section{Record Constructor Functions}\label{record-constructor-functions}
 
-Whenever a record is defined, a record constructor function with the
-same name and in the same scope as the record class is implicitly
-defined according to the following rules:
+Whenever a record is defined, a record constructor function with the same name and in the same scope as the record class is implicitly defined according to the following rules:
 
 % Warning: 'partial flatteing' doesn't seem to be defined.  See 'partial instantitation'.
 The declaration of the record is partially flattened including inheritance, modifications, redeclarations, and expansion of all names referring to declarations outside of the scope of the record to their fully qualified names.
@@ -939,34 +852,23 @@ The declaration of the record is partially flattened including inheritance, modi
 The partial flattening is performed in order to remove potentially conflicting \lstinline!import!-clauses in the record constructor function due to flattening the inheritance tree.
 \end{nonnormative}
 
-All record elements (i.e., components and local class
-definitions) of the partially flattened record declaration are used
-as declarations in the record constructor function with the following
-exceptions:
+All record elements (i.e., components and local class definitions) of the partially flattened record declaration are used as declarations in the record constructor function with the following exceptions:
 \begin{itemize}
 \item
-  Component declarations which do not allow a modification (such
-  as \lstinline!final parameter Real!) are declared
-  as protected components in the record constructor function.
+  Component declarations which do not allow a modification (such as \lstinline!final parameter Real!) are declared as protected components in the record constructor function.
 \item
-  Prefixes (\lstinline!constant!, \lstinline!parameter!, \lstinline!final!, \lstinline!discrete!, \ldots) of the remaining
-  record components are removed.
+  Prefixes (\lstinline!constant!, \lstinline!parameter!, \lstinline!final!, \lstinline!discrete!, \ldots) of the remaining record components are removed.
 \item
-  The prefix \lstinline!input! is added to the public components of the record
-  constructor function.
+  The prefix \lstinline!input! is added to the public components of the record constructor function.
 \end{itemize}
 
-An instance of the record is declared as output parameter using
-a name not appearing in the record, together with a modification. In
-the modification, all input parameters are used to set the corresponding
-record variables.
+An instance of the record is declared as output parameter using a name not appearing in the record, together with a modification.
+In the modification, all input parameters are used to set the corresponding record variables.
 
-A record constructor can only be called if the referenced record class
-is found in the global scope, and thus cannot be modified.
+A record constructor can only be called if the referenced record class is found in the global scope, and thus cannot be modified.
 
 \begin{nonnormative}
-This allows constructing an instance of a record, with an
-optional modification, at all places where a function call is allowed.
+This allows constructing an instance of a record, with an optional modification, at all places where a function call is allowed.
 
 Examples:
 \begin{lstlisting}[language=modelica]
@@ -985,8 +887,7 @@ equation
   c2 = add(c1, Complex(sin(time), cos(time));
 \end{lstlisting}
 
-In the following example, a convenient data sheet library of
-components is built up:
+In the following example, a convenient data sheet library of components is built up:
 \begin{lstlisting}[language=modelica]
 package Motors
   record MotorData "Data sheet of a motor"
@@ -1025,9 +926,8 @@ model Robot
 end Robot;
 \end{lstlisting}
 
-Example showing most of the situations, which may occur for the
-implicit record constructor function creation. With the following record
-definitions:
+Example showing most of the situations, which may occur for the implicit record constructor function creation.
+With the following record definitions:
 \begin{lstlisting}[language=modelica]
 package Demo
   record Record1
@@ -1052,9 +952,7 @@ package Demo
 end Demo;
 \end{lstlisting}
 
-The following record constructor functions are implicitly defined
-(the name of the output, given in italic below, is not defined; it
-should be chosen to not cause any conflict):
+The following record constructor functions are implicitly defined (the name of the output, given in italic below, is not defined; it should be chosen to not cause any conflict):
 % henrikt-ma: TODO: Fix too long lines.
 \begin{lstlisting}[language=modelica,escapechar=!]
 package Demo
@@ -1095,36 +993,24 @@ parameter Demo.Record2 r3 =
   Demo.Record2(c2 = 2, n2 = 1, r1 = 1, r4 = 4, r6 = 1 : 5, r7 = {1});
 \end{lstlisting}
 
-The above example is only used to show the different variants
-appearing with prefixes, but it is not very meaningful, because it is
-simpler to just use a direct modifier.
+The above example is only used to show the different variants appearing with prefixes, but it is not very meaningful, because it is simpler to just use a direct modifier.
 \end{nonnormative}
 
 \subsection{Casting to Record}\label{casting-to-record}
 
-A constructor of a record \lstinline!R! can be used to cast an instance m of a
-\lstinline!model!, \lstinline!block!, \lstinline!connector! class \lstinline!M! to a value of type \lstinline!R!, provided that for
-each component defined in \lstinline!R! (that do not have a default value) there is
-also a public component defined in \lstinline!M! with identical name and type. A
-nested record component of \lstinline!R! is handled as follows, if the corresponding
-component of \lstinline!M! is a \lstinline!model!/\lstinline!block!/\lstinline!connector! a nested record constructor is
-called -- otherwise the component is used directly; and the resulting
-call/component is used as argument to the record constructor \lstinline!R!. If the
-corresponding component of \lstinline!R! in \lstinline!M! is a conditional component, it is an
-error. The instance \lstinline!m! is given as single (un-named)
-argument to the record constructor of \lstinline!R!. The interpretation is that \lstinline!R(m)!
-is replaced by a record constructor of type \lstinline!R! where all public
-components of \lstinline!M! that are present in \lstinline!R! are assigned to the corresponding
-components of \lstinline!R!. The record cast can be used in vectorized form
-according to \cref{scalar-functions-applied-to-array-arguments}.
+A constructor of a record \lstinline!R! can be used to cast an instance m of a \lstinline!model!, \lstinline!block!, \lstinline!connector! class \lstinline!M! to a value of type \lstinline!R!, provided that for each component defined in \lstinline!R! (that do not have a default value) there is also a public component defined in \lstinline!M! with identical name and type.
+A nested record component of \lstinline!R! is handled as follows, if the corresponding component of \lstinline!M! is a \lstinline!model!/\lstinline!block!/\lstinline!connector! a nested record constructor is called -- otherwise the component is used directly; and the resulting call/component is used as argument to the record constructor \lstinline!R!.
+If the corresponding component of \lstinline!R! in \lstinline!M! is a conditional component, it is an error.
+The instance \lstinline!m! is given as single (un-named) argument to the record constructor of \lstinline!R!.
+The interpretation is that \lstinline!R(m)! is replaced by a record constructor of type \lstinline!R! where all public components of \lstinline!M! that are present in \lstinline!R! are assigned to the corresponding components of \lstinline!R!.
+The record cast can be used in vectorized form according to \cref{scalar-functions-applied-to-array-arguments}.
 
 \begin{nonnormative}
 The problem if \lstinline!R! would be a conditional component is that the corresponding binding would be illegal since it is not a \lstinline!connect!-equation.
 \end{nonnormative}
 
 \begin{nonnormative}
-The record cast operation is uniquely distinguished from a record constructor call, because an argument of the record constructor cannot
-be a \lstinline!model!, \lstinline!block! or \lstinline!connector! instance.
+The record cast operation is uniquely distinguished from a record constructor call, because an argument of the record constructor cannot be a \lstinline!model!, \lstinline!block! or \lstinline!connector! instance.
 \end{nonnormative}
 
 \begin{example}
@@ -1336,19 +1222,14 @@ function foo2 end foo2;
 \end{lstlisting}
 \end{example}
 
-The inputs and outputs of the derivative function of {\lstinline!order!} 1 are constructed as
-follows:
+The inputs and outputs of the derivative function of {\lstinline!order!} 1 are constructed as follows:
 \begin{itemize}
 \item
-  First are all inputs to the original function, and after all them we
-  will in order append one derivative for each input containing reals.
-  These common inputs must have the same name, type, and declaration
-  order for the function and its derivative.
+  First are all inputs to the original function, and after all them we will in order append one derivative for each input containing reals.
+  These common inputs must have the same name, type, and declaration order for the function and its derivative.
 \item
-  The outputs are constructed by starting with an empty list and then in
-  order appending one derivative for each output containing reals. The
-  outputs must have the same type and declaration order for the function
-  and its derivative.
+  The outputs are constructed by starting with an empty list and then in order appending one derivative for each output containing reals.
+  The outputs must have the same type and declaration order for the function and its derivative.
 \end{itemize}
 
 If the Modelica function call is a $n$th derivative ($n \geq 1$), i.e., this function call has been derived from an $(n-1)$th derivative by differentiation inside the tool, an {\lstinline!annotation(derivative(order=$n+1$) = $\ldots$)!}, specifies the $(n+1)$th derivative, and the $(n+1)$th derivative call is constructed as follows:
@@ -1361,11 +1242,8 @@ If the Modelica function call is a $n$th derivative ($n \geq 1$), i.e., this fun
 \end{itemize}
 
 \begin{nonnormative}
-The restriction that only the result of differentiation can use
-higher-order derivatives ensures that the derivatives {\lstinline!x!}, {\lstinline!der_x!},
-\ldots{} are in fact derivatives of each other. Without that restriction
-we would have both {\lstinline!der(x)!} and {\lstinline!x_der!} as inputs (or perform advanced
-tests to verify that they are the same).
+The restriction that only the result of differentiation can use higher-order derivatives ensures that the derivatives {\lstinline!x!}, {\lstinline!der_x!}, \ldots{} are in fact derivatives of each other.
+Without that restriction we would have both {\lstinline!der(x)!} and {\lstinline!x_der!} as inputs (or perform advanced tests to verify that they are the same).
 \end{nonnormative}
 
 \begin{example}
@@ -1424,8 +1302,7 @@ The function must have at least one input containing reals.
 The output list of the derivative function shall not be empty.
 
 \begin{example}
-Here is one example use case with records mixing {\lstinline!Real!} and
-non-{\lstinline!Real!} as inputs and outputs:
+Here is one example use case with records mixing {\lstinline!Real!} and non-{\lstinline!Real!} as inputs and outputs:
 \begin{lstlisting}[language=modelica]
 record ThermodynamicState "Thermodynamic state"
   SpecificEnthalpy h "Specific enthalpy";
@@ -1495,13 +1372,8 @@ If the derivative-function also specifies a derivative the common variables shou
 
 \begin{nonnormative}
 Assume that function {\lstinline!f!} takes a matrix and a scalar.
-Since the matrix argument is usually a parameter expression it is then
-useful to define the function as follows (the additional derivative =
-{\lstinline!fGeneralDer!} is optional and can be used when the derivative of
-the matrix or offset is non-zero). Note that the derivative annotation of {\lstinline!fDer!} must specify
-{\lstinline!zeroDerivative!} for both {\lstinline!y!} and {\lstinline!offset!} as below, but the derivative annotation of {\lstinline!fGeneralDer!} shall not have
-{\lstinline!zeroDerivative!} for either of them (it may specify {\lstinline!zeroDerivative!} for {\lstinline!x_der!},
-{\lstinline!y_der!}, or {\lstinline!offset_der!}).
+Since the matrix argument is usually a parameter expression it is then useful to define the function as follows (the additional derivative = {\lstinline!fGeneralDer!} is optional and can be used when the derivative of the matrix or offset is non-zero).
+Note that the derivative annotation of {\lstinline!fDer!} must specify {\lstinline!zeroDerivative!} for both {\lstinline!y!} and {\lstinline!offset!} as below, but the derivative annotation of {\lstinline!fGeneralDer!} shall not have {\lstinline!zeroDerivative!} for either of them (it may specify {\lstinline!zeroDerivative!} for {\lstinline!x_der!}, {\lstinline!y_der!}, or {\lstinline!offset_der!}).
 
 \begin{lstlisting}[language=modelica]
 function f "Simple table lookup"
@@ -1577,8 +1449,7 @@ The inputs excluded using {\lstinline!zeroDerivative!} or {\lstinline!noDerivati
 
 \begin{nonnormative}
 Assume that function {\lstinline!fg!} is defined as a composition {\lstinline!f(x, g(x))!}.
-When differentiating {\lstinline!f!} it is useful to give the derivative under the
-assumption that the second argument is defined in this way:
+When differentiating {\lstinline!f!} it is useful to give the derivative under the assumption that the second argument is defined in this way:
 \begin{lstlisting}[language=modelica]
 function fg
   input Real x;
@@ -1605,8 +1476,7 @@ algorithm
   $\ldots$
 end h;
 \end{lstlisting}
-This is useful if {\lstinline!g!} represents the major computational
-effort of {\lstinline!fg!}.
+This is useful if {\lstinline!g!} represents the major computational effort of {\lstinline!fg!}.
 
 Therefore {\lstinline!h!} indirectly includes the derivative with respect to {\lstinline!y!} as follows:
 \begin{equation*}
@@ -1906,25 +1776,19 @@ Here, the word \emph{function} is used to refer to an arbitrary external routine
 The Modelica external function call interface provides the following:
 \begin{itemize}
 \item
-  Support for external functions written in C (specifically C89) and
-  FORTRAN~77. Other languages, e.g., C++ and Fortran 90, may be supported
-  in the future, and provided the function is link-compatible with C89
-  or FORTRAN~77 it can be written in any language.
+  Support for external functions written in C (specifically C89) and FORTRAN~77.
+  Other languages, e.g., C++ and Fortran 90, may be supported in the future, and provided the function is link-compatible with C89 or FORTRAN~77 it can be written in any language.
 \item
   Mapping of argument types from Modelica to the target language and
   back.
 \item
-  Natural type conversion rules in the sense that there is a mapping
-  from Modelica to standard libraries of the target language.
+  Natural type conversion rules in the sense that there is a mapping from Modelica to standard libraries of the target language.
 \item
   Handling arbitrary parameter order for the external function.
 \item
-  Passing arrays to and from external functions where the dimension
-  sizes are passed as explicit integer parameters.
+  Passing arrays to and from external functions where the dimension sizes are passed as explicit integer parameters.
 \item
-  Handling of external function parameters which are used both for input
-  and output, by passing an output that has a binding equation to
-  the external function.
+  Handling of external function parameters which are used both for input and output, by passing an output that has a binding equation to the external function.
   \begin{nonnormative}
   Binding equations are executed prior to calling the external function.
   \end{nonnormative}
@@ -1948,8 +1812,7 @@ Just as for any other function, components in the public part of an external fun
 Protected components can be passed to the external function without being initialized by means of a declaration equation, which is useful for passing workspace memory to functions with FORTRAN style memory management, and the reason for passing them in the same (writable) way as output components (see \cref{argument-type-mapping}).
 The value of a protected component passed to the external function should be considered undefined (destroyed) after the external function call.
 
-The {\lstinline[language=grammar]!language-specification!} must currently be one of {\lstinline!"builtin"!} (deprecated), {\lstinline!"C"!}, {\lstinline!"C$\ldots$"!} (for one of the specific C standards like C89, C99, and C11 -- specifying
-that it relies on the C standard library of that version) or {\lstinline!"FORTRAN 77"!}.
+The {\lstinline[language=grammar]!language-specification!} must currently be one of {\lstinline!"builtin"!} (deprecated), {\lstinline!"C"!}, {\lstinline!"C$\ldots$"!} (for one of the specific C standards like C89, C99, and C11 -- specifying that it relies on the C standard library of that version) or {\lstinline!"FORTRAN 77"!}.
 Unless the external language is specified, it is assumed to be {\lstinline!"C"!}.
 
 \begin{nonnormative}
@@ -1960,7 +1823,8 @@ The deprecated {\lstinline!"builtin"!} specification is only used for the elemen
 The external function call mechanism for {\lstinline!"builtin"!} functions is implementation-defined.
 
 \begin{nonnormative}
-Typically, for functions from the standard C library, the prototype of the function is provided but no {\lstinline!Library!} annotation.  Currently, there are no other builtin functions defined in Modelica.
+Typically, for functions from the standard C library, the prototype of the function is provided but no {\lstinline!Library!} annotation.
+Currently, there are no other builtin functions defined in Modelica.
 \end{nonnormative}
 
 \begin{example}
@@ -2032,7 +1896,8 @@ The external code would remain the owner of such a string, and would be responsi
 Consequently, the Modelica simulation environment would not be able to assume that only its own string deallocation routines could invalidate any of the strings returned by external functions.
 \end{nonnormative}
 
-{\lstinline!Boolean!} values are mapped to C such that {\lstinline!false!} in Modelica is 0 in C and {\lstinline!true!} in Modelica is 1 in C.  If the returned value from C is 0 it is treated as {\lstinline!false!} in Modelica; otherwise as {\lstinline!true!}.
+{\lstinline!Boolean!} values are mapped to C such that {\lstinline!false!} in Modelica is 0 in C and {\lstinline!true!} in Modelica is 1 in C.
+If the returned value from C is 0 it is treated as {\lstinline!false!} in Modelica; otherwise as {\lstinline!true!}.
 
 \begin{nonnormative}
 It is recommended that the C function should interpret any non-zero value as true.
@@ -2062,10 +1927,8 @@ Returning strings from FORTRAN~77 subroutines/functions is currently not support
 Enumeration types used as arguments are mapped to type int when calling an external C function, and to type {\lstinline!INTEGER!} when calling an external FORTRAN function.
 The $i$th enumeration literal is mapped to integer value $i$, starting at 1.
 
-Return values are mapped to enumeration types analogously: integer value
-1 is mapped to the first enumeration literal, 2 to the second, etc.
-Returning a value which does not map to an existing enumeration literal
-for the specified enumeration type is an error.
+Return values are mapped to enumeration types analogously: integer value 1 is mapped to the first enumeration literal, 2 to the second, etc.
+Returning a value which does not map to an existing enumeration literal for the specified enumeration type is an error.
 
 \subsubsection{Arrays}\label{arrays-1}
 
@@ -2129,8 +1992,7 @@ The type \lstinline!T! is allowed to be any of the simple types which can be pas
 \end{center}
 
 \begin{example}
-The following two examples illustrate the default mapping of
-array arguments to external C and FORTRAN~77 functions.
+The following two examples illustrate the default mapping of array arguments to external C and FORTRAN~77 functions.
 
 \begin{lstlisting}[language=modelica]
 function foo
@@ -2152,8 +2014,7 @@ function foo
 external "FORTRAN 77";
 end foo;
 \end{lstlisting}
-the default assumptions correspond to a FORTRAN~77 function
-defined as follows:
+the default assumptions correspond to a FORTRAN~77 function defined as follows:
 \begin{lstlisting}[language=FORTRAN77]
 FUNCTION foo(a, d1, d2, d3)
   DOUBLE PRECISION(d1, d2, d3) a
@@ -2166,13 +2027,10 @@ END
 \end{lstlisting}
 \end{example}
 
-When an explicit call to the external function is present, the array and
-the sizes of its dimensions must be passed explicitly.
+When an explicit call to the external function is present, the array and the sizes of its dimensions must be passed explicitly.
 
 \begin{example}
-This example shows how arrays can be passed explicitly to an
-external FORTRAN~77 function when the default assumptions are
-unsuitable.
+This example shows how arrays can be passed explicitly to an external FORTRAN~77 function when the default assumptions are unsuitable.
 
 \begin{lstlisting}[language=modelica]
 function foo
@@ -2216,8 +2074,7 @@ A Modelica record class is mapped as follows:
   Arrays cannot be mapped.
 \end{itemize}
 
-Records are passed by reference (i.e., a pointer to the record is being
-passed).
+Records are passed by reference (i.e., a pointer to the record is being passed).
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -2253,8 +2110,7 @@ Storage for arrays as return values is allocated by the calling routine, so the 
 See \cref{simple-types} regarding returning of {\lstinline!String!} values.
 
 \begin{nonnormative}
-In the case of an external function not returning anything, argument type mapping according to \cref{simple-types} is performed in the absence
-of any explicit external function call.
+In the case of an external function not returning anything, argument type mapping according to \cref{simple-types} is performed in the absence of any explicit external function call.
 \end{nonnormative}
 
 Return types are by default mapped as follows for C and FORTRAN~77:
@@ -2279,10 +2135,8 @@ The element type {\lstinline!T!} of an array can be any simple type as defined i
 
 \subsection{Aliasing}\label{aliasing}
 
-Any potential aliasing in the external function is the responsibility of
-the tool and not the user. An external function is not allowed to
-internally change the inputs (even if they are restored before the end
-of the function).
+Any potential aliasing in the external function is the responsibility of the tool and not the user.
+An external function is not allowed to internally change the inputs (even if they are restored before the end of the function).
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -2319,15 +2173,11 @@ double f(double a) {
 }
 \end{lstlisting}
 
-The reason for not allowing the external function to change the
-inputs is to ensure that inputs can be stored in static memory and to
-avoid superfluous copying (especially of matrices). If the routine does
-not satisfy the requirements the interface must copy the input argument
-to a temporary. This is rare but occurs, e.g., in {\lstinline!dormlq!} in some
-Lapack implementations. In those special cases the writer of the
-external interface have to copy the input to a temporary. If the first
-input was changed internally in myfoo the designer of the interface
-would have to change the interface function {\lstinline!foo!} to:
+The reason for not allowing the external function to change the inputs is to ensure that inputs can be stored in static memory and to avoid superfluous copying (especially of matrices).
+If the routine does not satisfy the requirements the interface must copy the input argument to a temporary.
+This is rare but occurs, e.g., in {\lstinline!dormlq!} in some Lapack implementations.
+In those special cases the writer of the external interface have to copy the input to a temporary.
+If the first input was changed internally in myfoo the designer of the interface would have to change the interface function {\lstinline!foo!} to:
 \begin{lstlisting}[language=modelica]
 function foo
   input Real x;
@@ -2339,12 +2189,8 @@ external "FORTRAN 77"
 end foo;
 \end{lstlisting}
 
-Note that we discuss input arguments for Fortran-routines even
-though FORTRAN~77 does not formally have input arguments and forbid
-aliasing between any pair of arguments to a function (Section 15.9.3.6
-of X3J3/90.4). For the few (if any) FORTRAN~77 compilers that strictly
-follow the standard and are unable to handle aliasing between input
-variables the tool must transform the first call of {\lstinline!foo!} into:
+Note that we discuss input arguments for Fortran-routines even though FORTRAN~77 does not formally have input arguments and forbid aliasing between any pair of arguments to a function (Section 15.9.3.6 of X3J3/90.4).
+For the few (if any) FORTRAN~77 compilers that strictly follow the standard and are unable to handle aliasing between input variables the tool must transform the first call of {\lstinline!foo!} into:
 \begin{lstlisting}[language=C]
 temp1 = a; /* Temporary to avoid aliasing */
 myfoo_(&a, &temp1, &b);
@@ -2374,7 +2220,7 @@ They can all specify either a scalar value or an array of values as indicated be
 
   The included code should be valid C89 code.
   If the \lstinline[language=grammar]!external-function-call! contains any `size`-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
-The \lstinline!"insertedCode"!, conditionally preceded by a header for \lstinline[language=C]!size_t!, must be a valid translation unit.
+  The \lstinline!"insertedCode"!, conditionally preceded by a header for \lstinline[language=C]!size_t!, must be a valid translation unit.
 
   When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.
 
@@ -2428,16 +2274,12 @@ The \lstinline!"insertedCode"!, conditionally preceded by a header for \lstinlin
   It is not specified how they are built.
 \end{itemize}
 
-The \filename{win32} or \filename{win64} directories may contain \filename{gcc47}, \filename{vs2010}, \filename{vs2012}
-for specific versions of these compilers and these are used instead of
-the general \filename{win32} or \filename{win64} directories, and similarly for other
-platforms.
+The \filename{win32} or \filename{win64} directories may contain \filename{gcc47}, \filename{vs2010}, \filename{vs2012} for specific versions of these compilers and these are used instead of the general \filename{win32} or \filename{win64} directories, and similarly for other platforms.
 
-The library on Windows may refer to a lib-file (static library), both a lib- and dll-file (in this case the lib-file is an import-library),
-or just a dll-file. It shall not refer to an obj-file.
+The library on Windows may refer to a lib-file (static library), both a lib- and dll-file (in this case the lib-file is an import-library), or just a dll-file.
+It shall not refer to an obj-file.
 
-If the directory for the specific compiler version is missing the
-platform specific directory is used.
+If the directory for the specific compiler version is missing the platform specific directory is used.
 
 \begin{nonnormative}
 A tool may give a diagnostic if the directory corresponding to the selected compiler version is missing.
@@ -2533,21 +2375,14 @@ Directory structure:
 \else
 \par
 \fi
-Note that calling the function {\lstinline!MyExternalFunctions.ExternalFunc1!} will use
-the header and library files from {\lstinline!ExternalFunction!}, the {\lstinline!ExternalFunctions.Example!} will not use \filename{ExternalFunc3.c},
-and one library file may contain multiple functions.
+Note that calling the function {\lstinline!MyExternalFunctions.ExternalFunc1!} will use the header and library files from {\lstinline!ExternalFunction!}, the {\lstinline!ExternalFunctions.Example!} will not use \filename{ExternalFunc3.c}, and one library file may contain multiple functions.
 
 The C-source \filename{ExternalFunc3.c} will be included fully, and is not part of any library.
 That is not ideal for C-code, but it works for small functions.
 
 It is not specified how the C-sources in the specified {\lstinline!SourceDirectory!} will be used to build the libraries.
 
-Header file for the function in the dynamic link / shared library
-\filename{ExternalLib2} so that the desired functions are defined to be exported
-for Microsoft VisualStudio and for GNU C compiler (note, for Linux it is
-recommended to use the compiler option {\lstinline!-fPIC!} to build shared
-libraries or object libraries that are later transformed to a shared
-library):
+Header file for the function in the dynamic link / shared library \filename{ExternalLib2} so that the desired functions are defined to be exported for Microsoft VisualStudio and for GNU C compiler (note, for Linux it is recommended to use the compiler option {\lstinline!-fPIC!} to build shared libraries or object libraries that are later transformed to a shared library):
 \begin{lstlisting}[language=C]
 /* File ExternalFunc2.h */
 #ifndef EXTERNAL_FUNC2_H_
@@ -2585,9 +2420,9 @@ The {\lstinline!Library!} name and the {\lstinline!LibraryDirectory!} name in th
 \subsubsection{Input Parameters, Function Value}\label{input-parameters-function-value}
 
 \begin{example}
-Here all parameters to the external function are input
-parameters. One function value is returned. If the external language is
-not specified, the default is {\lstinline!"C"!}, as below.
+Here all parameters to the external function are input parameters.
+One function value is returned.
+If the external language is not specified, the default is {\lstinline!"C"!}, as below.
 \begin{lstlisting}[language=modelica]
 function foo
   input Real x;
@@ -2614,9 +2449,7 @@ z = foo(2.4, 3);
 \subsubsection{Arbitrary Placement of Output Parameters, No External Function Value}\label{arbitrary-placement-of-output-parameters-no-external-function-value}
 
 \begin{example}
-In the following example, the external function call is given
-explicitly which allows passing the arguments in a different order than
-in the Modelica version.
+In the following example, the external function call is given explicitly which allows passing the arguments in a different order than in the Modelica version.
 \begin{lstlisting}[language=modelica]
 function foo
   input Real x;
@@ -2644,9 +2477,8 @@ myfoo(2.4, &z1, 3, &i2);
 \subsubsection{Both Function Value and Output Variable}\label{external-function-with-both-function-value-and-output-variable}\label{both-function-value-and-output-variable}
 
 \begin{example}
-The following external function returns two results: one
-function value and one output parameter value. Both are mapped to
-Modelica output parameters.
+The following external function returns two results: one function value and one output parameter value.
+Both are mapped to Modelica output parameters.
 \begin{lstlisting}[language=modelica]
 function foo
   input Real x;
@@ -2701,13 +2533,9 @@ The functions listed below produce a message in different ways.
 
 The \emph{Message}-functions only produce the message, but the \emph{Warning}- and \emph{Error}-functions combine this with error handling as follows.
 
-The \emph{Warning}-functions view the message as a warning and can skip
-duplicated messages similarly as an {\lstinline!assert!} with
-{\lstinline!level = AssertionLevel.Warning!} in the Modelica code.
+The \emph{Warning}-functions view the message as a warning and can skip duplicated messages similarly as an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Warning!} in the Modelica code.
 
-The \emph{Error}-functions never return to the calling function, but handle the
-error similarly to an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Error!} in the
-Modelica code.
+The \emph{Error}-functions never return to the calling function, but handle the error similarly to an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Error!} in the Modelica code.
 
 \begin{functiondefinition*}[ModelicaMessage, ModelicaWarning, ModelicaError]\label{modelica:ModelicaMessage-et-al}%
 \indexinline{ModelicaMessage}\indexinline{ModelicaWarning}\indexinline{ModelicaError}
@@ -2858,22 +2686,17 @@ Within Modelica this memory is defined as instance of the predefined class {\lst
 \item
   Classes derived from {\lstinline!ExternalObject!} can neither be used in an {\lstinline!extends!}-clause nor in a short class definition.
 \item
-  Only the constructor may return external objects and an external object
-  can only be bound in component declarations and neither modified later
-  nor assigned to.
+  Only the constructor may return external objects and an external object can only be bound in component declarations and neither modified later nor assigned to.
   \begin{nonnormative}
   It follows that a function cannot return a component containing an external object, since only the constructor may return an external object and the constructor exactly returns the external object.
   \end{nonnormative}
 \item
-  External functions may be defined which operate on the internal memory
-  of an {\lstinline!ExternalObject!}. An {\lstinline!ExternalObject!} used as input argument or
-  return value of an external C function is mapped to the C type
-  {\lstinline!void*!}.
+  External functions may be defined which operate on the internal memory of an {\lstinline!ExternalObject!}.
+  An {\lstinline!ExternalObject!} used as input argument or return value of an external C function is mapped to the C type {\lstinline!void*!}.
 \end{itemize}
 
 \begin{example}
-A user-defined table may be defined in the following way as an {\lstinline!ExternalObject!}
-(the table is read in a user-defined format from file and has memory for the last used table interval):
+A user-defined table may be defined in the following way as an {\lstinline!ExternalObject!} (the table is read in a user-defined format from file and has memory for the last used table interval):
 \begin{lstlisting}[language=modelica]
 class MyTable
   extends ExternalObject;

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -213,7 +213,6 @@ declaration :
 modification :
    class-modification [ "=" modification-expression ]
    | "=" modification-expression
-   | ":=" modification-expression
 
 modification-expression :
    expression


### PR DESCRIPTION
Fixes #3493. Based on my interpretation of the issue conversation, this PR removes the deprecated syntax.

Note that the first commit is only about changing to sentence-based line breaks.  The actual semantic changes in the second commit are very small.
