### PR TITLE
Make it explicit that tools can show the value of variables for asserts

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -521,9 +521,7 @@ assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 
 It is recommended that asserts have a simple message as above, formulated with the recommended tool behavior in mind.
-Tools are recommended to include the failed condition in the message.
-Tools are also (especially for literal strings) recommended to automatically include the values of relevant variables, as part of the log or interactively accessible.
-Writing \lstinline!assert(T<500, "Temperature = "+String(T)+" was above 500");! is thus not recommended, and is likely to lead to duplicated information -- although tools may have specific compatibility handling of such cases.
+Writing \lstinline!assert(T<500, "Temperature = "+String(T)+" was above 500")! is thus not recommended, and is likely to lead to duplicated information.
 \end{nonnormative}
 
 \subsection{terminate}\label{terminate}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -521,7 +521,8 @@ assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 
 It is recommended that models have a simple message as above and not include the value of any variables (like \lstinline!T!) in the message given to \lstinline!assert!.
-Tools are (especially for simple messages) recommended to automatically include the values of relevant variables, as part of the log or interactively.
+Tools are (especially for simple messages) recommended to automatically include the values of relevant variables, as part of the log or interactively accessible.
+Similarly tools are recommended to include the failed condition.
 \end{nonnormative}
 
 \subsection{terminate}\label{terminate}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -506,6 +506,7 @@ If the \lstinline!condition! evaluates to false, different actions are taken dep
   \lstinline!condition! needs to be implicitly treated with \lstinline!noEvent! since otherwise events might be triggered that can lead to slightly changed simulation results.
   \end{nonnormative}
 \end{itemize}
+Tools may show more than the message for failed assertions, in particular the condition and the values of any variables used in it.
 
 \begin{nonnormative}
 The \lstinline!AssertionLevel.error! case can be used to avoid evaluating a model outside its limits of validity; for instance, a function to compute the saturated liquid temperature cannot be called with a pressure lower than the triple point value.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -506,7 +506,7 @@ If the \lstinline!condition! evaluates to false, different actions are taken dep
   \lstinline!condition! needs to be implicitly treated with \lstinline!noEvent! since otherwise events might be triggered that can lead to slightly changed simulation results.
   \end{nonnormative}
 \end{itemize}
-Tools may show more than the message for failed assertions, in particular the condition and the values of any variables used in it.
+Tools are recommended to provide more information than just the given message of a failed assertion, in particular the condition and the values of variables used in it.
 
 \begin{nonnormative}
 The \lstinline!AssertionLevel.error! case can be used to avoid evaluating a model outside its limits of validity; for instance, a function to compute the saturated liquid temperature cannot be called with a pressure lower than the triple point value.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -519,6 +519,9 @@ assert(T > 250 and T < 400, "Medium model outside full accuracy range",
        AssertionLevel.warning);
 assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
+
+It is recommended that models have a simple message as above and not include the value of any variables (like \lstinline!T!) in the message given to \lstinline!assert!.
+Tools are (especially for simple messages) recommended to automatically include the values of relevant variables, as part of the log or interactively.
 \end{nonnormative}
 
 \subsection{terminate}\label{terminate}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -520,7 +520,7 @@ assert(T > 250 and T < 400, "Medium model outside full accuracy range",
 assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 
-It is recommended that models have a simple message as above and not include the value of any variables (like \lstinline!T!) in the message given to \lstinline!assert!.
+It is recommended that asserts have a simple message as above, formulated with the recommended tool behavior in mind.
 Tools are (especially for simple messages) recommended to automatically include the values of relevant variables, as part of the log or interactively accessible.
 Similarly tools are recommended to include the failed condition.
 \end{nonnormative}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -521,8 +521,9 @@ assert(T > 200 and T < 500, "Medium model outside feasible region");
 \end{lstlisting}
 
 It is recommended that asserts have a simple message as above, formulated with the recommended tool behavior in mind.
-Tools are (especially for simple messages) recommended to automatically include the values of relevant variables, as part of the log or interactively accessible.
-Similarly tools are recommended to include the failed condition.
+Tools are recommended to include the failed condition in the message.
+Tools are also (especially for literal strings) recommended to automatically include the values of relevant variables, as part of the log or interactively accessible.
+Writing \lstinline!assert(T<500, "Temperature = "+String(T)+" was above 500");! is thus not recommended, and is likely to lead to duplicated information -- although tools may have specific compatibility handling of such cases.
 \end{nonnormative}
 
 \subsection{terminate}\label{terminate}


### PR DESCRIPTION
See: 
https://github.com/modelica/ModelicaStandardLibrary/pull/4519 and https://github.com/modelica/ModelicaStandardLibrary/issues/4399 for background.

The reason for "may" is:
- To not require the value to be duplicated, for cases such as: https://github.com/modelica/ModelicaStandardLibrary/issues/4399
- Support even smarter debugging.

I thought it was sufficiently important to make it normative.