### PR TITLE
Add min, max where appropriate.

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -443,7 +443,7 @@ The mathematical functions and conversion operators listed below do not generate
 \end{center}
 
 Except for the \lstinline!min!, \lstinline!max! and the \lstinline!String! conversion operator they are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
-The \lstinline!min! and \lstinline!max! functions including additional variants are described in \cref{reduction-functions-and-operators}.
+The \lstinline!min! and \lstinline!max! functions have array-specific variants which perform array reduction operations described in \cref{reduction-functions-and-operators}.
 
 Additional non-event generating mathematical functions are described in \cref{built-in-mathematical-functions-and-external-built-in-functions}, whereas the event-triggering mathematical functions are described in \cref{event-triggering-mathematical-functions}.
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -431,8 +431,8 @@ The mathematical functions and conversion operators listed below do not generate
 \hline
 {\lstinline!abs($v$)!} & Absolute value (event-free) & \Cref{modelica:abs} \\
 {\lstinline!sign($v$)!} & Sign of argument (event-free) & \Cref{modelica:sign} \\
-{\lstinline!min($x$, $y$)!} & Least of two scalars & \Cref{modelica:min-binary} \\
-{\lstinline!max($x$, $y$)!} & Greatest of two scalars & \Cref{modelica:max-binary} \\
+{\lstinline!min($x$, $y$)!} & Least of two scalars (event-free) & \Cref{modelica:min-binary} \\
+{\lstinline!max($x$, $y$)!} & Greatest of two scalars (event-free) & \Cref{modelica:max-binary} \\
 {\lstinline!sqrt($v$)!} & Square root & \Cref{modelica:sqrt} \\
 {\lstinline!nthRoot($v$, $n$)!} & $n$th root & \Cref{modelica:nthRoot} \\
 {\lstinline!Integer($e$)!} & Conversion from enumeration to {\lstinline!Integer!} & \Cref{modelica:integer-of-enumeration} \\

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -431,6 +431,8 @@ The mathematical functions and conversion operators listed below do not generate
 \hline
 {\lstinline!abs($v$)!} & Absolute value (event-free) & \Cref{modelica:abs} \\
 {\lstinline!sign($v$)!} & Sign of argument (event-free) & \Cref{modelica:sign} \\
+{\lstinline!min($x$, $y$)!} & Least of two scalars & \Cref{modelica:min-binary} \\
+{\lstinline!max($x$, $y$)!} & Greatest of two scalars & \Cref{modelica:max-binary} \\
 {\lstinline!sqrt($v$)!} & Square root & \Cref{modelica:sqrt} \\
 {\lstinline!nthRoot($v$, $n$)!} & $n$th root & \Cref{modelica:nthRoot} \\
 {\lstinline!Integer($e$)!} & Conversion from enumeration to {\lstinline!Integer!} & \Cref{modelica:integer-of-enumeration} \\
@@ -440,7 +442,8 @@ The mathematical functions and conversion operators listed below do not generate
 \end{tabular}
 \end{center}
 
-All of these except for the \lstinline!String! conversion operator are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
+Except for the \lstinline!min!, \lstinline!max! and the \lstinline!String! conversion operator they are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
+The \lstinline!min! and \lstinline!max! functions including additional variants are described in \cref{reduction-functions-and-operators}.
 
 Additional non-event generating mathematical functions are described in \cref{built-in-mathematical-functions-and-external-built-in-functions}, whereas the event-triggering mathematical functions are described in \cref{event-triggering-mathematical-functions}.
 


### PR DESCRIPTION
Closes #3650

I'm not sure if using the table in this way is ideal, if not I could see us adding a short description in chapter 3.7 forwarding to the other variant. I don't think that moving those two variants, and duplicating the actual definition would be bad.