### PR TITLE
Add missing 'constant' for members of License

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -2290,12 +2290,12 @@ record Protection
   end Authorization;
 
   record License
-    /*literal*/ String licensee = "" "Optional string to show information about the licensee";
-    /*literal*/ String id[:] "Unique machine identifications, e.g., MAC addresses";
-    /*literal*/ String features[:] "Activated library license features";
-    /*literal*/ String startDate = "" "Optional start date in UTCformat YYYY-MM-DD";
-    /*literal*/ String expirationDate = "" "Optional expiration date in UTCformat YYYY-MM-DD";
-    /*literal*/ String operations[:] "Library usage conditions";
+    /*literal*/ constant String licensee = "" "Optional string to show information about the licensee";
+    /*literal*/ constant String id[:] "Unique machine identifications, e.g., MAC addresses";
+    /*literal*/ constant String features[:] "Activated library license features";
+    /*literal*/ constant String startDate = "" "Optional start date in UTCformat YYYY-MM-DD";
+    /*literal*/ constant String expirationDate = "" "Optional expiration date in UTCformat YYYY-MM-DD";
+    /*literal*/ constant String operations[:] "Library usage conditions";
   end License;
 end Protection;
 \end{lstlisting}%


### PR DESCRIPTION
Just a minor thing I stumbled upon when trying to make sense of these annotations.
