### PR TITLE
Shorten identifier for two reasons

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -2549,7 +2549,7 @@ end MyLibraryAuthorization_Tool;
 
 \section{License Texts}\label{license-texts}
 
-For a top-level class the {\lstinline!annotation(License="modelica:/ModelicaLibraryName/Resources/Licenses/MyLicense.txt")!}\annotationindex{License}, gives a license text file for the class.
+For a top-level class the {\lstinline!annotation(License="modelica:/PackageName/Resources/Licenses/MyLicense.txt")!}\annotationindex{License}, gives a license text file for the class.
 The annotation may give a scalar string or an array of strings, where each string is a URI referencing a license text file, see \cref{external-resources}.
 The license text files are human-readable files containing the license conditions.
 If the annotation specifies an array of license text files the conditions in all of them must be satisfied (i.e., it is not intended for dual-licensing).

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2252,11 +2252,11 @@ They can all specify either a scalar value or an array of values as indicated be
   \end{nonnormative}
 \item
   The
-  {\lstinline!annotation(IncludeDirectory="modelica:/ModelicaLibraryName/Resources/Include")!}\annotationindex{IncludeDirectory}, used to specify a location for header files.
+  {\lstinline!annotation(IncludeDirectory="modelica:/PackageName/Resources/Include")!}\annotationindex{IncludeDirectory}, used to specify a location for header files.
   The preceding one is the default and need not be specified; but another location could be specified by using an URI name for the include directory, see \cref{external-resources}.
 \item
   The
-  {\lstinline!annotation(LibraryDirectory="modelica:/ModelicaLibraryName/Resources/Library")!}\annotationindex{LibraryDirectory}, used to specify a location for library files.
+  {\lstinline!annotation(LibraryDirectory="modelica:/PackageName/Resources/Library")!}\annotationindex{LibraryDirectory}, used to specify a location for library files.
   The preceding one is the default and need not be specified; but another location could be specified by using an URI name for the library directory, see \cref{external-resources}.
   Different versions of one object library can be provided (e.g., for Windows and for Linux) by providing a \emph{platform} directory below the {\lstinline!LibraryDirectory!}.
   If no platform directory is present, the object library must be present in the {\lstinline!LibraryDirectory!}.
@@ -2273,11 +2273,11 @@ They can all specify either a scalar value or an array of values as indicated be
   \end{itemize}
 \item
   The
-  {\lstinline!annotation(SourceDirectory="modelica:/ModelicaLibraryName/Resources/Source")!}\annotationindex{SourceDirectory}, gives the location for source files.
+  {\lstinline!annotation(SourceDirectory="modelica:/PackageName/Resources/Source")!}\annotationindex{SourceDirectory}, gives the location for source files.
   The preceding one is the default and need not be specified; but another location could be specified by using an URI name for the source directory, see \cref{external-resources}.
   It is not specified how they are built.
 \item
-  The {\lstinline!annotation(License="modelica:/ModelicaLibraryName/Resources/Licenses/MyLicense.txt")!}\annotationindex{License}, gives the license text file for the function.
+  The {\lstinline!annotation(License="modelica:/PackageName/Resources/Licenses/MyLicense.txt")!}\annotationindex{License}, gives the license text file for the function.
   It is analogous to the \lstinline!License! annotation for a top-level class, see \cref{license-texts}.
 \end{itemize}
 
@@ -2293,7 +2293,7 @@ A tool may give a diagnostic if the directory corresponding to the selected comp
 The directories may use symbolic links or use a text-file as described below: e.g., a text-file \filename{vs2008} containing the text \emph{../win32/vs2005} (or \emph{vs2005}) suggesting that it is compatible with vs2005.
 \end{nonnormative}
 
-The {\lstinline!ModelicaLibraryName!} used for {\lstinline!IncludeDirectory!}, {\lstinline!LibraryDirectory!}, and {\lstinline!SourceDirectory!} indicates the top-level class where the annotation is found in the Modelica source code.
+The {\lstinline!PackageName!} used for {\lstinline!IncludeDirectory!}, {\lstinline!LibraryDirectory!}, and {\lstinline!SourceDirectory!} indicates the top-level class where the annotation is found in the Modelica source code.
 
 \begin{example}
 Use of external functions and of object libraries:


### PR DESCRIPTION
The reasons are:
- It is too long
- It causes problem for HTML it seems (needs to be verified)

Closes #3663