### PR TITLE
Start clearing up annotation syntax for functions.

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1724,14 +1724,14 @@ Late inlining is especially useful for differentiation and inversion of function
 
 If {\lstinline!LateInline = false!}, the model developer proposes to not inline the function after symbolic transformations have been performed.
 
+The default for late inlining is tool-specific.
+In particular, tools may automatically delay inlining in order to take advantage of function annotations for derivatives and inverses.
+
 {\lstinline!Inline = true, LateInline = false!} is identical to {\lstinline!Inline = true!}.
 
 {\lstinline!Inline = true, LateInline = true!} is identical to {\lstinline!LateInline = true!}.
 
 {\lstinline!Inline = false, LateInline = true!} is identical to {\lstinline!LateInline = true!}.
-
-The default for late inlining is tool-specific.
-In particular, tools may automatically delay inlining in order to take advantage of function annotations for derivatives and inverses.
 
 \begin{nonnormative}
 This annotation is for example used in {\lstinline!Modelica.Media.Water.IF97_Utilities.T_props_ph!} to provide in combination with common subexpression elimination the automatic caching of function calls.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1722,8 +1722,6 @@ If {\lstinline!LateInline = true!}, the model developer proposes to inline the f
 Late inlining is especially useful for differentiation and inversion of functions; for efficiency reasons it is then useful to replace all function calls with identical input arguments by one function call, before the inlining.
 \end{nonnormative}
 
-The default for late inlining is tool-specific, in particular tools may automatically delay inlining to differentiate or possible invert the function before inlining it.
-
 If {\lstinline!LateInline = false!}, the model developer proposes to not inline the function after symbolic transformations have been performed.
 
 {\lstinline!Inline = true, LateInline = false!} is identical to {\lstinline!Inline = true!}.
@@ -1731,6 +1729,9 @@ If {\lstinline!LateInline = false!}, the model developer proposes to not inline 
 {\lstinline!Inline = true, LateInline = true!} is identical to {\lstinline!LateInline = true!}.
 
 {\lstinline!Inline = false, LateInline = true!} is identical to {\lstinline!LateInline = true!}.
+
+The default for late inlining is tool-specific.
+In particular, tools may automatically delay inlining in order to take advantage of function annotations for derivatives and inverses.
 
 \begin{nonnormative}
 This annotation is for example used in {\lstinline!Modelica.Media.Water.IF97_Utilities.T_props_ph!} to provide in combination with common subexpression elimination the automatic caching of function calls.
@@ -1747,8 +1748,9 @@ Furthermore, it is used in order that a tool is able to propagate specific entha
 Has only an effect within a function declaration.
 
 If {\lstinline!true!}, the model developer proposes to inline the function after the function is differentiated for index reduction, and before any other symbolic transformations are performed.
-This annotation cannot be combined with annotations {\lstinline!Inline!} and {\lstinline!LateInline!}.
 The default is to not perform this specific inlining.
+
+This annotation cannot be combined with annotations {\lstinline!Inline!} and {\lstinline!LateInline!}.
 \end{semantics}
 \end{annotationdefinition}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1670,7 +1670,7 @@ where the requirement $\text{{\lstinline!y!}} > 0$ can no longer be detected, re
 \section{Function Inlining and Event Generation}\label{function-inlining-and-event-generation}
 
 The annotations listed below affect inlining of functions and the related topic of event generation inside functions.
-For the semantics of the annotations see \cref{notation-for-annotation-definitions}.
+See \cref{notation-for-annotation-definitions} regarding the notation used to describe the annotations.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1711,7 +1711,7 @@ The default for inlining is tool-specific.
 
 \begin{annotationdefinition}[LateInline]
 \begin{synopsis}\begin{lstlisting}
-/*literal*/ constant Boolean LateInline = false;
+/*literal*/ constant Boolean LateInline;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.
@@ -1721,6 +1721,8 @@ If {\lstinline!LateInline = true!}, the model developer proposes to inline the f
 \begin{nonnormative}
 Late inlining is especially useful for differentiation and inversion of functions; for efficiency reasons it is then useful to replace all function calls with identical input arguments by one function call, before the inlining.
 \end{nonnormative}
+
+The default for late inlining is tool-specific, in particular tools may automatically delay inlining to differentiate or possible invert the function before inlining it.
 
 If {\lstinline!LateInline = false!}, the model developer proposes to not inline the function after symbolic transformations have been performed.
 
