### PR TITLE
Consistent built-in

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -413,7 +413,7 @@ The following built-in operators/functions are available:
   Array functions, see \cref{built-in-array-functions}.
 \end{itemize}
 
-Note that when the specification references a function having the name of a built-in function or operator it references the built-in function or operator, not a user-defined function having the same name, see also \cref{built-in-functions}.
+Note that when the specification references a function or operator having the name of a built-in function or operator it references the built-in function or operator, not a user-defined function having the same name, see also \cref{built-in-functions}.
 With the exception where inputs are named (e.g., \lstinline!String!), all operators and functions in this section can only be called with positional arguments.
 
 \subsection{Numeric Functions and Conversion Operators}\label{numeric-functions-and-conversion-functions}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -393,29 +393,30 @@ end SineSource;
 \end{lstlisting}
 \end{example}
 
-\section{Built-in Intrinsic Operators with Function Syntax}\label{built-in-intrinsic-operators-with-function-syntax}
+\section{Built-in Operators and Functions}\label{built-in-intrinsic-operators-with-function-syntax}
 
-Certain built-in operators of Modelica have the same syntax as a function call.
+Certain built-in operators of Modelica are called using the same syntax as a function call.
 However, they do not behave as a mathematical function, because the result depends not only on the input arguments but also on the status of the simulation.
 
 There are also built-in functions that depend only on the input argument, but also may trigger events in addition to returning a value.
-Intrinsic means that they are defined at the Modelica language level, not in the Modelica library.
-The following built-in intrinsic operators/functions are available:
+The built-in functions may also be overloaded such that a single Modelica function cannot be compatible with all calls of the function.
+Built-in means that they are defined at the Modelica language level, not in the Modelica library.
+The following built-in operators/functions are available:
 \begin{itemize}
 \item
-  Mathematical functions and conversion functions, see \cref{numeric-functions-and-conversion-functions} below.
+  Mathematical functions and conversion operators, see \cref{numeric-functions-and-conversion-functions} below.
 \item
   Derivative and special purpose operators with function syntax, see \cref{derivative-and-special-purpose-operators-with-function-syntax} below.
 \item
-  Event-related operators with function syntax, see \cref{event-related-operators-with-function-syntax} below.
+  Event-related functions, see \cref{event-related-operators-with-function-syntax} below.
 \item
-  Array operators/functions, see \cref{array-dimension-lower-and-upper-index-bounds}.
+  Array functions, see \cref{built-in-array-functions}.
 \end{itemize}
 
-Note that when the specification references a function having the name of a built-in function it references the built-in function, not a user-defined function having the same name, see also \cref{built-in-functions}.
-With exception of the built-in \lstinline!String! operator, all operators in this section can only be called with positional arguments.
+Note that when the specification references a function having the name of a built-in function or operator it references the built-in function or operator, not a user-defined function having the same name, see also \cref{built-in-functions}.
+With the exception where inputs are named (e.g., \lstinline!String!), all operators and functions in this section can only be called with positional arguments.
 
-\subsection{Numeric Functions and Conversion Functions}\label{numeric-functions-and-conversion-functions}
+\subsection{Numeric Functions and Conversion Operators}\label{numeric-functions-and-conversion-functions}
 
 The mathematical functions and conversion operators listed below do not generate events.
 \begin{center}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -410,7 +410,7 @@ The following built-in operators/functions are available:
 \item
   Event-related operators, see \cref{event-related-operators-with-function-syntax} below.
 \item
-  Array functions, see \cref{built-in-array-functions}.
+  Array operators/functions, see \cref{built-in-array-functions}.
 \item
   Synchronous operators, see \cref{synchronous-language-elements}.
 \item

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -400,7 +400,7 @@ However, they do not behave as a mathematical function, because the result depen
 
 There are also built-in functions that depend only on the input argument, but also may trigger events in addition to returning a value.
 The built-in functions may also be overloaded such that a single Modelica function cannot be compatible with all calls of the function.
