### PR TITLE
General record member referencing

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1357,6 +1357,9 @@ The following holds for slice operations:
   and does not require that \lstinline!size(a[1].m) = size(a[2].m)!.  The number of subscripts on \lstinline!m! must not be greater than the number of array dimension
   for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if
   \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
+\item
+  If \lstinline!...! gives an array of records (e.g. \lstinline!foo(time)!) then \lstinline!(...).m! is interpreted as selecting the \lstinline!m! component in that array of records.
+  If \lstinline!m! is also an array component, the slice operation is valid only if the resulting array is homogenous.
 \end{itemize}
 
 \begin{example}
@@ -1378,6 +1381,19 @@ equation
 \end{lstlisting}
 In this example the different \lstinline!x1! vectors have different lengths,
 but it is still possible to perform some operations on them.
+\end{example}
+
+\begin{example}
+General selection
+\begin{lstlisting}[language=modelica]
+  // Normal slice operation with extra array variable
+  Complex c[2]={Complex(1, 2), Complex(2, 3)}*Complex(1, 1);
+  Real x1[2]=c.im; 
+
+  // Same result without extra variable
+  // Using generalized member access operator
+  Real x2[2]=({Complex(1, 2), Complex(2, 3)}*Complex(1, 1)).im;
+\end{lstlisting}
 \end{example}
 
 \subsection{Relational Operators}\label{relational-operators}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1388,7 +1388,7 @@ General selection
 \begin{lstlisting}[language=modelica]
   // Normal slice operation with extra array variable
   Complex c[2]={Complex(1, 2), Complex(2, 3)}*Complex(1, 1);
-  Real x1[2]=c.im; 
+  Real x1[2]=c.im;
 
   // Same result without extra variable
   // Using generalized member access operator

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1359,7 +1359,7 @@ The following holds for slice operations:
   \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
 \item
   When the member access operator is applied to a record array, it is interpreted as constructing an array by selecting the member in each record.
-  If \lstinline!m! in \lstinline!($\ldots).m!  is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.
+  If \lstinline!m! in \lstinline!($\ldots).m! is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.
 \end{itemize}
 
 \begin{example}
@@ -1384,15 +1384,14 @@ but it is still possible to perform some operations on them.
 \end{example}
 
 \begin{example}
-General selection
+Member access slicing:
 \begin{lstlisting}[language=modelica]
-  // Normal slice operation with extra array variable
-  Complex c[2]={Complex(1, 2), Complex(2, 3)}*Complex(1, 1);
+  // Slice operation as part of component reference:
+  Complex c[2] = {Complex(1, 2), Complex(2, 3)} * Complex(1, 1);
   Real x1[2]=c.im;
 
-  // Same result without extra variable
-  // Using generalized member access operator
-  Real x2[2]=({Complex(1, 2), Complex(2, 3)}*Complex(1, 1)).im;
+  // Same result, but slicing a general expression:
+  Real x2[2] = ({Complex(1, 2), Complex(2, 3)} * Complex(1, 1)).im;
 \end{lstlisting}
 \end{example}
 

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1359,7 +1359,7 @@ The following holds for slice operations:
   \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
 \item
   When the member access operator is applied to a record array, it is interpreted as constructing an array by selecting the member in each record.
