### PR TITLE
Don't speak of postfix operators

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -45,7 +45,7 @@ The following table presents the precedence and associativity of all the express
 \caption{%
 Operators in order of precedence from highest to lowest.
 Operators with different precedence are separated by horizontal lines.
-All operators are binary except the postfix operators and those shown as unary together with \emph{expr}, the conditional operator, the array construction operator
+All operators are binary except array index, member access, function call, those shown as unary together with \emph{expr}, the conditional operator, the array construction operator
 % Beware that the array construction operator, normally expressed as \lstinline!{ }! needs escaped braces inside \caption.
 % This isn't handled correctly by LaTeXML, as reported here:
 % - https://github.com/brucemiller/LaTeXML/issues/1377 (fixed on master 2022-12-10)
@@ -63,11 +63,11 @@ $^{\dagger}$ The associativity of array construction and concatenation refers to
 \tablehead{Operator group} & \tablehead{Assoc.} & \tablehead{Operator syntax} & \tablehead{Examples}\\
 \hline
 \hline
-Postfix array index & left & {\lstinline![]!} & {\lstinline!arr[index]!}\\
+Array index & left & {\lstinline![]!} & {\lstinline!arr[index]!}\\
 \hline
-Postfix access & left & {\lstinline!.!} & {\lstinline!a.b!}\\
+Member access & left & {\lstinline!.!} & {\lstinline!a.b!}\\
 \hline
-Postfix function call & none & {\lstinline!$\mathit{funcName}$($\mathit{args}$)!} & {\lstinline!sin(4.36)!}\\
+Function call & none & {\lstinline!$\mathit{funcName}$($\mathit{args}$)!} & {\lstinline!sin(4.36)!}\\
 \hline
 Array construction & left$^{\dagger}$ & {\lstinline!{$\mathit{expr}$, $\mathit{expr}$, $\ldots$}!} & {\lstinline!{2, 3}!}\\
 Horizontal concatenation & left$^{\dagger}$ & {\lstinline![$\mathit{expr}$, $\mathit{expr}$, $\ldots$]!} & {\lstinline![5, 6]!}\\
@@ -103,12 +103,12 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 \end{center}
 \end{table}
 
-The postfix array index and postfix access operators can both be part of a \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) and be applied to general expressions when the left operand is parenthesized.
-Directly using both postfix access operator and postfix array index in a \lstinline[language=grammar]!component-reference! has a special intuitive meaning.
+The array index and member access operators can both be part of a \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) and be applied to general expressions when the left operand is parenthesized.
+Directly using both member access and array index in a \lstinline[language=grammar]!component-reference! has a special intuitive meaning.
 See \cref{indexing} and \cref{member-access-operator}.
 
 \begin{example}
-Relative precedence of postfix array index and postfix access.
+Relative precedence of array index and member access.
 Consider the following definition of the array variable \lstinline!a!:
 \begin{lstlisting}[language=modelica]
 record R
@@ -116,7 +116,7 @@ record R
 end R;
 R[3] a;
 \end{lstlisting}
-These are some valid as well as invalid ways to using postfix array index and postfix access:
+These are some valid as well as invalid ways to using array index and member access:
 \begin{lstlisting}[language=modelica]
 a[3].x[2]   // OK: Component reference of type Real
 a[3].x      // OK: Component reference of type Real[2]
@@ -130,7 +130,7 @@ a[3]        // OK: Component reference of type R
 (a[3]).x[1] // Error.
 ((a[3]).x)[1] // OK: Like a[3].x[1], but not a component reference
 \end{lstlisting}
-The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than postfix access.
+The relation between \lstinline!a.x!, \lstinline!a.x[2]!, and \lstinline!(a.x)[2]! illustrates the effect of giving higher precedence to array index than member access.
 Had the precedence been equal, this would have changed the meaning of \lstinline!a.x[2]! to the same thing that \lstinline!(a.x)[2]! expresses, being a component reference of type \lstinline!Real[2]!.
 \end{example}
 


### PR DESCRIPTION
Fixes #3541.

This fix is more general than just renaming _postfix access operator_ → _member access operator_.

The reason is that just as _postfix_ doesn't seem very appropriate for the operator `.` in the expression `a.b`, it doesn't make sense for the Modelica array indexing or function call either.  By addressing the general misuse of _postfix_ for these operators, we get a fix for #3541 for free.
