### PR TITLE
Clarify acyclic for record equations

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -282,7 +282,7 @@ Further details on how the prefixes relate to component variability, as well as 
 
 For a constant or parameter \lstinline!v! with declaration equation, the expression of the declaration equation in the flattended model must not depend on \lstinline!v! itself, neither directly nor indirectly via other variables' declaration equations.
 To satisfy this condition, dependencies shall be removed as needed by applying simplifications based on values of constants (except with \lstinline!Evaluate = false!) and all other \willintroduce{evaluable parameters} (\cref{component-variability}) that don't depend on \lstinline!v!.
-It is not permitted to expand a non-scalar declaration equation into scalar equations to satisfy the condition.
+It is not permitted to expand a record and/or non-scalar declaration equation into scalar equations to satisfy the condition.
 
 That the value of an evaluable parameter is used for these simplifications does not mean that it has to be determined during translation, but if \lstinline!v! is found to be an evaluable parameter, then a Modelica tool will be able to break all cycles involving \lstinline!v! by making some (possibly none or all) of the other evaluable parameters determined during translation.
 Hence, evaluation of a constant or evaluable parameter can never require solving systems of equations; they can always be sorted so that they can be solved one at a time with the natural causality (i.e., the declaration equation is used to determine the value of the component to which it belongs).


### PR DESCRIPTION
I think this just clarifies the current text which had "expand into scalar equations"; but didn't consider that the original could be a record equation. 
I don't see a need to specify something special for inlining as it is just one case of expanding - and the current text also prohibits `parameter Real a=cat(1,a[2:end],{1}); `
We could change to "into e.g., scalar equations" - but it seems a bit excessive. 
Closes #3662