### PR TITLE
Be clearer in definition of Inf and avoid relying on Modelica.Constants.

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -596,7 +596,7 @@ If \lstinline!function-name! is \lstinline!sum!, \lstinline!product!, \lstinline
 For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using types as ranges see \cref{types-as-iteration-ranges}.
 
 \begin{table}[H]
-\caption{Reduction expressions with iterators.  (The least and greatest values of \lstinline!Real! are available as \lstinline!-Modelica.Constants.inf! and \lstinline!Modelica.Constants.inf!, respectively.)}
+\caption{Reduction expressions with iterators.}
 \begin{center}
 \begin{tabular}{l l l}
 \hline
@@ -611,6 +611,8 @@ For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using typ
 \end{tabular}
 \end{center}
 \end{table}
+
+The least and greatest values of \lstinline!Real! are the minimum and maximum representable finite floating point numbers of the underlying type, see also \cref{real-type}.
 
 \begin{example}
 % No frame since the math would break it.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,7 +1478,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min = -Inf, max = +Inf; // See below
+  parameter RealType min, max;         //  See below
   parameter RealType start;            // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
@@ -1500,8 +1500,11 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
-Here \lstinline!+Inf! (and \lstinline!-Inf!) corresponds to the maximum (and minimum) representable finite floating point number of the underlying type.
-Thus the default \lstinline!min!- and \lstinline!max!-attributes do not constrain the value.
+The default \lstinline!min!- and \lstinline!max!-attributes do not constrain the value.
+The \lstinline!max! and \lstinline!max!-attributes can be given as the minimum and maximum representable finite floating point number of the underlying type.
+\begin{nonnormative}
+The minimum representable floating point number is usually minus the maximum representable floating point number, and should not be confused with the minimum positive one.
+\end{nonnormative}
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1506,7 +1506,7 @@ The value must be a finite floating point number, and thus the default default \
 The minimum representable floating point number is usually the negation of the maximum representable floating point number, and should not be confused with the minimum positive one.
 \end{nonnormative}
 
-The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 
@@ -1556,7 +1556,7 @@ The minimal recommended number range for \lstinline!IntegerType! is from -214748
 
 The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.
 
-The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
 
 \subsection{Boolean Type}\label{boolean-type}
 
@@ -1577,7 +1577,7 @@ The following attributes shall be evaluable: \lstinline!quantity!, and \lstinlin
 
 The fallback value is \lstinline!false!.
 
-The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
 
 \subsection{String Type}\label{string-type}
 
@@ -1600,7 +1600,7 @@ A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other 
 
 The fallback value is \lstinline!""!.
 
-The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
 
 \subsection{Enumeration Types}\label{enumeration-types}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,9 +1478,10 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min = $\ldots$, max = $\ldots$; //  See below
+  parameter RealType min = $\ldots$; // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter RealType max = $\ldots$; // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
   parameter RealType start;            // Initial value
-  parameter BooleanType fixed = $\ldots$; // See below
+  parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
   parameter RealType nominal;            // Nominal value
   parameter BooleanType unbounded = false; // For error control
   parameter StateSelect stateSelect = StateSelect.default;
@@ -1536,9 +1537,10 @@ The following is the predefined \lstinline!Integer!\indexinline{Integer} type:
 type Integer // Note: Defined with Modelica syntax although predefined
   IntegerType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter IntegerType min = $\ldots$, max = $\ldots$; //  See below
+  parameter IntegerType min = $\ldots$; // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter IntegerType max = $\ldots$; // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
   parameter IntegerType start;         // Initial value
-  parameter BooleanType fixed = $\ldots$; // See below
+  parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 equation
   assert(min <= $\langle$$\mbox{\emph{value}}$$\rangle$ and $\langle$$\mbox{\emph{value}}$$\rangle$ <= max, "Variable value out of limit");
 end Integer;
@@ -1566,7 +1568,7 @@ type Boolean // Note: Defined with Modelica syntax although predefined
   BooleanType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter BooleanType start;         // Initial value
