### PR TITLE
Sentence-based line breaks and small fixes in inheritance.tex

### DIFF
--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -6,6 +6,7 @@ In this process, the data and behavior of the original class in the form of vari
 In fact, the inherited contents is copied from the superclass into the derived class, but before copying certain operations, such as type expansion, checking, and modification, are performed on the inherited contents when appropriate.
 This chapter describes the inheritance concept in Modelica, together with the related concepts modification and redeclaration.
 
+
 \section{Inheritance -- Extends Clause}\label{inheritance-extends-clause}
 
 The class \lstinline!A! is called a \firstuse{base class} of \lstinline!B!, if \lstinline!B! extends \lstinline!A!.
@@ -73,19 +74,14 @@ yields an instance with \lstinline!bcomp.b = 3!, which overrides \lstinline!b = 
 The declaration elements of the flattened base class shall either:
 \begin{itemize}
 \item
-  Not already exist in the partially flattened enclosing class
-  (i.e., have different names).
+  Not already exist in the partially flattened enclosing class (i.e., have different names).
 \item
   The new element is a long form of redeclare or uses the \lstinline!class extends A! syntax, see \cref{redeclaration}.
 \item
-  Be exactly identical to any element of the flattened enclosing class
-  with the same name and the same level of protection (public or
-  protected) and same contents. In this case, the first element in order
-  (can be either inherited or local) is kept. It is recommended to give
-  a warning for this case; unless it can be guaranteed that the
-  identical contents will behave in the same way.
+  Be exactly identical to any element of the flattened enclosing class with the same name and the same level of protection (public or protected) and same contents.
+  In this case, the first element in order (can be either inherited or local) is kept.
+  It is recommended to give a warning for this case; unless it can be guaranteed that the identical contents will behave in the same way.
 \end{itemize}
-
 Otherwise the model is incorrect.
 
 \begin{nonnormative}
@@ -104,15 +100,13 @@ end B;
 \end{lstlisting}
 \end{nonnormative}
 
-Equations of the flattened base class that are syntactically equivalent
-to equations in the flattened enclosing class are discarded. This
-feature is deprecated, and it is recommended to give a warning when
-discarding them and for the future give a warning about all forms of
-equivalent equations due to inheritance.
+Equations of the flattened base class that are syntactically equivalent to equations in the flattened enclosing class are discarded.
+This feature is deprecated, and it is recommended to give a warning when discarding them and for the future give a warning about all forms of equivalent equations due to inheritance.
 
 \begin{nonnormative}
 Equations that are mathematically equivalent but not syntactically equivalent are not discarded, hence yield an overdetermined system of equations.
 \end{nonnormative}
+
 
 \subsection{Multiple Inheritance}\label{multiple-inheritance}
 
@@ -122,11 +116,13 @@ Multiple inheritance is possible since multiple \lstinline!extends!-clauses can 
 As stated in \cref{the-inherited-contents-of-the-element}, it is illegal for an \lstinline!extends!-clause to influence the lookup of the class name of any \lstinline!extends!-clause in the same class definition.
 \end{nonnormative}
 
+
 \subsection{Inheritance of Protected and Public Elements}\label{inheritance-of-protected-and-public-elements}
 
 If an \lstinline!extends!-clause is used under the \lstinline!protected! heading, all elements of the base class become protected elements of the current class.
 If an \lstinline!extends!-clause is a public element, all elements of the base class are inherited with their own protection.
 The eventual headings \lstinline!protected! and \lstinline!public! from the base class do not affect the consequent elements of the current class (i.e., headings \lstinline!protected! and \lstinline!public! are not inherited).
+
 
 \subsection{Restrictions on the Kind of Base Class}\label{restrictions-on-the-kind-of-base-class}
 
@@ -177,8 +173,7 @@ The following table shows which kind of specialized class can be used in an \lst
 \ifpdf}\else\fi%
 \end{center}
 
