### PR TITLE
Make absoluteValue inferred by default

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1531,7 +1531,8 @@ inner replaceable World world;
 Allowed for simple types and components of a simple types.
 If \lstinline!false!, then the component defines a relative quantity, and if \lstinline!true! an absolute quantity.
 When converting between units (e.g., in plots and where parameters are edited), the unit offset must be ignored for relative quantities.
-The annotation is inherited in the sense that when \lstinline!absoluteValue! is defined for a simple type, it also applies to components declared with the type, as well as derived classes.
+The annotation is inherited in the sense that when \lstinline!absoluteValue! is defined for a simple type, it also applies derived classes.
+When \lstinline!absoluteValue! is defined for a simple type, it also applies to components declared with the type.
 
 When \lstinline!absoluteValue! of a component is not determined by an annotation (possibly through inheritance), the \lstinline!absoluteValue! status may be inferred by the tool.
 If the \lstinline!absoluteValue! of a component is neither determined by annotation nor inference, unit conversions that would differ depending on \lstinline!absoluteValue! cannot be performed.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1481,9 +1481,10 @@ A simple type or component of a simple type may have:
 \annotationindex{absoluteValue}
 
 If \lstinline!false!, then the component defines a relative quantity, and if \lstinline!true! an absolute quantity.
-By default, the \lstinline!absoluteValue! status is inferred by the tool.
-
 When converting between units (e.g., in plots and where parameters are edited), the unit offset must be ignored for relative quantities.
+The annotation is inherited in the sense that when \lstinline!absoluteValue! is defined for a simple type, it also applies to components declared with the type, as well as derived classes.
+
+When \lstinline!absoluteValue! of a component is not determined by an annotation (possibly through inheritance), the \lstinline!absoluteValue! status may be inferred by the tool.
 If the \lstinline!absoluteValue! of a component is neither determined by annotation nor inference, unit conversions that would differ depending on \lstinline!absoluteValue! cannot be performed.
 
 \begin{nonnormative}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1476,16 +1476,20 @@ inner replaceable World world;
 
 A simple type or component of a simple type may have:
 \begin{lstlisting}[language=modelica]
-/*literal*/ constant Boolean absoluteValue = true;
+/*literal*/ constant Boolean absoluteValue;
 \end{lstlisting}%
 \annotationindex{absoluteValue}
 
-If \lstinline!false!, then the variable defines a relative quantity, and if \lstinline!true! an absolute quantity.
+If \lstinline!false!, then the component defines a relative quantity, and if \lstinline!true! an absolute quantity.
+By default, the \lstinline!absoluteValue! status is inferred by the tool.
+
+When converting between units (e.g., in plots and where parameters are edited), the unit offset must be ignored for relative quantities.
+If the \lstinline!absoluteValue! of a component is neither determined by annotation nor inference, unit conversions that would differ depending on \lstinline!absoluteValue! cannot be performed.
 
 \begin{nonnormative}
-When converting between units (in the user-interface for plotting and entering parameters), the unit offset must be ignored for a variable defined with annotation \lstinline!absoluteValue = false!.
-This annotation is used in the Modelica Standard Library, for example in \lstinline!Modelica.Units.SI! for the type definition \lstinline!TemperatureDifference!.
-For most types there is no unit offset and the annotation is not needed for them.
+For most quantities there are no units with offset, and the annotation is not needed.
+For a component where unit conversions involving offsets could be of interest (mainly temperatures), ensuring that \lstinline!absoluteValue! is determined by an annotation (typically by means of using a type where it has been specified) may reduce impact of quality-of-implementation in tool ability to infer \lstinline!absoluteValue!.
+Example applications of this annotation can be found among the type definitions in the \lstinline!Modelica.Units! package of the Modelica Standard Library, such as \lstinline!TemperatureDifference!.
 \end{nonnormative}
 
 A model or block definition may contain:


### PR DESCRIPTION
Based on discussion in #3631.

This restores the [Modelica 3.6 (latest release) situation](https://specification.modelica.org/maint/3.6/annotations.html#annotations-for-the-graphical-user-interface) of the `absoluteValue`-annotation not having a constant default value. The difference to the 3.6 situation is that the default behavior is described in the text, as being tool inference.  Similar to unit checking, the specification does not give details about how the inference shall be performed.

Without directly recommending for or against explicit use of `absoluteValue`, the non-normative text is still biased by only explaining possible consequences of leaving it out, and not mentioning the drawbacks of over-specifying.  This is meant to be a compromise between fear of problems when using tools that don't have good inference, and fear of pedantic/ambitious library authors putting the annotation all over their libraries in ways that might do more harm than good when using tools with good inference.

Fixes #3631.
