### PR TITLE
Add cross references to the connection set rule regarding 'quantity'

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1511,6 +1511,8 @@ The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and c
 
 The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!unit!, \lstinline!displayUnit!, \lstinline!fixed!, and \lstinline!stateSelect!.
 
+The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
+
 The \lstinline!unit!- and \lstinline!displayUnit!-attributes may be either the empty string or a string matching \lstinline[language=grammar]!unit-expression! in \cref{unit-expressions}.
 The meaning of the empty string depends on the context.
 For the input and output components of a function, the empty string allows different units to be used in different calls to the function.
@@ -1553,6 +1555,8 @@ end Integer;
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
+The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
+
 The default \lstinline!min!- and \lstinline!max!-attributes are the minimum and maximum numbers of \lstinline!IntegerType!.
 The minimal recommended number range for \lstinline!IntegerType! is from -2147483648 to +2147483647, corresponding to a two's-complement 32-bit integer implementation.
 
@@ -1577,6 +1581,8 @@ end Boolean;
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
 
+The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
+
 The fallback value is \lstinline!false!.
 
 The default \lstinline!fixed!-attribute is \lstinline!true! for parameters and constants, and \lstinline!false! for other variables.
@@ -1597,6 +1603,8 @@ end String;
 \index{fixed@\robustinline{fixed}!attribute of \robustinline{String}}
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
+
+The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
 
 A \lstinline!StringType! value (such as $\langle\mathit{value}\rangle$ or other textual attributes of built-in types) may contain any Unicode data (and nothing else).
 
@@ -1726,6 +1734,8 @@ end E;
 \end{lstlisting}
 
 The following attributes shall be evaluable: \lstinline!quantity!, and \lstinline!fixed!.
+
+The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
 
 The fallback value is the \lstinline!min! bound.
 

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -597,8 +597,8 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
   \begin{nonnormative}
   Otherwise it would not be possible to deduce the causality for the expandable connector element.
   \end{nonnormative}
-\item
-  In a connection set all variables having non-empty quantity attribute must have the same quantity attribute.
+\item\label{connect-set-quantity-rule}\index{quantity@\robustinline{quantity}!connect set rule}
+  In a connection set, all variables having non-empty \lstinline!quantity!-attribute must have the same \lstinline!quantity!-attribute.
 \item
   A \lstinline!connect!-equation shall not (directly or indirectly) connect two connectors of \lstinline!outer! elements.
   \begin{nonnormative}


### PR DESCRIPTION
Filling a gap in the description of the built-in types, where the `quantity` was not explained at all, and also making the rule in which `quantity` is involved possible to find using the document index.
