### PR TITLE
Remove empty rest-of-line comment in listing

### DIFF
--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -218,7 +218,7 @@ class A
     class C
       Real TI;
       class D
-        outer Real TI; //
+        outer Real TI;
       end D;
       D d;
     end C;


### PR DESCRIPTION
Removing the comment is the simple solution.  Alternatively, we could figure out what to say in the comment.
