### PR TITLE
Describe lookup of annotation enumeration types

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -31,7 +31,7 @@ If the annotation is declared as a \lstinline!/*literal*/ constant! the correspo
 
 \section{Semantic Restrictions of Annotation Syntax}\label{semantic-restrictions-of-annotation-syntax}
 
-The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the very generic \lstinline[language=grammar]!class-modification!.
+The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the generic \lstinline[language=grammar]!class-modification!.
 However, except where explicitly stated, the following constructs shall not be used in annotations:
 \begin{itemize}
 \item

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -87,7 +87,6 @@ model M_annotation
 end M_annotation;
 \end{lstlisting}
 where \lstinline!AnnotationEnumerations! is a hidden package containing all enumeration types used in annotations, and $\mathit{T}$ is the expected type of the expression.
-(Actual implementations will also need to avoid potential shadowing problems involving the names \lstinline!M_annotation! and \lstinline!result!.)
 \end{nonnormative}
 
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -29,6 +29,27 @@ If the annotation is declared as an \lstinline!/*evaluable*/ parameter! the corr
 If the annotation is declared as a \lstinline!/*literal*/ constant! the corresponding modifier is further restricted to be a literal value.
 
 
+\section{Semantic Restrictions of Annotation Syntax}\label{semantic-restrictions-of-annotation-syntax}
+
+The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the very generic \lstinline[language=grammar]!class-modification!.
+However, except where explicitly stated, the following constructs shall not be used in annotations:
+\begin{itemize}
+\item
+\lstinline!final!.
+For instance, neither \lstinline!final experiment(StopTime = 2.0)! nor \lstinline!experiment(final StopTime = 2.0)! may be used to prevent that an extending model overrides the \lstinline!StopTime! setting.
+\item
+\lstinline!each!.
+When an annotation is given for an array component declaration, it applies to the array as a whole.
+Thus, neither should values be given in arrays matching the size of the declared component, nor should \lstinline!each! be used express that a scalar value applies to each element of the array.
+\item
+\lstinline[language=grammar]!element-redeclaration! in the grammar.
+In particular, the keyword \lstinline!redeclare! cannot be used.
+\item
+\lstinline[language=grammar]!element-replaceable! in the grammar.
+In particular the keywords \lstinline!replaceable! and \lstinline!constrainedby! cannot be used.
+\end{itemize}
+
+
 \section{Expression Evaluation Inside Annotations}\label{expression-evaluation-inside-annotations}
 
 This section describes some differences to the evaluation of expressions inside of annotations compared to normal evaluation rules outside of annotations.
@@ -73,6 +94,7 @@ where \lstinline!AnnotationEnumerations! is a hidden package containing all enum
 \section{Vendor-Specific Annotations}\label{vendor-specific-annotations}
 
 A vendor may -- anywhere inside an annotation -- add specific, possibly undocumented, annotations which are not intended to be interpreted by other tools.
+The semantic restrictions in \cref{semantic-restrictions-of-annotation-syntax} are not enforced in vendor-specific annotations, giving vendors the full freedom of using the most general form of annotations.
 The only requirement is that any tool shall save files with all vendor-specific annotations (and all annotations from this chapter) intact.
 Two variants of vendor-specific annotations\index{vendor-specific annotation} exist; one simple and one hierarchical.
 Double underscore concatenated with a vendor name as initial characters of the identifier are used to identify vendor-specific annotations.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -31,7 +31,7 @@ If the annotation is declared as a \lstinline!/*literal*/ constant! the correspo
 
 \section{Semantic Restrictions of Annotation Syntax}\label{semantic-restrictions-of-annotation-syntax}
 
