### PR TITLE
Change to proper function declarations for ModelicaUtilities.h

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2539,9 +2539,9 @@ The \emph{Error}-functions never return to the calling function, but handle the 
 \begin{functiondefinition*}[ModelicaMessage, ModelicaWarning, ModelicaError]\label{modelica:ModelicaMessage-et-al}%
 \indexinline{ModelicaMessage}\indexinline{ModelicaWarning}\indexinline{ModelicaError}
 \begin{synopsis}[C]\begin{lstlisting}
-void ModelicaMessage(const char* $\mathit{string}$)
-void ModelicaWarning(const char* $\mathit{string}$)
-void ModelicaError(const char* $\mathit{string}$)
+void ModelicaMessage(const char* $\mathit{string}$);
+void ModelicaWarning(const char* $\mathit{string}$);
+void ModelicaError(const char* $\mathit{string}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Output the fixed message string (no format control).
@@ -2553,9 +2553,9 @@ Output the fixed message string (no format control).
 \begin{synopsis}[C]
 % Note that the "..." below are actual C code, and shouldn't be typeset as \ldots.
 \begin{lstlisting}
-void ModelicaFormatMessage(const char* $\mathit{format}$, ...)
-void ModelicaFormatWarning(const char* $\mathit{format}$, ...)
-void ModelicaFormatError(const char* $\mathit{format}$, ...)
+void ModelicaFormatMessage(const char* $\mathit{format}$, ...);
+void ModelicaFormatWarning(const char* $\mathit{format}$, ...);
+void ModelicaFormatError(const char* $\mathit{format}$, ...);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Output the message under the same format control as the C function {\lstinline[language=C]!printf!}.
@@ -2565,9 +2565,9 @@ Output the message under the same format control as the C function {\lstinline[l
 \begin{functiondefinition*}[ModelicaVFormatMessage, ModelicaVFormatWarning, ModelicaVFormatError]\label{modelica:ModelicaVFormatMessage-et-al}%
 \indexinline{ModelicaVFormatMessage}\indexinline{ModelicaVFormatWarning}\indexinline{ModelicaVFormatError}
 \begin{synopsis}[C]\begin{lstlisting}
-void ModelicaVFormatMessage(const char* $\mathit{format}$, va_list $\mathit{ap}$)
-void ModelicaVFormatWarning(const char* $\mathit{format}$, va_list $\mathit{ap}$)
-void ModelicaVFormatError(const char* $\mathit{format}$, va_list $\mathit{ap}$)
+void ModelicaVFormatMessage(const char* $\mathit{format}$, va_list $\mathit{ap}$);
+void ModelicaVFormatWarning(const char* $\mathit{format}$, va_list $\mathit{ap}$);
+void ModelicaVFormatError(const char* $\mathit{format}$, va_list $\mathit{ap}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Output the message under the same format control as the C function {\lstinline[language=C]!vprintf!}.
@@ -2602,7 +2602,7 @@ Memory that is not passed to the Modelica simulation environment, such as memory
 
 \begin{functiondefinition}[ModelicaAllocateString]
 \begin{synopsis}[C]\begin{lstlisting}
-char* ModelicaAllocateString(size_t $\mathit{len}$)
+char* ModelicaAllocateString(size_t $\mathit{len}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Allocates $\mathit{len}+1$ characters, and sets the last one to \textsc{nul}.
@@ -2612,7 +2612,7 @@ If an error occurs, this function does not return, but calls {\lstinline[languag
 
 \begin{functiondefinition}[ModelicaAllocateStringWithErrorReturn]
 \begin{synopsis}[C]\begin{lstlisting}
-char* ModelicaAllocateStringWithErrorReturn(size_t $\mathit{len}$)
+char* ModelicaAllocateStringWithErrorReturn(size_t $\mathit{len}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Same as {\lstinline[language=C]!ModelicaAllocateString!}, except that in case of error, the function returns 0.
@@ -2623,7 +2623,7 @@ After cleaning up resources, use {\lstinline[language=C]!ModelicaError!} or {\ls
 
 \begin{functiondefinition}[ModelicaDuplicateString]
 \begin{synopsis}[C]\begin{lstlisting}
-char* ModelicaDuplicateString(const char* $\mathit{str}$)
+char* ModelicaDuplicateString(const char* $\mathit{str}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Returns a writeable duplicate of the \textsc{nul}-terminated string $\mathit{str}$.
@@ -2633,7 +2633,7 @@ If an error occurs, this function does not return, but calls {\lstinline[languag
 
 \begin{functiondefinition}[ModelicaDuplicateStringWithErrorReturn]
 \begin{synopsis}[C]\begin{lstlisting}
-char* ModelicaDuplicateStringWithErrorReturn(const char* $\mathit{str}$)
+char* ModelicaDuplicateStringWithErrorReturn(const char* $\mathit{str}$);
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Same as {\lstinline[language=C]!ModelicaDuplicateString!}, except that in case of error, the function returns 0.


### PR DESCRIPTION
So that they are not mistaken for the start of functions definitions.

As discussed in https://github.com/modelica/ModelicaStandardLibrary/issues/4484#issuecomment-2657722744 I think we should use function declarations when we discuss the contents of a header-file and not something that is the start of either a function definition or a function declaration.

Obviously they will be defined somewhere, but not in the header-file.
(I didn't change the tables, as they look like function calls.)