### PR TITLE
Add connectorSizing to document index

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1717,7 +1717,7 @@ When clicking on an instance of model \lstinline!DialogDemo!, a dialog is shown 
 \end{semantics}
 \end{annotationdefinition}
 
-\subsection{Connector Sizing}\label{connector-sizing}
+\subsection{Connector Sizing}\label{connector-sizing}\annotationindex{connectorSizing}
 
 This section describes the \lstinline!connectorSizing! annotation inside a \lstinline!Dialog! annotation.
 The value of \lstinline!connectorSizing! must be a literal \lstinline!false! or \lstinline!true!.

--- a/mlsshared.sty
+++ b/mlsshared.sty
@@ -185,7 +185,7 @@
 }[keywords,comments,strings,directives]
 
 \lstdefinelanguage{CSS}{
-      keywords={},  
+      keywords={},
       sensitive=true,
       morecomment=[l]{//},
       morecomment=[s]{/*}{*/},


### PR DESCRIPTION
On behalf of @maltelenz.  While it feels somewhat inconsistent to not add all members of all annotation records to the document index, I can see that things like `connectorSizing` which have their own dedicated sections in the text may be considered more relevant for the document index than other annotation record members.