-If a derived class is inherited from another type of specialized class,
-then the result is a specialized class of the derived class type.
+If a derived class is inherited from another type of specialized class, then the result is a specialized class of the derived class type.
 
 \begin{nonnormative}
 For example, if a \lstinline!block! inherits from a \lstinline!record!, then the result is a \lstinline!block!.
@@ -191,10 +186,7 @@ A \lstinline!class! may only contain class definitions, annotations, and \lstinl
 It is recommended to use the most specific specialized class.
 \end{nonnormative}
 
-The specialized classes \lstinline!package!, \lstinline!operator!, \lstinline!function!,
-\lstinline!type,! \lstinline!record!,
-\lstinline!operator record!, and \lstinline!expandable connector! can only be derived from their
-own kind and from \lstinline!class!.
+The specialized classes \lstinline!package!, \lstinline!operator!, \lstinline!function!, \lstinline!type,! \lstinline!record!, \lstinline!operator record!, and \lstinline!expandable connector! can only be derived from their own kind and from \lstinline!class!.
 
 \begin{nonnormative}
 E.g., a package can only be base class for packages.
@@ -225,6 +217,7 @@ end ModelB;
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Require Transitively Non-Replaceable}\label{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}\label{require-transitively-non-replaceable}
 
 The class name used after \lstinline!extends! for base classes and for constraining classes must use a class reference considered transitively non-replaceable, see definition in \cref{transitively-non-replaceable}.
@@ -235,9 +228,9 @@ The requirement to use a transitively non-replaceable name excludes the long for
 \end{nonnormative}
 
 \begin{nonnormative}
-The rule for a replaceable component declaration without \lstinline[language=grammar]!constraining-clause! implies that constraining classes are always transitively non-replaceable -- both
-if explicitly given or implicitly by the declaration.
+The rule for a replaceable component declaration without \lstinline[language=grammar]!constraining-clause! implies that constraining classes are always transitively non-replaceable -- both if explicitly given or implicitly by the declaration.
 \end{nonnormative}
+
 
 \section{Modifications}\label{modifications}
 
@@ -270,9 +263,8 @@ Real altitude(start = 59404);
 A modification (e.g., \lstinline!C1 c1(x = 5)!) is called a \firstuse{modification equation}, if the modified variable (here: \lstinline!c1.x!) is a non-parameter variable.
 
 \begin{nonnormative}
-The modification equation is created, if the modified component (here: \lstinline!c1!) is also created (see \cref{class-declarations}). In most cases
-a modification equation for a non-parameter variable requires that the variable was declared with a declaration equation, see \cref{balanced-models};
-in those cases the declaration equation is replaced by the modification equation.
+The modification equation is created, if the modified component (here: \lstinline!c1!) is also created (see \cref{class-declarations}).
+In most cases a modification equation for a non-parameter variable requires that the variable was declared with a declaration equation, see \cref{balanced-models}; in those cases the declaration equation is replaced by the modification equation.
 \end{nonnormative}
 
 A more dramatic change is to modify the \emph{type} and/or the \emph{prefixes} and possibly the \emph{dimension sizes} of a declared element.
@@ -308,9 +300,11 @@ end D;
 
 When present, the description-string of a modifier overrides the existing description.
 
+
 \subsection{Syntax of Modifications and Redeclarations}\label{syntax-of-modifications-and-redeclarations}
 
 The syntax is defined in the grammar, \cref{modification}.
+
 
 \subsection{Modification Environment}\label{modification-environment}
 
@@ -321,9 +315,12 @@ The modification environment is built by merging class modifications, where oute
 This should not be confused with \lstinline!inner outer! prefixes described in \cref{instance-hierarchy-name-lookup-of-inner-declarations}.
 \end{nonnormative}
 
+
 \subsection{Merging of Modifications}\label{merging-of-modifications}
 
