### PR TITLE
Allow deselection partial classes.

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -1240,6 +1240,7 @@ A connection \lstinline!connect(c, d)!, with \lstinline!c! and \lstinline!d! arb
 Two code fragments \lstinline!a! and \lstinline!c! are syntactically equivalent, if, and only if, the context-free derivations of \lstinline!a! and \lstinline!c! according to the grammar given in \cref{expressions1} are the same.
 \end{itemize}
 \item Conditionally declared components of \lstinline!B! are assumed to be declared for all purposes of matching.
+\item The deselected component may be of a partial class even in a simulation model.
 \item The deselection \lstinline!break $D$! must match at least one element of \lstinline!B!.
 \item The component deselection are applied before the connection deselections of the same \lstinline!extends!-clause.
 \end{enumerate}
@@ -1309,6 +1310,7 @@ An instance tree is not required.
 \item Conditional components can be deselected without evaluating whether they are disabled or not.
 In particular deselecting a disabled conditional component is not an error.
 Connections involving the deselected conditional component are by the deselection removed as for a disabled component.
+\item No need to check whether the class of the deselected component was partial.
 \item Assuming the deselections are semantically valid they can be handled in any order.
 Handling component deselections before connection deselections is only necessary to semantically check that a connection deselection does not involve a deselected component.
 \end{itemize}


### PR DESCRIPTION
The basic issue are:
- It was a bit unclear
- Without this rule one has to introduce an intermediate level to be sure (see below), which is just weird.
- One has to check whether a class is partial, even if it is isn't used

Old work-around:
```
model MyAmazingClass
  extends AExtra(break b);
end MyAmazingClass;
model AExtra "Work-around"
  extends A(redeclare B b);
end AExtra;
```

New without work-around:
```
model MyAmazingClass
  extends A(break b);
end MyAmazingClass;
```

with:
```
model A
  replaceable PartialB b;
end A;
partial model PartialB end PartialB;
model B
  extends PartialB;
end B;
```