### PR TITLE
Remove deprecated

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -962,7 +962,11 @@ The \lstinline!string! may use the special symbols \lstinline!"%first"! and \lst
 
 The \lstinline!extent! and \lstinline!rotation! are relative to the \lstinline!origin! (default \lstinline!{0, 0}!) and the \lstinline!origin! is relative to the point on the \lstinline!Line!.
 
-The \lstinline!textColor! attribute defines the color of the text.  The text is drawn with transparent background and no border around the text (and without outline).  The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.  The default value for \lstinline!horizontalAlignment! is deprecated.  Having a zero size for the \lstinline!extent! is deprecated and is handled as if upper part is moved up an appropriate amount.
+The \lstinline!textColor! attribute defines the color of the text.
+The text is drawn with transparent background and no border around the text (and without outline).
+The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.
+The default value for \lstinline!horizontalAlignment! is deprecated.
+Having a zero size for the \lstinline!extent! is deprecated and is handled as if upper part is moved up an appropriate amount.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -964,7 +964,6 @@ The \lstinline!extent! and \lstinline!rotation! are relative to the \lstinline!o
 
 The \lstinline!textColor! attribute defines the color of the text.
 The text is drawn with transparent background and no border around the text (and without outline).
-The contents inherited from \lstinline!FilledShape! is deprecated, but kept for compatibility reasons.
 The default value for \lstinline!horizontalAlignment! is deprecated.
 Having a zero size for the \lstinline!extent! is deprecated and is handled as if upper part is moved up an appropriate amount.
 


### PR DESCRIPTION
Closes #3512 
In #3316 we removed `extends FilledShape;` but kept text about the inherited contents; that doesn't make sense.