-Built-in means that they are defined at the Modelica language level, not in the Modelica library.
+Here, \emph{built-in} means that they are defined at the Modelica language level, not through a Modelica \lstinline!function! definition.
 The following built-in operators/functions are available:
 \begin{itemize}
 \item
@@ -417,7 +417,7 @@ The following built-in operators/functions are available:
   State machine operators, see \cref{transitions}.
 \end{itemize}
 
-Note that when the specification references a function or operator having the name of a built-in function or operator it references the built-in function or operator, not a user-defined function having the same name, see also \cref{built-in-functions}.
+Except where shadowing problems are being discussed, references to built-in functions and operators within this document always assume that the built-in definitions are not shadowed by user-defined definitions, see also \cref{built-in-functions}.
 With the exception where inputs are named (e.g., \lstinline!String!), all operators and functions in this section can only be called with positional arguments.
 
 \subsection{Numeric Functions and Conversion Operators}\label{numeric-functions-and-conversion-functions}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -411,6 +411,10 @@ The following built-in operators/functions are available:
   Event-related functions, see \cref{event-related-operators-with-function-syntax} below.
 \item
   Array functions, see \cref{built-in-array-functions}.
+\item
+  Synchronous operators, see \cref{synchronous-language-elements}.
+\item
+  State machine operators, see \cref{transitions}.
 \end{itemize}
 
 Note that when the specification references a function or operator having the name of a built-in function or operator it references the built-in function or operator, not a user-defined function having the same name, see also \cref{built-in-functions}.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -613,7 +613,7 @@ If this is not desired, the \lstinline!noEvent! operator can be applied to them.
 E.g., \lstinline!noEvent(integer(v))!.
 \end{nonnormative}
 
