### PR TITLE
Correct highlighting

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -36,13 +36,13 @@ An equation section is comprised of the keyword \lstinline!equation!\index{equat
 The formal syntax is as follows:
 \begin{lstlisting}[language=grammar]
 equation-section :
-   [ initial ] equation { equation ";" }
+   [ initial ] equation { some-equation ";" }
 \end{lstlisting}
 
 The following kinds of equations may occur in equation sections.
 The syntax is defined as follows:
 \begin{lstlisting}[language=grammar]
-equation :
+some-equation :
    ( simple-expression "=" expression
      | if-equation
      | for-equation
@@ -82,7 +82,7 @@ Also compare with \cref{assignments-from-called-functions-with-multiple-results}
 The syntax of a \lstinline!for!-equation\index{for@\robustinline{for}!equation}\index{loop@\robustinline{loop}!for-equation@\robustinline{for}-equation} is as follows:
 \begin{lstlisting}[language=grammar]
 for for-indices loop
-  { equation ";" }
+  { some-equation ";" }
 end for ";"
 \end{lstlisting}
 
@@ -164,12 +164,12 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 The \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} have the following syntax:
 \begin{lstlisting}[language=grammar]
 if expression then
-  { equation ";" }
+  { some-equation ";" }
 { elseif expression then
-  { equation ";" }
+  { some-equation ";" }
 }
 [ else
-  { equation ";" }
+  { some-equation ";" }
 ]
 end if ";"
 \end{lstlisting}
@@ -192,9 +192,9 @@ If this condition is violated, the single assignment rule would not hold, becaus
 The \lstinline!when!-equations\index{when@\robustinline{when}!equation}\index{then@\robustinline{then}!when-equation@\robustinline{when}-equation}\index{elsewhen@\robustinline{elsewhen}!when-equation@\robustinline{when}-equation} have the following syntax:
 \begin{lstlisting}[language=grammar]
 when expression then
-  { equation ";" }
+  { some-equation ";" }
 { elsewhen expression then
-  { equation ";" }
+  { some-equation ";" }
 }
 end when ";"
 \end{lstlisting}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -260,12 +260,12 @@ short-class-definition :
 
 \begin{lstlisting}[language=grammar]
 equation-section :
-   [ initial ] equation { equation ";" }
+   [ initial ] equation { some-equation ";" }
 
 algorithm-section :
    [ initial ] algorithm { statement ";" }
 
-equation :
+some-equation :
    ( simple-expression "=" expression
      | if-equation
      | for-equation
@@ -290,12 +290,12 @@ statement :
 
 if-equation :
    if expression then
-     { equation ";" }
+     { some-equation ";" }
    { elseif expression then
-     { equation ";" }
+     { some-equation ";" }
    }
    [ else
-     { equation ";" }
+     { some-equation ";" }
    ]
    end if
 
@@ -312,7 +312,7 @@ if-statement :
 
 for-equation :
    for for-indices loop
-     { equation ";" }
+     { some-equation ";" }
    end for
 
 for-statement :
@@ -333,9 +333,9 @@ while-statement :
 
 when-equation :
    when expression then
-     { equation ";" }
+     { some-equation ";" }
    { elsewhen expression then
-     { equation ";" }
+     { some-equation ";" }
    }
    end when
 


### PR DESCRIPTION
Closes #3608

The problem was that we cannot use keywords as grammar constructs - but have to use different names to separate the two.
I know that `some-equation` isn't ideal - but it is easier to change once it has a separate name.