### PR TITLE
Sensible quoting.

### DIFF
--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -145,7 +145,7 @@ fails without searching for \lstinline!A! in any of the remaining roots in \lsti
 If during lookup a top-level name is not found in the unnamed top-level scope, the search continues in the package hierarchies stored in these directories.
 
 \begin{example}
-\Cref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}, with three directories containing the roots of the package hierarchies \lstinline!Modelica!, \lstinline!MyLib!, and \lstinline!ComplexNumbers!.
+\Cref{fig:roots} below shows an example \lstinline!MODELICAPATH! = \filename{C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2}, with three directories containing the roots of the package hierarchies \lstinline!Modelica!, \lstinline!MyLib!, and \lstinline!ComplexNumbers!.
 The first two are represented as the subdirectories \filename{C:\textbackslash{}library\textbackslash{}Modelica} and \filename{C:\textbackslash{}lib1\textbackslash{}MyLib}, whereas the third is stored as the file \filename{C:\textbackslash{}lib2\textbackslash{}ComplexNumbers.mo}.
 
 \begin{figure}[H]
@@ -153,7 +153,7 @@ The first two are represented as the subdirectories \filename{C:\textbackslash{}
     \includegraphics{modelicapath}
   \end{center}
   \caption{Roots of package hierarchies, e.g., \lstinline!Modelica!, \lstinline!MyLib!, and \lstinline!ComplexNumbers! in
-  \lstinline!MODELICAPATH! = \filename{"C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2"}.}
+  \lstinline!MODELICAPATH! = \filename{C:\textbackslash{}library;C:\textbackslash{}lib1;C:\textbackslash{}lib2}.}
   \label{fig:roots}
 \end{figure}
 
@@ -171,6 +171,8 @@ In this example the name matches the subdirectory named \filename{MyLib} in the 
 This subdirectory must have a file \filename{package.mo} containing a definition of the package \lstinline!MyLib!, according to the Modelica rules on how to map a package hierarchy to the file system.
 The subpackage \lstinline!Pack2! is stored in its own subdirectory or file in the subdirectory \filename{MyLib}.
 In this case the search succeeds and the package \lstinline!MyLib.Pack2! is loaded into the environment.
+
+Note that if you use the environment variable \lstinline!MODELICAPATH! in Modelica the value is a string which implies that it is quoted, i.e., \lstinline!"C:\\library;C:\\lib1;C:\\lib2"!.
 \end{example}
 
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -171,8 +171,6 @@ In this example the name matches the subdirectory named \filename{MyLib} in the 
 This subdirectory must have a file \filename{package.mo} containing a definition of the package \lstinline!MyLib!, according to the Modelica rules on how to map a package hierarchy to the file system.
 The subpackage \lstinline!Pack2! is stored in its own subdirectory or file in the subdirectory \filename{MyLib}.
 In this case the search succeeds and the package \lstinline!MyLib.Pack2! is loaded into the environment.
-
-Note that if you use the environment variable \lstinline!MODELICAPATH! in Modelica the value is a string which implies that it is quoted, i.e., \lstinline!"C:\\library;C:\\lib1;C:\\lib2"!.
 \end{example}
 
 


### PR DESCRIPTION
The previous variant didn't make sense.

The change is that when we discuss environment variables in general it doesn't make sense to include quotes (especially when we use a different font), you just set the environment variable to the specified value in some GUI/shell. However, if you want to show the value in Modelica (or C) quotes are needed, but the backslashes also needs to be doubled.

A completely different idea would be to allow quotes around specific elements of the MODELICAPATH as in `"C:\library";"C:\lib1";C:\lib2`. I have some vague idea that it was used at some point in time on Windows, but likely with space ` ` not `;` as separator. I thus don't see that we need to mention that.