-\begin{operatordefinition}[div]
+\begin{functiondefinition}[div]
 \begin{synopsis}\begin{lstlisting}
 div($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -625,9 +625,9 @@ This is defined for \lstinline!/! in C99; in C89 the result for negative numbers
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
-\begin{operatordefinition}[mod]
+\begin{functiondefinition}[mod]
 \begin{synopsis}\begin{lstlisting}
 mod($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -640,9 +640,9 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
-\begin{operatordefinition}[rem]
+\begin{functiondefinition}[rem]
 \begin{synopsis}\begin{lstlisting}
 rem($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -655,9 +655,9 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
-\begin{operatordefinition}[ceil]
+\begin{functiondefinition}[ceil]
 \begin{synopsis}\begin{lstlisting}
 ceil($x$)
 \end{lstlisting}\end{synopsis}
@@ -668,9 +668,9 @@ Result and argument shall have type \lstinline!Real!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
-\begin{operatordefinition}[floor]
+\begin{functiondefinition}[floor]
 \begin{synopsis}\begin{lstlisting}
 floor($x$)
 \end{lstlisting}\end{synopsis}
@@ -681,9 +681,9 @@ Result and argument shall have type \lstinline!Real!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
-\begin{operatordefinition}[integer]
+\begin{functiondefinition}[integer]
 \begin{synopsis}\begin{lstlisting}
 integer($x$)
 \end{lstlisting}\end{synopsis}
@@ -695,7 +695,7 @@ The result has type \lstinline!Integer!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{operatordefinition}
+\end{functiondefinition}
 
 \subsection{Elementary Mathematical Functions}\label{built-in-mathematical-functions-and-external-built-in-functions}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -408,7 +408,7 @@ The following built-in operators/functions are available:
 \item
   Derivative and special purpose operators with function syntax, see \cref{derivative-and-special-purpose-operators-with-function-syntax} below.
 \item
-  Event-related functions, see \cref{event-related-operators-with-function-syntax} below.
+  Event-related operators, see \cref{event-related-operators-with-function-syntax} below.
 \item
   Array functions, see \cref{built-in-array-functions}.
 \item

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -617,7 +617,7 @@ If this is not desired, the \lstinline!noEvent! operator can be applied to them.
 E.g., \lstinline!noEvent(integer(v))!.
 \end{nonnormative}
 
-\begin{functiondefinition}[div]
+\begin{operatordefinition}[div]
 \begin{synopsis}\begin{lstlisting}
 div($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -629,9 +629,9 @@ This is defined for \lstinline!/! in C99; in C89 the result for negative numbers
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
-\begin{functiondefinition}[mod]
+\begin{operatordefinition}[mod]
 \begin{synopsis}\begin{lstlisting}
 mod($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -644,9 +644,9 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
-\begin{functiondefinition}[rem]
+\begin{operatordefinition}[rem]
 \begin{synopsis}\begin{lstlisting}
 rem($x$, $y$)
 \end{lstlisting}\end{synopsis}
@@ -659,9 +659,9 @@ Note, outside of a \lstinline!when!-clause state events are triggered when the r
 Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
-\begin{functiondefinition}[ceil]
+\begin{operatordefinition}[ceil]
 \begin{synopsis}\begin{lstlisting}
 ceil($x$)
 \end{lstlisting}\end{synopsis}
@@ -672,9 +672,9 @@ Result and argument shall have type \lstinline!Real!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
-\begin{functiondefinition}[floor]
+\begin{operatordefinition}[floor]
 \begin{synopsis}\begin{lstlisting}
 floor($x$)
 \end{lstlisting}\end{synopsis}
@@ -685,9 +685,9 @@ Result and argument shall have type \lstinline!Real!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
-\begin{functiondefinition}[integer]
+\begin{operatordefinition}[integer]
 \begin{synopsis}\begin{lstlisting}
 integer($x$)
 \end{lstlisting}\end{synopsis}
@@ -699,7 +699,7 @@ The result has type \lstinline!Integer!.
 Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
-\end{functiondefinition}
+\end{operatordefinition}
 
 \subsection{Elementary Mathematical Functions}\label{built-in-mathematical-functions-and-external-built-in-functions}
 

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -381,7 +381,7 @@ However, errors that should only be reported in a simulation model must be omitt
 All necessary libraries including the model which is to be instantiated are loaded (e.g., from a file system) and form a so called \firstuse{class tree}.
 This tree represents the syntactic information from the class definitions.
 It contains also all modifications at their original locations in syntactic form.
-The builtin classes are put into the unnamed root of the class tree.
+The built-in classes are put into the unnamed root of the class tree.
 
 \begin{nonnormative}
 The class tree is built up directly during parsing of the Modelica texts.
@@ -411,7 +411,7 @@ The instance tree has the following properties:
 
 The instance tree is used for lookup during instantiation.
 To be prepared for that, it has to be based on the structure of the class tree with respect to the class definitions.
-The builtin classes are instantiated and put in the unnamed root prior to the instantiation of the user classes, to be able to find them.
+The built-in classes are instantiated and put in the unnamed root prior to the instantiation of the user classes, to be able to find them.
 
 \begin{nonnormative}
 The existence of the two separate trees (instance tree and class tree) is conceptual.


### PR DESCRIPTION
Closes #3590
The idea is to be clearer that "built-in operator" is something more complicated, whereas "built-in function" could (sort of) be defined in Modelica (even if not done). The only problematic case is `semiLinear` - but based on the special rules for simplification, I think we are justified in keeping it as a operator.

Note that intrinsic was previously used in an inconsistent way, it is an older synonym https://en.wikipedia.org/wiki/Intrinsic_function - but the text used "built-in intrinsic".

Of "built-in function ", "builtin function", and "intrinsic function" I preferred "built-in function" as it has become the most common phrase during this millenium:
https://books.google.com/ngrams/graph?content=%5Bbuilt+-+in+function%5D%2C%5Bbuiltin+function%5D%2C%5Bintrinsic+function%5D&year_start=1960&year_end=2022&corpus=en&smoothing=3

(A link in that section was also corrected, to refer to the actual list of array functions.)
