### PR TITLE
Update "parameter" to "evaluable" in connectors.tex

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -25,7 +25,7 @@ The \lstinline!connect!-equation construct takes two references to connectors, e
   \lstinline!m.c!, where \lstinline!m! is a non-connector element in the class and \lstinline!c! is a connector element of \lstinline!m!.
 \end{itemize}
 
-There may optionally be array subscripts on any of the components; the array subscripts shall be parameter expressions or the special operator \lstinline!:!.
+There may optionally be array subscripts on any of the components; the array subscripts shall be evaluable expressions or the special operator \lstinline!:!.
 If the connect construct references array of connectors, the array dimensions must match, and each corresponding pair of elements from the arrays is connected as a pair of scalar connectors.
 
 \begin{example}
@@ -556,9 +556,9 @@ This corresponds to a direct connection of the resistor.
 
 \begin{itemize}
 \item
-  The \lstinline!connect!-equations (and the special functions for overdetermined connectors) can only be used in equations, and shall not be used inside \lstinline!if!-equations with conditions that are not parameter expressions, or in \lstinline!when!-equations.
+  The \lstinline!connect!-equations (and the special functions for overdetermined connectors) can only be used in equations, and shall not be used inside \lstinline!if!-equations with conditions that are not evaluable expressions, or in \lstinline!when!-equations.
   \begin{nonnormative}
-  The \lstinline!for!-equations always have parameter expressions for the array expression.
+  The \lstinline!for!-equations always have evaluable expressions for the array expression.
   \end{nonnormative}
 \item
   A connector component shall not be declared with the prefix \lstinline!parameter! or \lstinline!constant!.
@@ -607,7 +607,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
   Otherwise the connection sets could contain redundant information breaking the equation count for locally balanced models and blocks.
   \end{nonnormative}
 \item
-  Subscripts in a connector reference shall be parameter expressions or the special operator \lstinline!:!.
+  Subscripts in a connector reference shall be evaluable expressions or the special operator \lstinline!:!.
 \item
   Constants or parameters in connected components yield the appropriate \lstinline!assert!-statements to check that they have the same value; connections are not generated.
 \item
@@ -864,7 +864,7 @@ Connections.potentialRoot(a.R, priority=$p$)
 \begin{semantics}
 The overdetermined type or record instance \lstinline!R! in connector instance \lstinline!a! is a \firstuse{potential root node}\index{root node!potential} in a virtual connection graph with priority \lstinline!p! ($p \geq 0$).
 If no second argument is provided, the priority is zero.
-\lstinline!p! shall be a parameter expression of type \lstinline!Integer!.
+\lstinline!p! shall be an evaluable expression of type \lstinline!Integer!.
 In a virtual connection subgraph without a \lstinline!Connections.root! definition, one of the potential roots with the lowest priority number is selected as root.
 
 \begin{nonnormative}


### PR DESCRIPTION
Changes in #3582 affected only equations.tex. I thought we should check connectors.tex as well. I believe those are all instances where "parameter" should be "evaluable." I believe it is ok to use "parameter" on line 854, so did not include it. But let me know if this should also be evaluable.