### PR TITLE
Add example about empty annotations

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -29,6 +29,16 @@ When an annotation is defined with a component variability prefix (\cref{compone
 If the annotation is declared as an \lstinline!/*evaluable*/ parameter! the corresponding modifier is further restricted to be evaluable.
 If the annotation is declared as a \lstinline!/*literal*/ constant! the corresponding modifier is further restricted to be a literal value.
 
+\begin{example}
+Since the semantics of an annotation comes from the interpretation as a modification, empty annotations have no impact at all.
+For example, these are both allowed, but meaningless:
+\begin{lstlisting}[language=modelica]
+annotation(Dialog());
+
+annotation(Dialog);
+\end{lstlisting}
+\end{example}
+
 
 \section{Semantic Restrictions of Annotation Syntax}\label{semantic-restrictions-of-annotation-syntax}
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -31,12 +31,15 @@ If the annotation is declared as a \lstinline!/*literal*/ constant! the correspo
 
 \begin{example}
 Since the semantics of an annotation comes from the interpretation as a modification, empty annotations have no impact at all.
-For example, these are both allowed, but meaningless:
+For example, these are all allowed, but meaningless:
 \begin{lstlisting}[language=modelica]
-annotation(Dialog());
-
-annotation(Dialog);
+annotation(
+  Dialog(),
+  Dialog,
+  Dialog(colorSelector)
+);
 \end{lstlisting}
+In particular, the effect of \lstinline!colorSelector! is not the same as \lstinline!colorSelector = true!, even though the latter is the only meaningful use of \lstinline!colorSelector!.
 \end{example}
 
 

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -31,15 +31,11 @@ If the annotation is declared as a \lstinline!/*literal*/ constant! the correspo
 
 \begin{example}
 Since the semantics of an annotation comes from the interpretation as a modification, empty annotations have no impact at all.
-For example, these are all allowed, but meaningless:
+For example, the following is allowed, but meaningless:
 \begin{lstlisting}[language=modelica]
-annotation(
-  Dialog(),
-  Dialog,
-  Dialog(colorSelector)
-);
+annotation(Dialog());
 \end{lstlisting}
-In particular, the effect of \lstinline!colorSelector! is not the same as \lstinline!colorSelector = true!, even though the latter is the only meaningful use of \lstinline!colorSelector!.
+An annotation such as \lstinline!annotation(Dialog)! is also meaningless, but deprecated according to \cref{semantic-restrictions-of-annotation-syntax}.
 \end{example}
 
 
@@ -61,7 +57,21 @@ In particular, the keyword \lstinline!redeclare! cannot be used.
 \item
 \lstinline[language=grammar]!element-replaceable! in the grammar.
 In particular the keywords \lstinline!replaceable! and \lstinline!constrainedby! cannot be used.
+\item
+A \lstinline[language=grammar]!element-modification! without \lstinline[language=grammar]!modification! is deprecated without exceptions.
+The meaning of such annotations has never been defined.
 \end{itemize}
+
+\begin{example}
+The following annotations are not merely meaningless, but deprecated:
+\begin{lstlisting}[language=modelica]
+annotation(
+  Dialog,
+  Dialog(colorSelector)
+);
+\end{lstlisting}
+In particular, the effect of \lstinline!colorSelector! is not the same as \lstinline!colorSelector = true!, even though the latter is the only meaningful use of \lstinline!colorSelector!.
+\end{example}
 
 
 \section{Expression Evaluation Inside Annotations}\label{expression-evaluation-inside-annotations}


### PR DESCRIPTION
Fixes #2852.

I think we have now reached a point where all we need to close #2852 is this example.
