### PR TITLE
Change to consistently use file extensions without leading dot

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1454,7 +1454,7 @@ If \lstinline!colorSelector = true!, it suggests the use of a color selector to 
 
 The presence of \lstinline!loadSelector! or \lstinline!saveSelector! specifying \fmtannotationindex{Selector} suggests the use of a file dialog to select a file.
 Setting \lstinline!filter! will in the dialog only show files that fulfill the given pattern.
-Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extensions \filename{.ext1} or \filename{.ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
+Setting \lstinline!text1 (*.ext1);;text2 (*.ext2)! will only show files with file extensions \filename{ext1} or \filename{ext2} with the corresponding description texts \lstinline!text1! and \lstinline!text2!, respectively.
 \lstinline!caption! is a caption for display in the file dialog.
 \lstinline!loadSelector! is used to select an existing file for reading, whereas \lstinline!saveSelector! is used to define a file for writing.
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -230,7 +230,7 @@ Classes and constants that are stored in \filename{package.mo} are also present 
 When mapping a package or class-hierarchy to a file (e.g., the file \filename{A.mo}), that file shall only define a single class \lstinline!A! with a name matching the name of the nonstructured entity.
 In a file hierarchy the files shall have the extension \filename{mo}.
 
-A \filename{mo} file defining more than one class cannot be part of the mapping
+A file defining more than one class cannot be part of the mapping
 to file-structure and it is an error if it is loaded from the
 \lstinline!MODELICAPATH!.
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -228,9 +228,9 @@ Classes and constants that are stored in \filename{package.mo} are also present 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}
 
 When mapping a package or class-hierarchy to a file (e.g., the file \filename{A.mo}), that file shall only define a single class \lstinline!A! with a name matching the name of the nonstructured entity.
-In a file hierarchy the files shall have the extension \filename{.mo}.
+In a file hierarchy the files shall have the extension \filename{mo}.
 
-A \filename{.mo} file defining more than one class cannot be part of the mapping
+A \filename{mo} file defining more than one class cannot be part of the mapping
 to file-structure and it is an error if it is loaded from the
 \lstinline!MODELICAPATH!.
 


### PR DESCRIPTION
The opposite decision as for #3595 (i.e., never have leading dot in file extensions).
Both variants would be fine for me, as long as we are consistent.