-  parameter BooleanType fixed = $\ldots$; // See below
+  parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 end Boolean;
 \end{lstlisting}%
 \index{quantity@\robustinline{quantity}!attribute of \robustinline{Boolean}}%
@@ -1587,7 +1589,7 @@ type String // Note: Defined with Modelica syntax although predefined
   StringType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter StringType start;          // Initial value
-  parameter BooleanType fixed = $\ldots$; // See below
+  parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 end String;
 \end{lstlisting}%
 \index{quantity@\robustinline{quantity}!attribute of \robustinline{String}}%

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1536,7 +1536,7 @@ The following is the predefined \lstinline!Integer!\indexinline{Integer} type:
 type Integer // Note: Defined with Modelica syntax although predefined
   IntegerType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter IntegerType min = -Inf, max = +Inf;
+  parameter IntegerType min = $\ldots$, max = $\ldots$; //  See below
   parameter IntegerType start;         // Initial value
   parameter BooleanType fixed = $\ldots$; // See below
 equation
@@ -1551,6 +1551,7 @@ end Integer;
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
+The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum numbers of the underlying type.
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
 The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,7 +1478,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min = ..., max = ...; //  See below
+  parameter RealType min = $\ldots$, max = $\ldots$; //  See below
   parameter RealType start;            // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
@@ -1500,10 +1500,10 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
-The default \lstinline!max! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point number of the underlying type.
+The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point numbers of the underlying type.
 Therefore they do not constrain the value.
 \begin{nonnormative}
-The minimum representable floating point number is usually minus the maximum representable floating point number, and should not be confused with the minimum positive one.
+The minimum representable floating point number is usually the negation of the maximum representable floating point number, and should not be confused with the minimum positive one.
 \end{nonnormative}
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1501,7 +1501,7 @@ end Real;
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
 The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point numbers of the underlying type.
-Therefore they do not constrain the value.
+The value must be a finite floating point number, and thus the default default \lstinline!min! and \lstinline!max!-attributes do not further constrain the value.
 \begin{nonnormative}
 The minimum representable floating point number is usually the negation of the maximum representable floating point number, and should not be confused with the minimum positive one.
 \end{nonnormative}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,11 +1478,11 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min = $\ldots$; // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
-  parameter RealType max = $\ldots$; // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
-  parameter RealType start;            // Initial value
+  parameter RealType min = $\ldots$;      // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter RealType max = $\ldots$;      // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter RealType start;         // Initial value
   parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
-  parameter RealType nominal;            // Nominal value
+  parameter RealType nominal;       // Nominal value
   parameter BooleanType unbounded = false; // For error control
   parameter StateSelect stateSelect = StateSelect.default;
 equation
@@ -1537,9 +1537,9 @@ The following is the predefined \lstinline!Integer!\indexinline{Integer} type:
 type Integer // Note: Defined with Modelica syntax although predefined
   IntegerType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter IntegerType min = $\ldots$; // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
-  parameter IntegerType max = $\ldots$; // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
-  parameter IntegerType start;         // Initial value
+  parameter IntegerType min = $\ldots$;    // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter IntegerType max = $\ldots$;    // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter IntegerType start;      // Initial value
   parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 equation
   assert(min <= $\langle$$\mbox{\emph{value}}$$\rangle$ and $\langle$$\mbox{\emph{value}}$$\rangle$ <= max, "Variable value out of limit");
@@ -1567,7 +1567,7 @@ The following is the predefined \lstinline!Boolean!\indexinline{Boolean} type:
 type Boolean // Note: Defined with Modelica syntax although predefined
   BooleanType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter BooleanType start;         // Initial value
+  parameter BooleanType start;      // Initial value
   parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 end Boolean;
 \end{lstlisting}%
@@ -1588,7 +1588,7 @@ The following is the predefined \lstinline!String!\indexinline{String} type:
 type String // Note: Defined with Modelica syntax although predefined
   StringType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter StringType start;          // Initial value