-Merging of modifiers means that outer modifiers override inner modifiers.  The merging is hierarchical, and a value for an entire non-simple component overrides value modifiers for all components, and it is an error if this overrides a \lstinline!final! prefix for a component, or if value for a simple component would override part of the value of a non-simple component. When merging modifiers each modification keeps its own \lstinline!each! prefix.
+Merging of modifiers means that outer modifiers override inner modifiers.
+The merging is hierarchical, and a value for an entire non-simple component overrides value modifiers for all components, and it is an error if this overrides a \lstinline!final! prefix for a component, or if value for a simple component would override part of the value of a non-simple component.
+When merging modifiers each modification keeps its own \lstinline!each! prefix.
 
 \begin{example}
 The following larger example demonstrates several aspects:
@@ -392,10 +389,8 @@ class C4
 end C4;
 \end{lstlisting}
 
-Outer modifications override inner modifications, e.g., \lstinline!b = 66!
-overrides the nested class modification of extends \lstinline!C2(b = 6)!.
-This is known as merging of modifications: merge\lstinline!((b = 66), (b = 6))!
-becomes \lstinline!(b = 66)!.
+Outer modifications override inner modifications, e.g., \lstinline!b = 66! overrides the nested class modification of extends \lstinline!C2(b = 6)!.
+This is known as merging of modifications: merge\lstinline!((b = 66), (b = 6))! becomes \lstinline!(b = 66)!.
 
 A flattening of class \lstinline!C4! will give an object with the following variables:
 \begin{center}
@@ -417,6 +412,7 @@ A flattening of class \lstinline!C4! will give an object with the following vari
 \end{tabular}
 \end{center}
 \end{example}
+
 
 \subsection{Single Modification}\label{single-modification}
 
@@ -503,6 +499,7 @@ end Test;
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Modifiers for Array Elements}\label{modifiers-for-array-elements}
 
 The following rules apply to modifiers:
@@ -546,7 +543,8 @@ model E
   B b2[2](c(each a = {1, 2, 3}, d = fill({1, 2, 3, 4, 5}, 2)), p = {1, 2});
 end E;
 \end{lstlisting}
-This implies \lstinline!b[k].c[i].a[j] = j!, \lstinline!b[k].c[i].d = i!, and \lstinline!b[k].p = k!.  For \lstinline!c.a! the additional (outer) \lstinline!each! has no effect, but it is necessary for \lstinline!c.d!.
+This implies \lstinline!b[k].c[i].a[j] = j!, \lstinline!b[k].c[i].d = i!, and \lstinline!b[k].p = k!.
+For \lstinline!c.a! the additional (outer) \lstinline!each! has no effect, but it is necessary for \lstinline!c.d!.
 
 Specifying array dimensions after the type works the same as specifying them after the variable name.
 \begin{lstlisting}[language=modelica]
@@ -559,13 +557,15 @@ end F;
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Final Element Modification Prevention}\label{final-element-modification-prevention}
 
-An element defined as final by the \lstinline!final!\indexinline{final} prefix in an element modification or declaration cannot be modified by a modification or by a redeclaration.  All elements of a final element are also final.
+An element defined as final by the \lstinline!final!\indexinline{final} prefix in an element modification or declaration cannot be modified by a modification or by a redeclaration.
+All elements of a final element are also final.
 
 \begin{nonnormative}
-Setting the value of a parameter in an experiment environment is conceptually treated as a modification.  This implies that a final modification equation
-of a parameter cannot be changed in a simulation environment.
+Setting the value of a parameter in an experiment environment is conceptually treated as a modification.
+This implies that a final modification equation of a parameter cannot be changed in a simulation environment.
 \end{nonnormative}
 
 \begin{example}
@@ -615,7 +615,9 @@ end Test2;
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Removing Modifiers -- break}\label{removing-modifiers-break}
+
 Modifications may contain the special keyword \lstinline!break!\index{break@\robustinline{break}!removing modifier} instead of an expression.
 The intention of \lstinline!break! is to remove the value.
 
@@ -637,13 +639,13 @@ Remove unwanted defaults for parameters:
 partial model PartialStraightPipe
   parameter Real roughness = 2.5e-5 "Average height of surface asperities";
   parameter Real height_ab (unit = "m" ) = 0 "Height between a and b";
