### PR TITLE
Break down example of quoted identifier

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1124,7 +1124,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   \begin{example}
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
-  When quoted identifiers (e.g., \lstinline!rec.'}'.'quoted ident'!) or composite names (i.e., not simple identifiers) are involved, the form \%\{\emph{par}\} must be used.
+  When quoted identifiers (e.g., \lstinline!'quoted ident'! or \lstinline!'}'!) or composite names (i.e., not simple identifiers) are involved, the form \%\{\emph{par}\} must be used.
   Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and \lstinline!%{a.p}! gives the value of the parameter \lstinline!p! in the component \lstinline!a!.
   The macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.


### PR DESCRIPTION
This is just a small enhancement of #3592.  I had it in mind when reviewing that PR, but must have forgotten to write it down.

The idea is that when we speak of both quoted identifiers and complex names, the example for quoted identifiers should illustrate just quoted identifiers without at the same time illustrating complex names.
