### PR TITLE
Clarify that component references work in this form.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1096,10 +1096,10 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
-  When quoted identifiers (e.g., \lstinline!rec.'}'.'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
-  Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and the macro can be directly followed by a letter.
+  When quoted identifiers (e.g., \lstinline!rec.'}'.'quoted ident'!) or composite names (i.e., not simple identifiers) are involved, the form \%\{\emph{par}\} must be used.
+  Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and \lstinline!%{a.p}! gives the value of the parameter \lstinline!p! in the component \lstinline!a!.
+  The macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
-  Additionally, \lstinline!%{a.p}! should give the value of the parameter \lstinline!p! in the component \lstinline!a!.
   If the parameter does not exist it is an error.
 \end{itemize}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1099,6 +1099,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   When quoted identifiers (e.g., \lstinline!rec.'}'.'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
   Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and the macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
+  Additionally, \lstinline!%{a.p}! should give the value of the parameter \lstinline!p! in the component \lstinline!a!.
   If the parameter does not exist it is an error.
 \end{itemize}
 


### PR DESCRIPTION
It is a clarification, since it already states that they are component-references and the quoted part includes it.

See https://github.com/modelica/ModelicaStandardLibrary/issues/4494