### PR TITLE
Require that ranges and conditions around 'connect' are evaluable

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -153,7 +153,7 @@ A \lstinline!connect!-equation has the following syntax:
 connect "(" component-reference "," component-reference ")" ";"
 \end{lstlisting}
 
-These can be placed inside \lstinline!for!-equations and \lstinline!if!-equations; provided the indices of the \lstinline!for!-loop and conditions of the \lstinline!if!-equation are parameter expressions that do not depend on \lstinline!cardinality!, \lstinline!rooted!, \lstinline!Connections.rooted!, or \lstinline!Connections.isRoot!.
+These can be placed inside \lstinline!for!-equations and \lstinline!if!-equations; provided the indices of the \lstinline!for!-loop and conditions of the \lstinline!if!-equation are evaluable expressions that do not depend on \lstinline!cardinality!, \lstinline!rooted!, \lstinline!Connections.rooted!, or \lstinline!Connections.isRoot!.
 The \lstinline!for!-equations/\lstinline!if!-equations are expanded.
 \lstinline!connect!-equations are described in detail in \cref{connect-equations-and-connectors}.
 


### PR DESCRIPTION
I don't see how the connect set handling would work unless it is known whether a `connect`-equation is present or not, so I'm hoping that this isn't a controversial restriction of variability.
