### PR TITLE
Simplify quoted identifier in text annotations

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1096,7 +1096,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
-  When quoted identifiers (e.g., \lstinline!'a{b}c'!, or \lstinline'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
+  When quoted identifiers (e.g., \lstinline'quoted ident'! or \lstinline!'}'!) are involved, the form \%\{\emph{par}\} must be used.
   Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and the macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
   If the parameter does not exist it is an error.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1096,7 +1096,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
-  When quoted identifiers (e.g., \lstinline!'a}b'!, or \lstinline'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
+  When quoted identifiers (e.g., \lstinline!'a{b}c'!, or \lstinline'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
   Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and the macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
   If the parameter does not exist it is an error.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1096,7 +1096,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
-  When quoted identifiers (e.g., \lstinline!rec.'}'.'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
+  When quoted identifiers (e.g., \lstinline!'a}b'!, or \lstinline'quoted ident'!) are involved, the form \%\{\emph{par}\} must be used.
   Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and the macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
   If the parameter does not exist it is an error.


### PR DESCRIPTION
I was confused by the previous text and almost thought it was an error.
Currently it says "( e.g., `rec.'}'.'quoted ident'`)" and the proposed change is "( e.g., `'a}x'` or `'quoted ident'`)"

I believe the rewrite is as clear and it preserves the two important parts of the previous change: 
- embedded space (only for quoted identifier)
- embedded `}` (cannot simplify string parsing due to this). 

It does not include a hierarchical name as that it is now explained separately. Should thus be merged after #3592

Not needed, but I think it avoids my confusion and is clearer