### PR TITLE
Add proposed texts.

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -777,7 +777,7 @@ In case of iterative solver failure, it is recommended to specially report those
 \end{nonnormative}
 
 If a parameter has a value for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the value for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.
-In this case a diagnostic message is recommended in a simulation model, unless the parameter has a \lstinline!Dialog(enable)! annotation set to false.
+In this case a diagnostic message is recommended in a simulation model, unless the parameter has a \lstinline!Dialog.enable! annotation set to false.
 
 \begin{nonnormative}
 This is used in libraries to give rudimentary defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that should be set properly.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -777,10 +777,11 @@ In case of iterative solver failure, it is recommended to specially report those
 \end{nonnormative}
 
 If a parameter has a value for the \lstinline!start!-attribute, does not have \lstinline!fixed = false!, and neither has a binding equation nor is part of a record having a binding equation, the value for the \lstinline!start!-attribute can be used to add a parameter binding equation assigning the parameter to that \lstinline!start! value.
-In this case a diagnostic message is recommended in a simulation model.
+In this case a diagnostic message is recommended in a simulation model, unless the parameter has a \lstinline!Dialog(enable)! annotation set to false.
 
 \begin{nonnormative}
 This is used in libraries to give rudimentary defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that should be set properly.
+The \lstinline!enable=false! case can be used to provide default values for parameters that are not used in the current configuration, while ensuring that they are explicitly given a value when used.
 \end{nonnormative}
 
 All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e., there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.


### PR DESCRIPTION
The explanation for enable=false was simplified to just say "parameters not used". The reason is that there can be multiple reasons for not using a parameter in a configuration:
- Propagated to disabled component
- Different initialization, xi_start in Modelica.Blocks.Continuous.LimPID
- Other configurations, dp_small in Modelica.Fluid.Fittings.BaseClasses.QuadraticTurbulent.BaseModel

(The models don't use this at the moment, and I don't think that these specific models should do it, but perhaps similar ones.)

Closes #3504