+  parameter StringType start;       // Initial value
   parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 end String;
 \end{lstlisting}%

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1500,11 +1500,11 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
-The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point numbers of the underlying type.
-The value must be a finite floating point number, and thus the default default \lstinline!min! and \lstinline!max!-attributes do not further constrain the value.
+The default \lstinline!min!- and \lstinline!max!-attributes are the minimum and maximum representable finite floating point numbers of \lstinline!RealType!.
+The $\langle$$\mbox{\emph{value}}$$\rangle$ must be a finite floating point number, and thus the default \lstinline!min!- and \lstinline!max!-attributes do not impose any further constraints.
 
 \begin{nonnormative}
-The minimum representable floating point number is usually the negation of the maximum representable floating point number, and should not be confused with the minimum positive one.
+Of the representable floating point numbers, the minimum number is usually the negation of the maximum number, and should not be confused with the minimum positive number.
 \end{nonnormative}
 
 The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
@@ -1553,7 +1553,7 @@ end Integer;
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
-The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum numbers of the underlying type.
+The default \lstinline!min!- and \lstinline!max!-attributes are the minimum and maximum numbers of \lstinline!IntegerType!.
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
 The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1537,8 +1537,8 @@ The following is the predefined \lstinline!Integer!\indexinline{Integer} type:
 type Integer // Note: Defined with Modelica syntax although predefined
   IntegerType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
-  parameter IntegerType min = $\ldots$;    // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
-  parameter IntegerType max = $\ldots$;    // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter IntegerType min = $\ldots$;   // Lower bound for $\langle$$\mbox{\emph{value}}$$\rangle$
+  parameter IntegerType max = $\ldots$;   // Upper bound for $\langle$$\mbox{\emph{value}}$$\rangle$
   parameter IntegerType start;      // Initial value
   parameter BooleanType fixed = $\ldots$; // Enforce exact value of 'start'
 equation

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1480,8 +1480,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType displayUnit = "" "Default display unit";
   parameter RealType min = $\ldots$, max = $\ldots$; //  See below
   parameter RealType start;            // Initial value
-  parameter BooleanType fixed = true,  // default for parameter/constant;
-                              = false; // default for other variables
+  parameter BooleanType fixed = $\ldots$; // See below
   parameter RealType nominal;            // Nominal value
   parameter BooleanType unbounded = false; // For error control
   parameter StateSelect stateSelect = StateSelect.default;
@@ -1502,9 +1501,12 @@ end Real;
 
 The default \lstinline!min! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point numbers of the underlying type.
 The value must be a finite floating point number, and thus the default default \lstinline!min! and \lstinline!max!-attributes do not further constrain the value.
+
 \begin{nonnormative}
 The minimum representable floating point number is usually the negation of the maximum representable floating point number, and should not be confused with the minimum positive one.
 \end{nonnormative}
+
+The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 
@@ -1536,8 +1538,7 @@ type Integer // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity = "";
   parameter IntegerType min = -Inf, max = +Inf;
   parameter IntegerType start;         // Initial value
-  parameter BooleanType fixed = true,  // default for parameter/constant;
-                              = false; // default for other variables
+  parameter BooleanType fixed = $\ldots$; // See below
 equation
   assert(min <= $\langle$$\mbox{\emph{value}}$$\rangle$ and $\langle$$\mbox{\emph{value}}$$\rangle$ <= max, "Variable value out of limit");
 end Integer;
@@ -1554,6 +1555,8 @@ The minimal recommended number range for \lstinline!IntegerType! is from -214748
 
 The fallback value is the closest value to $0$ consistent with the \lstinline!min! and \lstinline!max! bounds.
 
+The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+
 \subsection{Boolean Type}\label{boolean-type}
 
 The following is the predefined \lstinline!Boolean!\indexinline{Boolean} type:
@@ -1562,8 +1565,7 @@ type Boolean // Note: Defined with Modelica syntax although predefined
   BooleanType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter BooleanType start;         // Initial value
