### PR TITLE
Fix Merging of Modifications example explanation

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -347,6 +347,9 @@ class C3
   extends C2;
 end C3;
 \end{lstlisting}
+The modification environment of the declaration of \lstinline!t! is
+(\lstinline!x = 3!).
+
 The following example demonstrates overriding part of non-simple component:
 \begin{lstlisting}[language=modelica]
 record A
@@ -363,8 +366,7 @@ model C
 end C;
 \end{lstlisting}
 
-The modification environment of the declaration of \lstinline!t! is
-(\lstinline!x = 3!). The modification environment is built by merging class modifications, as shown by:
+The modification environment is built by merging class modifications, as shown by:
 \begin{lstlisting}[language=modelica]
 class C1
   parameter Real a;


### PR DESCRIPTION
Move an example explanation from its current location after the 2nd example in the Merging of Modifications subsection to the 1st example where it actually applies.