### PR TITLE
Let section title reflect that content also covers operators

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -198,7 +198,7 @@ The lower and upper index bounds for a dimension of an array indexed by \lstinli
 Regarding flexible array sizes and resizing of arrays in functions, see
 \cref{flexible-array-sizes-and-resizing-of-arrays-in-functions}.
 
-\section{Built-in Array Functions}\label{built-in-array-functions}
+\section{Built-in Array Operators and Functions}\label{built-in-array-functions}
 
 Modelica provides a number of built-in functions that are applicable to arrays.
 


### PR DESCRIPTION
This is a minor follow-up to #3600.
