### PR TITLE
Proposed

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1321,9 +1321,10 @@ The center of the image is positioned at the center of the extent.
 \subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
 Any value in graphical annotations can be dependent on evaluable parameters except when restricted otherwise in their respective definitions, (for example with \lstinline!/* literal */ constant!).
+
 \lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the static state and the second argument the value of the dynamic state.
 The first argument follows the same rules as when not using \lstinline!DynamicSelect!.
-The second argument may contain references to variables of a higher variability to enable displaying a dynamic behavior of a simulation.
+The second argument may contain references to variables of a higher variability to enable displaying dynamic behavior of a simulation.
 
 
 \begin{example}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1320,10 +1320,12 @@ The center of the image is positioned at the center of the extent.
 
 \subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
-Any value (coordinates, color, text, etc.) in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect!.
-\lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the editing state and the second argument the value of the non-editing state.
-The first argument must be a literal expression.
+Any value except when restricted otherwise in their respective definitions, for example with \lstinline!/* literal */ constant!) in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect!.
+\lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the static state and the second argument the value of the dynamic state.
+The first follow the rule given below.
 The second argument may contain references to variables to enable a dynamic behavior.
+
+If \lstinline!DynamicSelect! is not used (or for the first argument in \lstinline!DynamicSelect!), expressions dependent on evaluable parameters are allowed, but not expressions with a higher variability.
 
 \begin{example}
 The level of a tank could be animated by a rectangle expanding in vertical direction and its color depending on a variable overflow:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1320,12 +1320,11 @@ The center of the image is positioned at the center of the extent.
 
 \subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
-Any value in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect! except when restricted otherwise in their respective definitions, (for example with \lstinline!/* literal */ constant!).
+Any value in graphical annotations can be dependent on evaluable parameters except when restricted otherwise in their respective definitions, (for example with \lstinline!/* literal */ constant!).
 \lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the static state and the second argument the value of the dynamic state.
-The first argument follows the rule given below.
-The second argument may contain references to variables to enable a dynamic behavior.
+The first argument follows the same rules as when not using \lstinline!DynamicSelect!.
+The second argument may contain references to variables of a higher variability to enable displaying a dynamic behavior of a simulation.
 
-If \lstinline!DynamicSelect! is not used (or for the first argument in \lstinline!DynamicSelect!), expressions dependent on evaluable parameters are allowed, but not expressions with a higher variability.
 
 \begin{example}
 The level of a tank could be animated by a rectangle expanding in vertical direction and its color depending on a variable overflow:

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1322,7 +1322,7 @@ The center of the image is positioned at the center of the extent.
 
 Any value except when restricted otherwise in their respective definitions, for example with \lstinline!/* literal */ constant!) in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect!.
 \lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the static state and the second argument the value of the dynamic state.
-The first follow the rule given below.
+The first argument follow the rule given below.
 The second argument may contain references to variables to enable a dynamic behavior.
 
 If \lstinline!DynamicSelect! is not used (or for the first argument in \lstinline!DynamicSelect!), expressions dependent on evaluable parameters are allowed, but not expressions with a higher variability.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1320,9 +1320,9 @@ The center of the image is positioned at the center of the extent.
 
 \subsection{Variable Graphics and Schematic Animation}\label{variable-graphics-and-schematic-animation}
 
-Any value except when restricted otherwise in their respective definitions, for example with \lstinline!/* literal */ constant!) in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect!.
+Any value in graphical annotations can be dependent on class variables using \lstinline!DynamicSelect! except when restricted otherwise in their respective definitions, (for example with \lstinline!/* literal */ constant!).
 \lstinline!DynamicSelect! has the syntax of a function call with two arguments, where the first argument specifies the value of the static state and the second argument the value of the dynamic state.
-The first argument follow the rule given below.
+The first argument follows the rule given below.
 The second argument may contain references to variables to enable a dynamic behavior.
 
 If \lstinline!DynamicSelect! is not used (or for the first argument in \lstinline!DynamicSelect!), expressions dependent on evaluable parameters are allowed, but not expressions with a higher variability.


### PR DESCRIPTION
Closes #3376 

I'm not fully satisfied with it, as it seems a bit intermixed and repetitive:

> DynamicSelect text
> Rule for first arg, see below
> Rule for second arg (in detail)
> 
> Detailed rule when not using DynamicSelect (or for first argument).

The obvious way of reducing repetitions would be:

> DynamicSelect text
> Rule for second arg (in detail)
> 
> Detailed rule for first argument or when not using DynamicSelect.

But it seems weird.

So, what about the following?

> Detailed rule when not using DynamicSelect.
>
> DynamicSelect text
> Rule for first arg is same as rule when not using DynamicSelect
> Rule for second arg (in detail)

That would require a bit of reformulation for the DynamicSelect text, but apart from avoiding forward references and intermixing it gives a motivation for DynamicSelect