-  parameter BooleanType fixed = true,  // default for parameter/constant;
-                              = false, // default for other variables
+  parameter BooleanType fixed = $\ldots$; // See below
 end Boolean;
 \end{lstlisting}%
 \index{quantity@\robustinline{quantity}!attribute of \robustinline{Boolean}}%
@@ -1574,6 +1576,8 @@ The following attributes shall be evaluable: \lstinline!quantity!, and \lstinlin
 
 The fallback value is \lstinline!false!.
 
+The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
+
 \subsection{String Type}\label{string-type}
 
 The following is the predefined \lstinline!String!\indexinline{String} type:
@@ -1582,8 +1586,7 @@ type String // Note: Defined with Modelica syntax although predefined
   StringType $\langle$$\mbox{\emph{value}}$$\rangle$; // Not an attribute; only accessed without dot-notation
   parameter StringType quantity = "";
   parameter StringType start;          // Initial value
-  parameter BooleanType fixed = true,  // default for parameter/constant;
-                              = false, // default for other variables
+  parameter BooleanType fixed = $\ldots$; // See below
 end String;
 \end{lstlisting}%
 \index{quantity@\robustinline{quantity}!attribute of \robustinline{String}}%
@@ -1595,6 +1598,8 @@ The following attributes shall be evaluable: \lstinline!quantity!, and \lstinlin
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
 
 The fallback value is \lstinline!""!.
+
+The default value for the \lstinline!fixed!-attribute depends on the variability, and is \lstinline!true! for a parameter/constant and \lstinline!false! otherwise.
 
 \subsection{Enumeration Types}\label{enumeration-types}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,7 +1478,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min = -Inf, max = +Inf; // Inf denotes a large value
+  parameter RealType min = -Inf, max = +Inf; // See below
   parameter RealType start;            // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
@@ -1499,6 +1499,9 @@ end Real;
 \index{nominal@\robustinline{nominal}!attribute of \robustinline{Real}}%
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
+
+Here \lstinline!+Inf! (and \lstinline!-Inf!) corresponds to the maximum (and minimum) representable finite floating point number of the underlying type.
+Thus the default \lstinline!min!- and \lstinline!max!-attributes do not constrain the value.
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1478,7 +1478,7 @@ type Real // Note: Defined with Modelica syntax although predefined
   parameter StringType quantity    = "";
   parameter StringType unit        = "" "Unit used in equations";
   parameter StringType displayUnit = "" "Default display unit";
-  parameter RealType min, max;         //  See below
+  parameter RealType min = ..., max = ...; //  See below
   parameter RealType start;            // Initial value
   parameter BooleanType fixed = true,  // default for parameter/constant;
                               = false; // default for other variables
@@ -1500,8 +1500,8 @@ end Real;
 \index{unbounded@\robustinline{unbounded}!attribute of \robustinline{Real}}%
 \index{stateSelect@\robustinline{stateSelect}!attribute of \robustinline{Real}}
 
-The default \lstinline!min!- and \lstinline!max!-attributes do not constrain the value.
-The \lstinline!max! and \lstinline!max!-attributes can be given as the minimum and maximum representable finite floating point number of the underlying type.
+The default \lstinline!max! and \lstinline!max!-attributes are the minimum and maximum representable finite floating point number of the underlying type.
+Therefore they do not constrain the value.
 \begin{nonnormative}
 The minimum representable floating point number is usually minus the maximum representable floating point number, and should not be confused with the minimum positive one.
 \end{nonnormative}


### PR DESCRIPTION
This is what I meant with inlining the definition of Modelica.Constants.inf.

For comparison:
In C:
- DBL_MAX is the "maximum finite value of double"; https://en.cppreference.com/w/c/types/limits

In C++  (C++11 and later); https://en.cppreference.com/w/cpp/types/numeric_limits
- std::numeric_limits<double>::max() "returns the largest finite value of double"
- std::numeric_limits<double>::lowest() "returns the lowest finite value of double"
