### PR TITLE
Don't use inline code for the Boolean values

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -527,7 +527,7 @@ By setting \lstinline!HideResult = false!, the modeler would like to have the va
 "TestCase" "(" "shouldPass" "=" ( false | true ) ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-If \lstinline!shouldPass! is \lstinline!false! it indicates that the translation or the simulation of the model should fail.
+If \lstinline!shouldPass! is false it indicates that the translation or the simulation of the model should fail.
 If a tools checks a package where classes have \lstinline!shouldPass = false! they should not generate errors, and checking may even be skipped.
 On the other hand, models with \lstinline!shouldPass = false! may be useful for creation of negative tests in tool-specific ways.
 Similarly as a class with \lstinline!obsolete! annotation, a class with \lstinline!TestCase! annotation (regardless of the value of \lstinline!shouldPass!) shall not be used in other models, unless those models also have a \lstinline!TestCase! annotation.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -527,7 +527,7 @@ By setting \lstinline!HideResult = false!, the modeler would like to have the va
 "TestCase" "(" "shouldPass" "=" ( false | true ) ")"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-If \lstinline!shouldPass! is false it indicates that the translation or the simulation of the model should fail.
+If \lstinline!shouldPass! is \lstinline!false! it indicates that the translation or the simulation of the model should fail.
 If a tools checks a package where classes have \lstinline!shouldPass = false! they should not generate errors, and checking may even be skipped.
 On the other hand, models with \lstinline!shouldPass = false! may be useful for creation of negative tests in tool-specific ways.
 Similarly as a class with \lstinline!obsolete! annotation, a class with \lstinline!TestCase! annotation (regardless of the value of \lstinline!shouldPass!) shall not be used in other models, unless those models also have a \lstinline!TestCase! annotation.

--- a/chapters/overloaded.tex
+++ b/chapters/overloaded.tex
@@ -60,7 +60,7 @@ algorithm
 end f;
 \end{lstlisting}
 
-The vector $P$ indicates whether argument $m$ of \lstinline!f! has a default value (\lstinline!true! for default value, \lstinline!false! otherwise).
+The vector $P$ indicates whether argument $m$ of \lstinline!f! has a default value (true for default value, false otherwise).
 A call \lstinline!f($a_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldots$, $b_{p}$ = $w_{p}$)! with distinct names $b_{j}$ is a valid match for the function \lstinline!f!, provided (treating \lstinline!Integer! and \lstinline!Real! as the same type)
 \begin{itemize}
 \item
@@ -68,7 +68,7 @@ A call \lstinline!f($a_1$, $a_{2}$, $\ldots$, $a_{k}$, $b_{1}$ = $w_{1}$, $\ldot
 \item
   the names $b_{j}$ = $u_{Q_{j}}$, $Q_{j} > k$, $A_{Q_{j}}$ = typeOf($w_{j}$) for $1 \leq j \leq p$, and
 \item
-  if the union of $\{i: 1 \leq i \leq k \}$, $\{Q_{j}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ is \lstinline!true! and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
+  if the union of $\{i: 1 \leq i \leq k \}$, $\{Q_{j}: 1 \leq j \leq p\}$, and $\{m: P_{m} \text{ and } 1 \leq m \leq n \}$ is the set $\{i: 1 \leq i \leq n\}$.
 \end{itemize}
 
 \begin{nonnormative}


### PR DESCRIPTION
To is how we do it in the vast majority of cases, and is consistent with not using code style for numeric values.

Inspired by what appears to be a styling mistake made in #3561.  I checked for occurrences of the following to conclude that the style we use is plain English:
- `is true`
- `is \lstinline!true!`
- `is false`
- `is \lstinline!false!`

It should be noted that there is still a number of cases of just `\lstinline!false!` and `\lstinline!true!` that would be good candidates to also turn into plain English.  However, there are also cases where I think it is clear that code style _should_ be used, so it isn't as simple as turning them all into plain English.  Here's an example of the latter:
```
The value of \lstinline!connectorSizing! must be a literal \lstinline!false! or \lstinline!true!.
```

Perhaps we should try to write down a some guideline in the style guide?