-  If \lstinline!m! in \lstinline!($\ldots).m! is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.
+  If \lstinline!m! in \lstinline!($\ldots$).m! is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.
 \end{itemize}
 
 \begin{example}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -948,7 +948,7 @@ The number of dimensions of the expression is reduced by the number of scalar in
 If the number of index arguments is smaller than the number of dimensions of the array, the trailing indices will use `\lstinline!:!'.
 
 It is possible to index a general expression by enclosing it in parenthesis.
-Note that while the subscripts are applied to a \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
+Note that while the subscripts are applied to an \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
 
 It is also possible to use the array access operator to assign to element/elements of an array in algorithm sections.
 This is called an \firstuse[assignment statement!indexed]{indexed assignment statement}.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1348,15 +1348,14 @@ longer an elementary operation.
 The following holds for slice operations:
 \begin{itemize}
 \item
-  If the component reference \lstinline!a! is an array containing scalar components and \lstinline!m! is a component of those components, the component reference \lstinline!a.m! is interpreted as a
-  slice operation.  It returns the array of components \lstinline!{a[1].m, $\ldots$}!.
+  If the component reference \lstinline!a! is an array containing scalar components and \lstinline!m! is a component of those components, the component reference \lstinline!a.m! is interpreted as a slice operation.
+  It returns the array of components \lstinline!{a[1].m, $\ldots$}!.
 \item
   If \lstinline!m! is also an array component, the slice operation is valid only if \lstinline!size(a[1].m)! = \lstinline!size(a[2].m)! = \ldots
 \item
-  The slicing operation can for component references be combined with indexing, e.g., \lstinline!a.m[1]!.  It returns the array of components \lstinline!{a[1].m[1], a[2].m[1], $\ldots$}!,
-  and does not require that \lstinline!size(a[1].m) = size(a[2].m)!.  The number of subscripts on \lstinline!m! must not be greater than the number of array dimension
-  for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if
-  \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
+  The slicing operation can for component references be combined with indexing, e.g., \lstinline!a.m[1]!.
+  It returns the array of components \lstinline!{a[1].m[1], a[2].m[1], $\ldots$}!, and does not require that \lstinline!size(a[1].m) = size(a[2].m)!.
+  The number of subscripts on \lstinline!m! must not be greater than the number of array dimension for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
 \item
   When the member access operator is applied to a record array, it is interpreted as constructing an array by selecting the member in each record.
   If \lstinline!m! in \lstinline!($\ldots$).m! is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1348,12 +1348,12 @@ longer an elementary operation.
 The following holds for slice operations:
 \begin{itemize}
 \item
-  If \lstinline!a! is an array containing scalar components and \lstinline!m! is a component of those components, the expression \lstinline!a.m! is interpreted as a
+  If the component reference \lstinline!a! is an array containing scalar components and \lstinline!m! is a component of those components, the component reference \lstinline!a.m! is interpreted as a
   slice operation.  It returns the array of components \lstinline!{a[1].m, $\ldots$}!.
 \item
   If \lstinline!m! is also an array component, the slice operation is valid only if \lstinline!size(a[1].m)! = \lstinline!size(a[2].m)! = \ldots
 \item
-  The slicing operation can be combined with indexing, e.g., \lstinline!a.m[1]!.  It returns the array of components \lstinline!{a[1].m[1], a[2].m[1], $\ldots$}!,
+  The slicing operation can for component references be combined with indexing, e.g., \lstinline!a.m[1]!.  It returns the array of components \lstinline!{a[1].m[1], a[2].m[1], $\ldots$}!,
   and does not require that \lstinline!size(a[1].m) = size(a[2].m)!.  The number of subscripts on \lstinline!m! must not be greater than the number of array dimension
   for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if
   \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1358,8 +1358,8 @@ The following holds for slice operations:
   for \lstinline!m! (the number can be smaller, in which case the missing trailing indices are assumed to be `\lstinline!:!'), and is only valid if
   \lstinline!size(a[1].m[$\ldots$]) = size(a[2].m[$\ldots$])!.
 \item
-  If \lstinline!...! gives an array of records (e.g. \lstinline!foo(time)!) then \lstinline!(...).m! is interpreted as selecting the \lstinline!m! component in that array of records.
-  If \lstinline!m! is also an array component, the slice operation is valid only if the resulting array is homogenous.
+  When the member access operator is applied to a record array, it is interpreted as constructing an array by selecting the member in each record.
+  If \lstinline!m! in \lstinline!($\ldots).m!  is also an array component of the record, the slice operation is valid only if the resulting array is homogenous.
 \end{itemize}
 
 \begin{example}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -105,7 +105,8 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 
 The postfix array index and postfix access operators are not merely expression operators in the normal sense that \lstinline!a.b[1]! can be treated as \lstinline!a.(b[1])!.
 Instead, these operators need to be considered jointly to identify an entire \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) which is the smallest unit that can be seen as an expression in itself.