-The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the generic \lstinline[language=grammar]!class-modification!.
+The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the generic \lstinline[language=grammar]!class-modification! in \cref{modification}.
 However, except where explicitly stated, the following constructs shall not be used in annotations:
 \begin{itemize}
 \item

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -8,6 +8,7 @@ The structure of the annotation content is the same as a class modification (\ls
 (For replaceable class declarations with a \lstinline[language=grammar]!constraining-clause! also refer to \cref{constraining-clause-annotations}.)
 The specification in this document defines the semantic meaning if a tool implements any of these annotations.
 
+
 \section{Notation for Annotation Definitions}\label{notation-for-annotation-definitions}
 
 Annotations are defined using the syntactic forms of Modelica component declarations and record definitions, with the following special semantics.
@@ -26,6 +27,48 @@ The default behavior is either the implicit absence of any of the effects for de
 When an annotation is defined with a component variability prefix (\cref{component-variability-prefixes-discrete-parameter-constant}), this restricts the allowed variability of corresponding annotation modifiers analogously to the rules in \cref{variability-of-expressions}.
 If the annotation is declared as an \lstinline!/*evaluable*/ parameter! the corresponding modifier is further restricted to be evaluable.
 If the annotation is declared as a \lstinline!/*literal*/ constant! the corresponding modifier is further restricted to be a literal value.
+
+
+\section{Expression Evaluation Inside Annotations}\label{expression-evaluation-inside-annotations}
+
+This section describes some differences to the evaluation of expressions inside of annotations compared to normal evaluation rules outside of annotations.
+
+
+\subsection{Enumerations for Use in Annotations}\label{enumerations-for-use-in-annotations}
+
+Several annotations make use of dedicated enumeration types.
+These enumeration types do not have the full status of being built-in types as, e.g., \lstinline!StateSelect! (\cref{stateselect}).
+Instead, they are only in scope where expressions inside annotations are evaluated, shadowing any user-defined definitions with the same names.
+
+\begin{example}
+The \lstinline!smooth! attribute of a \lstinline!Polygon! can be controlled through a model parameter, but the parameter cannot use the \lstinline!Smooth! type directly:
+\begin{lstlisting}[language=modelica]
+model BezierParameter
+  parameter Smooth smooth = Smooth.Bezier; // Error: Smooth is unknown here.
+  parameter Boolean bezier = true;         // Fine.
+  annotation(Icon(graphics = {
+    Polygon(
+      smooth = if bezier then Smooth.Bezier else Smooth.None,
+      points = {{-50, -20}, {0, 30}, {50, -20}}
+    )
+  }));
+end BezierParameter;
+\end{lstlisting}
+\end{example}
+
+\begin{nonnormative}
+When evaluating the expression $\mathit{expr}$ in the model \lstinline!M!, one can imagine it being done as in
+\begin{lstlisting}[language=modelica]
+model M_annotation
+  extends M;
+  import AnnotationEnumerations.*;
+  $\mathit{T}$ result = $\mathit{expr}$;
+end M_annotation;
+\end{lstlisting}
+where \lstinline!AnnotationEnumerations! is a hidden package containing all enumeration types used in annotations, and $\mathit{T}$ is the expected type of the expression.
+(Actual implementations will also need to avoid potential shadowing problems involving the names \lstinline!M_annotation! and \lstinline!result!.)
+\end{nonnormative}
+
 
 \section{Vendor-Specific Annotations}\label{vendor-specific-annotations}
 
@@ -49,6 +92,7 @@ annotation(
 \end{lstlisting}
 This introduces a new attribute \lstinline!__NameOfVendor_shadow! for the \lstinline!Rectangle! primitive using the simple variant of vendor-specific annotations.
 \end{example}
+
 
 \section{Documentation}\label{annotations-for-documentation}\label{documentation}
 
@@ -412,6 +456,7 @@ In a similar way, vendor-specific markup can be used to prototype a link for fut
 This is an example where the vendor-specific markup could make use of the $\mathit{text}$ (for link text) together with the vendor-specific $\mathit{data}$ (describing the actual link).
 \end{example}
 
+
 \section{Symbolic Processing}\label{annotations-for-symbolic-processing}\label{symbolic-processing}
 
 The annotation listed below, in addition to annotations described in \crefrange{derivatives-and-inverses-of-functions}{function-inlining-and-event-generation}, can influence the symbolic processing.
@@ -641,6 +686,7 @@ partial model MultiPort
 end MultiPort;
 \end{lstlisting}
 \end{example}
+
 
 \section{Graphical Objects}\label{annotations-for-graphical-objects}\label{graphical-objects}
 
@@ -1294,6 +1340,7 @@ record OnMouseDownEditString
 end OnMouseDownEditString;
 \end{lstlisting}
 
+
 \section{Graphical User Interface}\label{annotations-for-the-graphical-user-interface}\label{graphical-user-interface}
 
 This section describes the annotations that are used to define properties of the graphical user interface.
@@ -1645,6 +1692,7 @@ equation
   connect($\ldots$, step1.inPorts[4]);  // new connect-equation
 \end{lstlisting}
 \end{nonnormative}
+
 
 \section{Versions}\label{annotations-for-version-handling}\label{versions}
 
@@ -2045,6 +2093,7 @@ The \lstinline!versionBuild! and \lstinline!dateModified! annotations can also b
 \begin{nonnormative}
 It is recommended that tools do not automatically store \lstinline!versionBuild! and \lstinline!dateModified! in the \lstinline!uses! annotation.
 \end{nonnormative}
+
 
 \section{Access Control to Protect Intellectual Property}\label{annotations-for-access-control-to-protect-intellectual-property}\label{access-control-to-protect-intellectual-property}
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1813,19 +1813,19 @@ The predefined \lstinline!AssertionLevel!\indexinline{AssertionLevel} enumeratio
 type AssertionLevel = enumeration(warning, error);
 \end{lstlisting}
 
-\subsubsection{Connections}\label{connections}
+\subsubsection{Connections}
 
 The package \lstinline!Connections!\indexinline{Connections} is used for over-constrained connection graphs, \cref{equation-operators-for-overconstrained-connection-based-equation-systems}.
 
-\subsubsection{ExternalObject}\label{externalobject}
+\subsubsection{ExternalObject}
 
 See \cref{external-objects} for information about the predefined type \lstinline!ExternalObject!.
 
-\subsubsection{Clock Types}\label{clock-types}
+\subsubsection{Clock Types}
 
 See \cref{clocks-and-clocked-variables} and \cref{clock-constructors}.
 
-\subsubsection{Graphical Annotation Types}\label{graphical-annotation-types}
+\subsubsection{Graphical Annotation Types}
 
 A number of ``predefined'' record types and enumeration types for graphical annotations are described in \cref{annotations}.
 These types are not predefined in the usual sense since they cannot be referenced in ordinary Modelica code, only within annotations, see \cref{enumerations-for-use-in-annotations}.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1806,10 +1806,6 @@ type StateSelect = enumeration(
 );
 \end{lstlisting}
 
-\subsubsection{ExternalObject}\label{externalobject}
-
-See \cref{external-objects} for information about the predefined type \lstinline!ExternalObject!.
-
 \subsubsection{AssertionLevel}\label{assertionlevel}
 
 The predefined \lstinline!AssertionLevel!\indexinline{AssertionLevel} enumeration type is used together with \lstinline!assert!, \cref{assert}.
@@ -1821,11 +1817,15 @@ type AssertionLevel = enumeration(warning, error);
 
 The package \lstinline!Connections!\indexinline{Connections} is used for over-constrained connection graphs, \cref{equation-operators-for-overconstrained-connection-based-equation-systems}.
 
-\subsubsection{Graphical Annotation Types}\label{graphical-annotation-types}
+\subsubsection{ExternalObject}\label{externalobject}
 
-A number of ``predefined'' record types and enumeration types for graphical annotations are described in \cref{annotations}.
-These types are not predefined in the usual sense since they cannot be referenced in ordinary Modelica code, only within annotations.
+See \cref{external-objects} for information about the predefined type \lstinline!ExternalObject!.
 
 \subsubsection{Clock Types}\label{clock-types}
 
 See \cref{clocks-and-clocked-variables} and \cref{clock-constructors}.
+
+\subsubsection{Graphical Annotation Types}\label{graphical-annotation-types}
+
+A number of ``predefined'' record types and enumeration types for graphical annotations are described in \cref{annotations}.
+These types are not predefined in the usual sense since they cannot be referenced in ordinary Modelica code, only within annotations, see \cref{enumerations-for-use-in-annotations}.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1109,16 +1109,20 @@ prefixes are inherited, \cref{redeclaration}):
 \subsection{Annotations for Redeclaration and Modification}\label{annotation-choices-for-suggested-redeclarations-and-modifications}
 
 A declaration can have an annotation \fmtannotationindex{choices} containing modifiers on \lstinline!choice!, where each of them indicates a suitable redeclaration or modifications of the element.
+This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclarations, where the string comments on the \lstinline!choice! modifiers can be used as textual explanations of the choices.
+The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
+
+The string comments for the \lstinline!choice! modifiers shall not automatically be copied to the modifier.
+
+The semantic restrictions in \cref{semantic-restrictions-of-annotation-syntax} are not enforced for the \lstinline!choice! modifiers.
+For instance, several examples of using \lstinline!redeclare! inside \lstinline!choice($\ldots$)! will be given below.
+
 Lookup inside a \lstinline!choice! modifier is performed in the context of the annotation, meaning that references may need to be transformed to preserve the meaning when a \lstinline!choice! is applied in a different context.
 
 \begin{nonnormative}
 It is recommended to avoid expressions with references to elements that are not globally accessible, such as contents within a \lstinline!protected! section of a class.
 By starting names with a dot it can be ensured that no transformation of references will be needed when a \lstinline!choice! is applied, and that applicability of a \lstinline!choice! does not depend on context, see \cref{global-name-lookup}.
 \end{nonnormative}
-
-This is a hint for users of the model, and can also be used by the user interface to suggest reasonable redeclaration, where the string comments on the choice declaration can be used as textual explanations of the choices.
-The string comments for the choices shall not automatically be copied to the modifier.
-The annotation is not restricted to replaceable elements but can also be applied to non-replaceable elements, enumeration types, and simple variables.
 
 It is allowed to include choices that are invalid in some contexts, e.g., a value might violate a \lstinline!min!-attribute.
 (Options for tools encountering such choices include not showing them, marking them as invalid, or detecting the violations later.)


### PR DESCRIPTION
Fixes #3620.

For a better presentation, the content of _Other Predefined Types_ is reordered a bit, so that the true built-in enumeration types are presented next to each other, and the related but not truly built-in types are mentioned last.

To avoid merge conflicts, I also plan to address #3615 as part ot this PR.