-  ...
+  $\ldots$
 end PartialStraightPipe;
 
 model StaticPipe
   extends PartialStraightPipe;
   parameter Real p_a_start = system.p_start;
-  ...
+  $\ldots$
 end StaticPipe;
 
 model MyPipe "Without defaults"
@@ -677,15 +679,16 @@ end A;
 model B "Computing x instead"
   extends A(final x=break);
 algorithm
-  x:=0;
-  while ...
-    x := x + ...
+  x := 0;
+  while $\ldots$
+    x := x + $\ldots$;
   end while;
 end B;
 \end{lstlisting}
 Note that this is only legal because the modifier is modifying an inherited declaration.
 Due to \cref{balanced-models} it is not legal to construct the corresponding component declaration, \lstinline!A a(x=break);!.
 \end{example}
+
 
 \section{Redeclaration}\label{redeclaration}
 
@@ -697,16 +700,11 @@ For modifiers, the redeclare of classes uses the \lstinline[language=grammar]!sh
 
 A modifier with the keyword \lstinline!replaceable!\indexinline{replaceable} is automatically seen as being a \lstinline!redeclare!.
 
-In redeclarations some parts of the original declaration is
-automatically inherited by the new declaration. This is intended to make
-it easier to write declarations by not having to repeat common parts of
-the declarations, and does in particular apply to prefixes that must be
-identical. The inheritance only applies to the declaration itself and
-not to elements of the declaration.
+In redeclarations some parts of the original declaration is automatically inherited by the new declaration.
+This is intended to make it easier to write declarations by not having to repeat common parts of the declarations, and does in particular apply to prefixes that must be identical.
+The inheritance only applies to the declaration itself and not to elements of the declaration.
 
-The general rule is that if no prefix within one of the following groups
-is present in the new declaration the old prefixes of that kind are
-preserved.
+The general rule is that if no prefix within one of the following groups is present in the new declaration the old prefixes of that kind are preserved.
 
 The groups that are valid for both classes and components:
 \begin{itemize}
@@ -715,7 +713,7 @@ The groups that are valid for both classes and components:
 \item
   \lstinline!inner!, \lstinline!outer!
 \item
-  constraining type according to rules in \cref{constraining-type}.
+  constraining type according to rules in \cref{constraining-type}
 \end{itemize}
 
 The groups that are only valid for components:
@@ -730,22 +728,16 @@ The groups that are only valid for components:
   array dimensions
 \end{itemize}
 
-Note that if the old declaration was a short class definition with array
-dimensions the array dimensions are not automatically preserved, and
-thus have to be repeated in the few cases they are used.
+Note that if the old declaration was a short class definition with array dimensions the array dimensions are not automatically preserved, and thus have to be repeated in the few cases they are used.
 
-Replaceable component array declarations with array sizes on the left of
-the component are seen as syntactic sugar for having all arrays sizes on
-the right of the component; and thus can be redeclared in a consistent
-way.
+Replaceable component array declarations with array sizes on the left of the component are seen as syntactic sugar for having all arrays sizes on the right of the component; and thus can be redeclared in a consistent way.
 
 The presence of annotations on the \lstinline!redeclare! construct in a modifier is deprecated, but since none of the annotations in the specification ever had a meaning in this context it only impacts vendor-specific annotations.
 
 \begin{nonnormative}
-Note: The inheritance is from the original declaration. In most
-cases replaced or original does not matter. It does matter if a user
-redeclares a variable to be a parameter and then redeclares it without
-parameter.
+Note: The inheritance is from the original declaration.
+In most cases replaced or original does not matter.
+It does matter if a user redeclares a variable to be a parameter and then redeclares it without parameter.
 \end{nonnormative}
 
 \begin{nonnormative}
@@ -773,6 +765,7 @@ M m(redeclare Modelica.Units.SI.Length x[2, 4]); // Valid redeclare of the type
 \end{lstlisting}
 \end{nonnormative}
 