@@ -1739,19 +1741,20 @@ Furthermore, it is used in order that a tool is able to propagate specific entha
 
 \begin{annotationdefinition}[InlineAfterIndexReduction]
 \begin{synopsis}\begin{lstlisting}
-/*literal*/ constant Boolean InlineAfterIndexReduction = false;
+/*literal*/ constant Boolean InlineAfterIndexReduction;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.
 
 If {\lstinline!true!}, the model developer proposes to inline the function after the function is differentiated for index reduction, and before any other symbolic transformations are performed.
 This annotation cannot be combined with annotations {\lstinline!Inline!} and {\lstinline!LateInline!}.
+The default is to not perform this specific inlining.
 \end{semantics}
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[GenerateEvents]
 \begin{synopsis}\begin{lstlisting}
-/*literal*/ constant Boolean GenerateEvents = false;
+/*literal*/ constant Boolean GenerateEvents;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1670,6 +1670,7 @@ where the requirement $\text{{\lstinline!y!}} > 0$ can no longer be detected, re
 \section{Function Inlining and Event Generation}\label{function-inlining-and-event-generation}
 
 The annotations listed below affect inlining of functions and the related topic of event generation inside functions.
+For the semantics of the annotations see \cref{notation-for-annotation-definitions}.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -1689,8 +1690,8 @@ At the same time, another important consequence of inlining a function is that a
 Hence, one needs to find the right balance between inlining too early (loss of provided derivatives and inverses) and too late (earlier stages of symbolic processing cannot benefit from symbolic simplifications).
 
 \begin{annotationdefinition}[Inline]
-\begin{synopsis}[grammar]\begin{lstlisting}
-"Inline" "=" ( false | true )
+\begin{synopsis}\begin{lstlisting}
+/*literal*/ constant Boolean Inline;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.
@@ -1700,6 +1701,8 @@ This means, that the body of the function is included at all places where the fu
 
 If {\lstinline!Inline = false!}, the model developer proposes to not inline the function.
 
+The default for inlining is tool-specific.
+
 \begin{nonnormative}
 {\lstinline!Inline = true!} is for example used in {\lstinline!Modelica.Mechanics.MultiBody.Frames!} and in functions of {\lstinline!Modelica.Media!} to have no overhead for function calls such as resolving a vector in a different coordinate system and at the same time the function can be analytically differentiated, e.g., for index reduction needed for mechanical systems.
 \end{nonnormative}
@@ -1707,8 +1710,8 @@ If {\lstinline!Inline = false!}, the model developer proposes to not inline the 
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[LateInline]
-\begin{synopsis}[grammar]\begin{lstlisting}
-"LateInline" "=" ( false | true )
+\begin{synopsis}\begin{lstlisting}
+/*literal*/ constant Boolean LateInline = false;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.
@@ -1735,8 +1738,8 @@ Furthermore, it is used in order that a tool is able to propagate specific entha
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[InlineAfterIndexReduction]
-\begin{synopsis}[grammar]\begin{lstlisting}
-"InlineAfterIndexReduction" "=" ( false | true )
+\begin{synopsis}\begin{lstlisting}
+/*literal*/ constant Boolean InlineAfterIndexReduction = false;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.
@@ -1747,8 +1750,8 @@ This annotation cannot be combined with annotations {\lstinline!Inline!} and {\l
 \end{annotationdefinition}
 
 \begin{annotationdefinition}[GenerateEvents]
-\begin{synopsis}[grammar]\begin{lstlisting}
-"GenerateEvents" "=" ( false | true )
+\begin{synopsis}\begin{lstlisting}
+/*literal*/ constant Boolean GenerateEvents = false;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Has only an effect within a function declaration.


### PR DESCRIPTION
It is intended to work towards close #3495 - but it doesn't handle all of the annotations as some are problematic.

Note that I deliberately added default values in some cases, I believe they are the correct ones.

It might be that we should add more, or view this as enough to close it - and later think about the rest.

The problem with the other ones are:
- "Trivial": the external function ones can specify either an array or a scalar.
- "Messy": The derivative and inline-annotations don't fit into the pattern for two reasons:
   - The "value" is not a value - so no good type for the declaration (it is a function for derivatives, and something else for inverse)
   - The optional sub-modifiers for values, like `smoothOrder(normallyConstant=x)=2`

(I have might have missed some that could be handled.)