### PR TITLE
Allow extends-clauses in package.order.

### DIFF
--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -220,10 +220,12 @@ If directory \filename{A} contains the three files \filename{package.mo}, \filen
 A directory shall not contain both the sub-directory \filename{A} and the file \filename{A.mo}.
 \end{example}
 
-In order to preserve the order of sub-entities it is advisable to create a file \filename{package.order} where each line contains the name of one class or constant (using its Modelica \lstinline!IDENT! form).
-If a \filename{package.order} is present when reading a structured entity the classes and constants are added in this order; if the contents does not exactly match the classes and constants in the package, the resulting order is tool specific and a warning may be given.
+In order to preserve the order of sub-entities it is advisable to create a file \filename{package.order} where each line contains the name of one class, constant (using its Modelica \lstinline!IDENT! form), or \lstinline!extends!-clause (in the form \lstinline!extends A.B! -- one space, no semicolon).
+If a \filename{package.order} is present when reading a structured entity the classes, constants, and optionally \lstinline!extends!-clauses are added in this order; if the contents does not exactly match the classes and constants in the package, the resulting order is tool specific and a warning may be given.
+The relative order of classes, constants, and optionally \lstinline!extends!-clauses that are stored in \filename{package.mo} must be consistent with the relative order of the corresponding entries in \filename{package.order} (that is, the \filename{package.order} only adds information regarding the ordering of classes not stored in \filename{package.mo}).
 Classes and constants that are stored in \filename{package.mo} are also present in \filename{package.order} but their relative order should be identical to the one in \filename{package.mo} (this ensures that the relative order between classes and constants stored in different ways is preserved).
-Any extends-clause (stored in \filename{package.mo}) may be present in \filename{package.order} in the form \lstinline!extends A.B! (one space, no semicolon), but should be omitted if the extends-clause(s) precedes normal classes.
+An \lstinline!extends!-clause entry shall be omitted from \filename{package.order} if it would appear before any class not stored in \filename{package.mo}.
+If an \lstinline!extends!-clause is missing from \filename{package.order} it shall be added at the first position consistent the order in \filename{package.mo}.
 
 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -225,7 +225,7 @@ If a \filename{package.order} is present when reading a structured entity the cl
 The relative order of classes, constants, and optionally \lstinline!extends!-clauses that are stored in \filename{package.mo} must be consistent with the relative order of the corresponding entries in \filename{package.order} (that is, the \filename{package.order} only adds information regarding the ordering of classes not stored in \filename{package.mo}).
 Classes and constants that are stored in \filename{package.mo} are also present in \filename{package.order} but their relative order should be identical to the one in \filename{package.mo} (this ensures that the relative order between classes and constants stored in different ways is preserved).
 An \lstinline!extends!-clause entry shall be omitted from \filename{package.order} if it would appear before any class not stored in \filename{package.mo}.
-If an \lstinline!extends!-clause is missing from \filename{package.order} it shall be added at the first position consistent the order in \filename{package.mo}.
+If an \lstinline!extends!-clause is missing from \filename{package.order} it shall be added at the first position consistent with the order in \filename{package.mo}.
 
 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -223,6 +223,7 @@ A directory shall not contain both the sub-directory \filename{A} and the file \
 In order to preserve the order of sub-entities it is advisable to create a file \filename{package.order} where each line contains the name of one class or constant (using its Modelica \lstinline!IDENT! form).
 If a \filename{package.order} is present when reading a structured entity the classes and constants are added in this order; if the contents does not exactly match the classes and constants in the package, the resulting order is tool specific and a warning may be given.
 Classes and constants that are stored in \filename{package.mo} are also present in \filename{package.order} but their relative order should be identical to the one in \filename{package.mo} (this ensures that the relative order between classes and constants stored in different ways is preserved).
+Any extends-clause (stored in \filename{package.mo}) may be present in \filename{package.order} in the form \lstinline!extends A.B! (one space, no semicolon), but should be omitted if the extends-clause(s) precede normal classes.
 
 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -223,7 +223,7 @@ A directory shall not contain both the sub-directory \filename{A} and the file \
 In order to preserve the order of sub-entities it is advisable to create a file \filename{package.order} where each line contains the name of one class or constant (using its Modelica \lstinline!IDENT! form).
 If a \filename{package.order} is present when reading a structured entity the classes and constants are added in this order; if the contents does not exactly match the classes and constants in the package, the resulting order is tool specific and a warning may be given.
 Classes and constants that are stored in \filename{package.mo} are also present in \filename{package.order} but their relative order should be identical to the one in \filename{package.mo} (this ensures that the relative order between classes and constants stored in different ways is preserved).
-Any extends-clause (stored in \filename{package.mo}) may be present in \filename{package.order} in the form \lstinline!extends A.B! (one space, no semicolon), but should be omitted if the extends-clause(s) precede normal classes.
+Any extends-clause (stored in \filename{package.mo}) may be present in \filename{package.order} in the form \lstinline!extends A.B! (one space, no semicolon), but should be omitted if the extends-clause(s) precedes normal classes.
 
 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}


### PR DESCRIPTION
Closes #3438

The reasons for not making it more required are:
- For backwards compatibility reasons we should be able to read packages where "package.order" doesn't include extends.
- If extends-clauses must be included in "package.order" tools would anyway need a compatibility setting when working with libraries using an older version.
Thus it makes sense that we only add them when needed.