+
 \subsection{The ``class extends'' Redeclaration Mechanism}\label{the-class-extends-redeclaration-mechanism}
 
 A class declaration of the type \lstinline!redeclare class extends B($\ldots$)!, where \lstinline!class! as usual can be replaced by any other specialized class, replaces the inherited class \lstinline!B! with another declaration that extends the inherited class where the optional class-modification is applied to the inherited class.
@@ -780,8 +773,7 @@ Inherited \lstinline!B! here means that the class containing \lstinline!redeclar
 The new declaration should explicitly include \lstinline!redeclare!.
 
 \begin{nonnormative}
-Since the rule about applying the optional class-modification implies that all declarations are inherited with modifications applied, there is no need
-to apply modifiers to the new declaration.
+Since the rule about applying the optional class-modification implies that all declarations are inherited with modifications applied, there is no need to apply modifiers to the new declaration.
 \end{nonnormative}
 
 % henrikt-ma: Adding index entry for 'replaceable' here, since I can't find a place where the term is really explained in terms of using the corresponding keyword.
@@ -801,9 +793,7 @@ long-class-specifier : $\ldots$
     | extends IDENT [ class-modification ] description-string
       composition end IDENT
 \end{lstlisting}
-The nonterminal \lstinline!class-definition! is referenced in several places in the
-grammar, including the following case which is used in some examples
-below, including \lstinline!package extends! and \lstinline!model extends!:
+The nonterminal \lstinline!class-definition! is referenced in several places in the grammar, including the following case which is used in some examples below, including \lstinline!package extends! and \lstinline!model extends!:
 \begin{lstlisting}[language=grammar]
 element :
    import-clause |
@@ -870,20 +860,12 @@ package MoistAir "Special type of medium"
 end MoistAir;
 \end{lstlisting}
 
-Note, since \lstinline!MostAir! extends from \lstinline!PartialMedium!,
-constant \lstinline!nX! = 2 in package \lstinline!MoistAir! and the model
-\lstinline!BaseProperties! and the function \lstinline!dynamicViscosity! is present
-in \lstinline!MoistAir!. By the following definitions, the available
-\lstinline!BaseProperties! model is replaced by another implementation which
-extends from the \lstinline!BaseProperties! model that has been temporarily
-constructed during the extends of package \lstinline!MoistAir! from
-\lstinline!PartialMedium!. The redeclared \lstinline!BaseProperties! model
-references constant \lstinline!nX! which is 2, since by construction the
-redeclared \lstinline!BaseProperties! model is in a package with \lstinline!nX! = 2.
+Note, since \lstinline!MostAir! extends from \lstinline!PartialMedium!, constant \lstinline!nX! = 2 in package \lstinline!MoistAir! and the model \lstinline!BaseProperties! and the function \lstinline!dynamicViscosity! is present in \lstinline!MoistAir!.
+By the following definitions, the available \lstinline!BaseProperties! model is replaced by another implementation which extends from the \lstinline!BaseProperties! model that has been temporarily constructed during the extends of package \lstinline!MoistAir! from \lstinline!PartialMedium!.
+The redeclared \lstinline!BaseProperties! model references constant \lstinline!nX! which is 2, since by construction the redeclared \lstinline!BaseProperties! model is in a package with \lstinline!nX! = 2.
 