-Postfix access can only be applied immediately to a \lstinline[language=grammar]!component-reference!; not even parentheses around the left operand are allowed.
+Postfix access can only immediately be applied to a \lstinline[language=grammar]!component-reference!.
+Postfix access can additionally be applied if there are parentheses around the left operand, see \cref{member-access-operator}.
 Postfix array index can additionally be applied if there are parentheses around the left operand, see \cref{indexing}.
 
 \begin{example}
@@ -127,7 +128,8 @@ a.x         // OK: Component reference of type Real[3, 2]
 (a.x)[2]    // OK: Component reference of type Real[2] - same as a[2].x[:]
 (a.x)[2, :] // OK: Component reference of type Real[2] - same as a[2].x[:]
 a[3]        // OK: Component reference of type R
-(a[3]).x    // Error: Invalid use of parentheses
+(a[3]).x    // OK: A Real[2] but not a component reference
+(a[3]).x[1] // Error.
 \end{lstlisting}
 The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than postfix access.
 Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! expresses, being a component reference of type \lstinline!Real[2]!.
@@ -355,11 +357,20 @@ Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 \subsection{Member Access Operator}\label{member-access-operator}
 
 It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
+It is also possible to select a record member of a general expression by enclosing it in parenthesis.
+Note that while the selection is applied to a output-expression-list in the grammar, it is only semantically valid when the output-expression-list represents an expression.
+
+In case the first operand is an array it is seen as a slicing operation, see \cref{slice-operation}.
 
 \begin{example}
 \lstinline!R1.R! for accessing the resistance component \lstinline!R! of resistor \lstinline!R1!.
 Another use of dot notation: local classes which are members of a class can of course also be accessed using dot notation on the name of the class, not on instances of the class.
+
+\lstinline!(Complex(2, 3)).re! constructs the record \lstinline!Complex(2, 3)! and then selects the \lstinline!re! component in it.
+Using \lstinline!Complex(2, 3).re! is not syntactically legal.
 \end{example}
+
+ 
 
 \subsection{Built-in Variable time}\label{built-in-variable-time}\indexinline{time}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -370,8 +370,6 @@ Another use of dot notation: local classes which are members of a class can of c
 Using \lstinline!Complex(2, 3).re! is not syntactically legal.
 \end{example}
 
- 
-
 \subsection{Built-in Variable time}\label{built-in-variable-time}\indexinline{time}
 
 All declared variables are functions of the independent variable \lstinline!time!.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -103,9 +103,8 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 \end{center}
 \end{table}
 
-The postfix array index and postfix access operators are not merely expression operators in the normal sense that \lstinline!a.b[1]! can be treated as \lstinline!a.(b[1])!.
-Instead, these operators need to be considered jointly to identify an entire \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) which is the smallest unit that can be seen as an expression in itself.
-Postfix access can only immediately be applied to a \lstinline[language=grammar]!component-reference!.
+The postfix array index and postfix access operators can both be part of a \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) and be applied to general expressions when the left operand is parenthesized.
+Directly using both postfix access operator and postfix array index in a \lstinline[language=grammar]!component-reference! has a special intuitive meaning.
 See \cref{indexing} and \cref{member-access-operator}.
 
 \begin{example}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -106,8 +106,7 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 The postfix array index and postfix access operators are not merely expression operators in the normal sense that \lstinline!a.b[1]! can be treated as \lstinline!a.(b[1])!.
 Instead, these operators need to be considered jointly to identify an entire \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) which is the smallest unit that can be seen as an expression in itself.
 Postfix access can only immediately be applied to a \lstinline[language=grammar]!component-reference!.
-Postfix access can additionally be applied if there are parentheses around the left operand, see \cref{member-access-operator}.
-Postfix array index can additionally be applied if there are parentheses around the left operand, see \cref{indexing}.
+See \cref{indexing} and \cref{member-access-operator}.
 
 \begin{example}
 Relative precedence of postfix array index and postfix access.
@@ -128,8 +127,9 @@ a.x         // OK: Component reference of type Real[3, 2]
 (a.x)[2]    // OK: Component reference of type Real[2] - same as a[2].x[:]
 (a.x)[2, :] // OK: Component reference of type Real[2] - same as a[2].x[:]
 a[3]        // OK: Component reference of type R
