### PR TITLE
Be consistent for file extensions.

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1454,7 +1454,7 @@ If \lstinline!colorSelector = true!, it suggests the use of a color selector to 
 
 The presence of \lstinline!loadSelector! or \lstinline!saveSelector! specifying \fmtannotationindex{Selector} suggests the use of a file dialog to select a file.
 Setting \lstinline!filter! will in the dialog only show files that fulfill the given pattern.
-Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extension \filename{ext1} or \filename{ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
+Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extension \filename{.ext1} or \filename{.ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
 \lstinline!caption! is a caption for display in the file dialog.
 \lstinline!loadSelector! is used to select an existing file for reading, whereas \lstinline!saveSelector! is used to define a file for writing.
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1454,7 +1454,7 @@ If \lstinline!colorSelector = true!, it suggests the use of a color selector to 
 
 The presence of \lstinline!loadSelector! or \lstinline!saveSelector! specifying \fmtannotationindex{Selector} suggests the use of a file dialog to select a file.
 Setting \lstinline!filter! will in the dialog only show files that fulfill the given pattern.
-Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extension \filename{.ext1} or \filename{.ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
+Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extensions \filename{.ext1} or \filename{.ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
 \lstinline!caption! is a caption for display in the file dialog.
 \lstinline!loadSelector! is used to select an existing file for reading, whereas \lstinline!saveSelector! is used to define a file for writing.
 


### PR DESCRIPTION
In #3588 I realized that it's a bit unclear if the file extension starts with the dot or after the dot. 
https://en.wikipedia.org/wiki/Filename_extension isn't clear either

 Alternatively we could have the part after the dot, this is just to make it consistent