-This definition is compact but is difficult to understand. At a
-first glance an alternative exists that is more straightforward and
-easier to understand:
+This definition is compact but is difficult to understand.
+At a first glance an alternative exists that is more straightforward and easier to understand:
 \begin{lstlisting}[language=modelica]
 package MoistAir2 "Alternative definition that does not work"
   extends PartialMedium(nX=2,
@@ -916,6 +898,7 @@ For larger models this is not practical and therefore the only practically usefu
 
 To detect this issue the rule on lookup of composite names (\cref{composite-name-lookup}) ensures that \lstinline!PartialMedium.dynamicViscosity! is incorrect in a simulation model.
 \end{nonnormative}
+
 
 \subsection{Constraining Type}\label{constraining-type}
 
@@ -963,8 +946,7 @@ class D
 end D;
 \end{lstlisting}
 
-A modification of the constraining type is automatically applied
-in subsequent redeclarations:
+A modification of the constraining type is automatically applied in subsequent redeclarations:
 \begin{lstlisting}[language=modelica]
 model ElectricalSource
   replaceable SineSource source constrainedby MO(final n=5);
@@ -977,8 +959,7 @@ model TrapezoidalSource
 end TrapezoidalSource;
 \end{lstlisting}
 
-A modification of the base type without a constraining type is
-automatically applied in subsequent redeclarations:
+A modification of the base type without a constraining type is automatically applied in subsequent redeclarations:
 \begin{lstlisting}[language=modelica]
 model Circuit
   replaceable model NonlinearResistor = Resistor(R=100);
@@ -1002,11 +983,8 @@ model Circuit3
 end Circuit3;
 \end{lstlisting}
 
-\lstinline!Circuit2! is intended to illustrate that a user can still select
-any resistor model (including the original one, as is done in \lstinline!Circuit3!),
-since the constraining type is kept from the original declaration if not
-specified in the redeclare. Thus it is easy to select an advanced
-resistor model, without limiting the possible future changes.
+\lstinline!Circuit2! is intended to illustrate that a user can still select any resistor model (including the original one, as is done in \lstinline!Circuit3!), since the constraining type is kept from the original declaration if not specified in the redeclare.
+Thus it is easy to select an advanced resistor model, without limiting the possible future changes.
 
 A redeclaration can redefine the constraining type:
 \begin{lstlisting}[language=modelica]
@@ -1023,27 +1001,17 @@ end Circuit5;
 \end{lstlisting}
 \end{example}
 
-The class or type of component shall be a subtype of the constraining
-type. In a redeclaration of a replaceable element, the class or type of
-a component must be a subtype of the constraining type. The constraining
-type of a replaceable redeclaration must be a subtype of the
-constraining type of the declaration it redeclares. In an element
-modification of a replaceable element, the modifications are applied
-both to the actual type and to the constraining type.
+The class or type of component shall be a subtype of the constraining type.
+In a redeclaration of a replaceable element, the class or type of a component must be a subtype of the constraining type.
+The constraining type of a replaceable redeclaration must be a subtype of the constraining type of the declaration it redeclares.
+In an element modification of a replaceable element, the modifications are applied both to the actual type and to the constraining type.
 
-In an element-redeclaration of a replaceable element the modifiers of
-the replaced constraining type are merged to both the new declaration
-and to the new constraining type, using the normal rules where outer
-modifiers override inner modifiers.
+In an element-redeclaration of a replaceable element the modifiers of the replaced constraining type are merged to both the new declaration and to the new constraining type, using the normal rules where outer modifiers override inner modifiers.
 
-When a class is flattened as a constraining type, the flattening of its
-replaceable elements will use the constraining type and not the actual
-default types.
+When a class is flattened as a constraining type, the flattening of its replaceable elements will use the constraining type and not the actual default types.
 
-The number of dimension in the constraining type should correspond to
-the number of dimensions in the type-part. Similarly the type used in a
-redeclaration must have the same number of dimensions as the type of
-redeclared element.
+The number of dimension in the constraining type should correspond to the number of dimensions in the type-part.
+Similarly the type used in a redeclaration must have the same number of dimensions as the type of redeclared element.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -1051,9 +1019,9 @@ replaceable T1 x[n] constrainedby T2;
 replaceable type T=T1[n] constrainedby T2;
 replaceable T1[n] x constrainedby T2;
 \end{lstlisting}
-In these examples the number of dimensions must be the same in \lstinline!T1! and \lstinline!T2!, as well as in a redeclaration.  Normally \lstinline!T1! and \lstinline!T2! are scalar types, but both
-could also be defined as array types (with the same number of dimensions).  Thus if \lstinline!T2! is a scalar type (e.g., \lstinline!type T2 = Real!) then \lstinline!T1! must also be a scalar type,
-and if \lstinline!T2! is defined as vector type (e.g., \lstinline!type T2 = Real[3]!) then \lstinline!T1! must also be vector type.
+In these examples the number of dimensions must be the same in \lstinline!T1! and \lstinline!T2!, as well as in a redeclaration.
+Normally \lstinline!T1! and \lstinline!T2! are scalar types, but both could also be defined as array types (with the same number of dimensions).
+Thus if \lstinline!T2! is a scalar type (e.g., \lstinline!type T2 = Real!) then \lstinline!T1! must also be a scalar type, and if \lstinline!T2! is defined as vector type (e.g., \lstinline!type T2 = Real[3]!) then \lstinline!T1! must also be vector type.
 \end{example}
 
 \subsubsection{Constraining-Clause Annotations}\label{constraining-clause-annotations}
@@ -1084,14 +1052,13 @@ replaceable Resistor load3
 
 See also the examples in \cref{annotation-choices-for-suggested-redeclarations-and-modifications}.
 
+
 \subsection{Restrictions on Redeclarations}\label{restrictions-on-redeclarations}
 
-The following additional constraints apply to redeclarations (after
-prefixes are inherited, \cref{redeclaration}):
+The following additional constraints apply to redeclarations (after prefixes are inherited, \cref{redeclaration}):
 \begin{itemize}
 \item
-  Only classes and components declared as replaceable can be redeclared with a new type, which must have an interface compatible with the constraining
-  interface of the original declaration, and to allow further redeclarations one must use \lstinline!redeclare replaceable!.
+  Only classes and components declared as replaceable can be redeclared with a new type, which must have an interface compatible with the constraining interface of the original declaration, and to allow further redeclarations one must use \lstinline!redeclare replaceable!.
   \begin{nonnormative}
   Redeclaration with the same type can be used to restrict variability and/or change array dimensions.
   \end{nonnormative}
@@ -1107,6 +1074,7 @@ prefixes are inherited, \cref{redeclaration}):
   This is one example of redeclaration of non-replaceable elements.
   \end{nonnormative}
 \end{itemize}