-(a[3]).x    // OK: A Real[2] but not a component reference
+(a[3]).x    // OK: Like a[3].x, but not a component reference
 (a[3]).x[1] // Error.
+((a[3]).x)[1] // OK: Like a[3].x[1], but not a component reference
 \end{lstlisting}
 The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than postfix access.
 Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! expresses, being a component reference of type \lstinline!Real[2]!.
@@ -358,7 +358,7 @@ Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 
 It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
 It is also possible to select a record member of a general expression by enclosing it in parenthesis.
-Note that while the selection is applied to a output-expression-list in the grammar, it is only semantically valid when the output-expression-list represents an expression.
+Note that while the selection is applied to an \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
 
 In case the first operand is an array it is seen as a slicing operation, see \cref{slice-operation}.
 
@@ -367,7 +367,7 @@ In case the first operand is an array it is seen as a slicing operation, see \cr
 Another use of dot notation: local classes which are members of a class can of course also be accessed using dot notation on the name of the class, not on instances of the class.
 
 \lstinline!(Complex(2, 3)).re! constructs the record \lstinline!Complex(2, 3)! and then selects the \lstinline!re! component in it.
-Using \lstinline!Complex(2, 3).re! is not syntactically legal.
+\lstinline!Complex(2, 3).re! is not valid syntax.
 \end{example}
 
 \subsection{Built-in Variable time}\label{built-in-variable-time}\indexinline{time}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -356,14 +356,16 @@ Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 \subsection{Member Access Operator}\label{member-access-operator}
 
 It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
-It is also possible to select a record member of a general expression by enclosing it in parenthesis.
+It is also possible to select a record member of a general expression by enclosing it in parentheses.
 Note that while the selection is applied to an \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
 
 In case the first operand is an array it is seen as a slicing operation, see \cref{slice-operation}.
 
 \begin{example}
-\lstinline!R1.R! for accessing the resistance component \lstinline!R! of resistor \lstinline!R1!.
-Another use of dot notation: local classes which are members of a class can of course also be accessed using dot notation on the name of the class, not on instances of the class.
+The component reference \lstinline!R1.R! accesses the resistance component \lstinline!R! of resistor \lstinline!R1!.
+
+The qualified class name \lstinline!A.B! is a reference to the local class \lstinline!B! which is a member of the class \lstinline!A!.
+Note that the left operand in this case is a class, not an instance of the class.
 
 \lstinline!(Complex(2, 3)).re! constructs the record \lstinline!Complex(2, 3)! and then selects the \lstinline!re! component in it.
 \lstinline!Complex(2, 3).re! is not valid syntax.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -398,7 +398,7 @@ primary :
    | true
    | ( component-reference | der | initial | pure ) function-call-args
    | component-reference
-   | "(" output-expression-list ")" [ (array-subscripts | "." IDENT) ]
+   | "(" output-expression-list ")" [ ( array-subscripts | "." IDENT ) ]
    | "[" expression-list { ";" expression-list } "]"
    | "{" array-arguments "}"
    | end

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -398,7 +398,7 @@ primary :
    | true
    | ( component-reference | der | initial | pure ) function-call-args
    | component-reference
-   | "(" output-expression-list ")" [ array-subscripts ]
+   | "(" output-expression-list ")" [ (array-subscripts | "." IDENT) ]
    | "[" expression-list { ";" expression-list } "]"
    | "{" array-arguments "}"
    | end

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -389,7 +389,7 @@ mul-operator :
    "*" | "/" | ".*" | "./"
 
 factor :
-   primary [ ("^" | ".^") primary ]
+   primary [ ( "^" | ".^" ) primary ]
 
 primary :
    UNSIGNED-NUMBER


### PR DESCRIPTION
Closes #3510 
Note:
- I was at first considering saying "like vectorized call of function", as well as the operation to slice-operation, but I'm not sure that it is helpful.
- I hope I have caught all cases where the restriction was listed.
- I deliberately did not add `(...).x[1]`. I'm not sure it is needed
- Unfortunately the operation already had multiple names: "postfix access", "member access operator", and "slice". I just kept that.