### PR TITLE
Specify that comments on choices shall not be copied.

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1117,6 +1117,7 @@ By starting names with a dot it can be ensured that no transformation of referen
 \end{nonnormative}
 
 This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclaration, where the string comments on the choice declaration can be used as textual explanations of the choices.
+The string comments for the choices shall not automatically be copied to the modifier.
 The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
 
 It is allowed to include choices that are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
@@ -1194,8 +1195,9 @@ type KindOfController = Integer(min = 1, max = 3)
 model A
   parameter KindOfController x;
 end A;
-A a(x = 3 "PID");
+A a(x = 3);
 \end{lstlisting}
+Note that \lstinline!"PID"! was not copied here.
 
 The \lstinline!choices! annotation can also be applied to \lstinline!Boolean! variables to define a check box.
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
Closes #3397
Note that line 309 already contain "When present, the description-string of a modifier overrides the existing description."