+
 
 \subsection{Annotations for Redeclaration and Modification}\label{annotation-choices-for-suggested-redeclarations-and-modifications}
 
@@ -1211,13 +1179,16 @@ parameter Boolean useHeatPort = false annotation(choices(checkBox = true));
 \end{lstlisting}
 \end{example}
 
+
 \section{Selective Model Extension}\label{selective-model-extension}\index{deselection!selective model extension}
+
 \begin{nonnormative}
 The goal of selective model extension is to enable unforeseen structural variability without requiring deliberately prepared base-models, \textcite{Buerger2019SelectiveModel}.
-
 This is done by deselecting specific elements from a base class, described here, combined with adding elements as normal.
 \end{nonnormative}
+
 Selective model extension is activated by using one (or more) \lstinline[language=grammar]!inheritance-modification! in the optional \lstinline[language=grammar]!class-or-inheritance-modification! of an \lstinline!extends!-clause.
+
 \begin{nonnormative}
 There is no corresponding mechanism for component modifications, short class definitions, or constrainedby.
 \end{nonnormative}
@@ -1232,19 +1203,27 @@ end C;
 \index{break@\robustinline{break}!deselection}
 The semantic rules are:
 \begin{enumerate}
-\item The deselection \lstinline!break $D$! is applied before any other, non selective model extension related, modifications of \lstinline!B! in \lstinline!C!.
-\item When adding elements from \lstinline!B! to \lstinline!C! the elements matched by any deselection in \lstinline!extends B! are excluded.
-\begin{itemize}
-\item A component deselection, \lstinline!break f!, matches the component with that name, \lstinline!f!, of \lstinline!B! and all connections with the component or its subcomponents.
-Matched components must be models, blocks or connectors.
-\item A connection deselection, \lstinline!break connect(a, b)!, matches all syntactical equivalent connections of \lstinline!B!.
-A connection \lstinline!connect(c, d)!, with \lstinline!c! and \lstinline!d! arbitrary but valid connection arguments, is syntactically equivalent to a connection deselection \lstinline!break connect(a, b)!, if, and only if, either, \lstinline!c! is syntactically equivalent to \lstinline!a! and \lstinline!d! is syntactically equivalent to \lstinline!b! or, vice versa, \lstinline!c! is syntactically equivalent to \lstinline!b! and \lstinline!d! is syntactically equivalent to \lstinline!a!.
-Two code fragments \lstinline!a! and \lstinline!c! are syntactically equivalent, if, and only if, the context-free derivations of \lstinline!a! and \lstinline!c! according to the grammar given in \cref{expressions1} are the same.
-\end{itemize}
-\item Conditionally declared components of \lstinline!B! are assumed to be declared for all purposes of matching.
-\item The deselected component may be of a partial class even in a simulation model.
-\item The deselection \lstinline!break $D$! must match at least one element of \lstinline!B!.
-\item The component deselection are applied before the connection deselections of the same \lstinline!extends!-clause.
+\item
+  The deselection \lstinline!break $D$! is applied before any other, non selective model extension related, modifications of \lstinline!B! in \lstinline!C!.
+\item
+  When adding elements from \lstinline!B! to \lstinline!C! the elements matched by any deselection in \lstinline!extends B! are excluded.
+  \begin{itemize}
+  \item
+    A component deselection, \lstinline!break f!, matches the component with that name, \lstinline!f!, of \lstinline!B! and all connections with the  component or its subcomponents.
+    Matched components must be models, blocks or connectors.
+  \item
+    A connection deselection, \lstinline!break connect(a, b)!, matches all syntactical equivalent connections of \lstinline!B!.
+    A connection \lstinline!connect(c, d)!, with \lstinline!c! and \lstinline!d! arbitrary but valid connection arguments, is syntactically equivalent  to a connection deselection \lstinline!break connect(a, b)!, if, and only if, either, \lstinline!c! is syntactically equivalent to \lstinline!a! and   \lstinline!d! is syntactically equivalent to \lstinline!b! or, vice versa, \lstinline!c! is syntactically equivalent to \lstinline!b! and \lstinline! d! is syntactically equivalent to \lstinline!a!.
+    Two code fragments \lstinline!a! and \lstinline!c! are syntactically equivalent, if, and only if, the context-free derivations of \lstinline!a! and \ lstinline!c! according to the grammar given in \cref{expressions1} are the same.
+  \end{itemize}
+\item
+  Conditionally declared components of \lstinline!B! are assumed to be declared for all purposes of matching.
+\item
+  The deselected component may be of a partial class even in a simulation model.
+\item
+  The deselection \lstinline!break $D$! must match at least one element of \lstinline!B!.
+\item
+  The component deselection are applied before the connection deselections of the same \lstinline!extends!-clause.
 \end{enumerate}
 
 \begin{example}

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -359,7 +359,7 @@ model B
 end B;
 
 model C
-  B b1(a(x = 4)); // Error since attempting to override value for a.x when a has a value.
+  B b1(a(x = 4)); // Error: Cannot override value for a.x when a has a value.
 end C;
 \end{lstlisting}
 

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -96,8 +96,8 @@ function B
   extends A;
   input Real a;
 end B;
-// The inputs of B are {a, b} in that order; the "input Real a;" is ignored.
 \end{lstlisting}
+The inputs of \lstinline!B! are $\{\text{\lstinline!a!}, \text{\lstinline!b!}\}$ in that order; the \lstinline!input Real a;! is ignored.
 \end{nonnormative}
 
 Equations of the flattened base class that are syntactically equivalent to equations in the flattened enclosing class are discarded.


### PR DESCRIPTION
This is a follow-up to #3679, where the new content accidentally contained non-sentence-based line breaks due to a copy/paste mistake.

As I was inspecting the generated PDF after the whitespace cleanup, I discovered two minor issues which were addressed in separate commits.
