### PR TITLE
Simplify text for constraining modifiers

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -926,7 +926,7 @@ If the \lstinline[language=grammar]!constraining-clause! is not present in the o
 \item
   The type of the declaration is also used as a constraining type.
 \item
-  The modifiers for subsequent redeclarations and constraining type are the modifiers on the component or \lstinline[language=grammar]!short-class-definition! if that is used in the original declaration, otherwise empty.
+  The modifiers for subsequent redeclarations and constraining type are the modifiers on the original component or \lstinline[language=grammar]!short-class-definition!.
 \end{itemize}
 
 The syntax of a \lstinline[language=grammar]!constraining-clause!\indexinline{constrainedby} is as follows:

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -926,7 +926,7 @@ If the \lstinline[language=grammar]!constraining-clause! is not present in the o
 \item
   The type of the declaration is also used as a constraining type.
 \item
-  The modifiers for subsequent redeclarations and constraining type are the modifiers on the original component or \lstinline[language=grammar]!short-class-definition!.
+  If modifiers are present in the original declaration, they also become modifiers on the constraining type.
 \end{itemize}
 
 The syntax of a \lstinline[language=grammar]!constraining-clause!\indexinline{constrainedby} is as follows:


### PR DESCRIPTION
Don't make a special case for ignoring empty modifiers that don't matter.

Closes #3576