### PR TITLE
Fix link

### DIFF
--- a/mls.bib
+++ b/mls.bib
@@ -62,7 +62,7 @@
   year = {1987},
   volume = {8},
   pages = {231--274},
-  url = {http://www.inf.ed.ac.uk/teaching/courses/seoc1/2005_2006/resources/statecharts.pdf},
+  url = {https://doi.org/10.1016/0167-6423(87)90035-9},
 }
 
 @InProceedings{ThummelEtAl2005InverseModels,

--- a/mls.bib
+++ b/mls.bib
@@ -7,7 +7,8 @@
   volume = {9},
   number = {2},
   pages = {213–-231},
-  url = {https://doi.org/10.1137/0909014},
+% url = {https://doi.org/10.1137/0909014},
+  doi = {10.1137/0909014},
 }
 
 @Article{BenvenisteEtAl2003SynchronousTwelveYearsLater,
@@ -17,7 +18,8 @@
   journal = {Proceedings of the {IEEE}},
   volume = {91},
   number = {1},
-  url = {https://doi.org/10.1109/JPROC.2002.805826},
+% url = {https://doi.org/10.1109/JPROC.2002.805826},
+  doi = {10.1109/JPROC.2002.805826},
 }
 
 @InProceedings{ColacoPouzet2003ClocksFirstClass,
@@ -28,6 +30,7 @@
   booktitle = {Third International Workshop on Embedded Software, {EMSOFT} 2003},
   address = {Philadelphia, Pennsylvania, {USA}},
   url = {http://www.di.ens.fr/~pouzet/lucid-synchrone/papers/emsoft03.ps.gz},
+  doi = {10.1007/978-3-540-45212-6_10},
 }
 
 @InProceedings{ElmqvistOtterCellier1995InlineIntegration,
@@ -51,7 +54,8 @@
   booktitle = {11\textsuperscript{th} {IEEE} High Assurance Systems Engineering Symposium ({HASE}'08)},
   pages = {251--260},
   address = {Nanjing, China},
-  url = {https://doi.org/10.1109/HASE.2008.47},
+% url = {https://doi.org/10.1109/HASE.2008.47},
+  doi = {10.1109/HASE.2008.47},
 }
 
 @Article{Harel1987Statecharts,
@@ -62,7 +66,8 @@
   year = {1987},
   volume = {8},
   pages = {231--274},
-  url = {https://doi.org/10.1016/0167-6423(87)90035-9},
+% url = {https://doi.org/10.1016/0167-6423(87)90035-9},
+  doi = {10.1016/0167-6423(87)90035-9},
 }
 
 @InProceedings{ThummelEtAl2005InverseModels,
@@ -99,5 +104,6 @@
   booktitle = {Proceedings of the 13\textsuperscript{th} International Modelica Conference},
   pages = {277--288},
   address = {Regensburg, Germany},
-  url = {https://doi.org/10.3384/ecp19157277},
+% url = {https://doi.org/10.3384/ecp19157277},
+  doi = {10.3384/ecp19157277},
 }

--- a/mls.bib
+++ b/mls.bib
@@ -7,7 +7,6 @@
   volume = {9},
   number = {2},
   pages = {213–-231},
-% url = {https://doi.org/10.1137/0909014},
   doi = {10.1137/0909014},
 }
 
@@ -18,7 +17,6 @@
   journal = {Proceedings of the {IEEE}},
   volume = {91},
   number = {1},
-% url = {https://doi.org/10.1109/JPROC.2002.805826},
   doi = {10.1109/JPROC.2002.805826},
 }
 
@@ -54,7 +52,6 @@
   booktitle = {11\textsuperscript{th} {IEEE} High Assurance Systems Engineering Symposium ({HASE}'08)},
   pages = {251--260},
   address = {Nanjing, China},
-% url = {https://doi.org/10.1109/HASE.2008.47},
   doi = {10.1109/HASE.2008.47},
 }
 
@@ -66,7 +63,6 @@
   year = {1987},
   volume = {8},
   pages = {231--274},
-% url = {https://doi.org/10.1016/0167-6423(87)90035-9},
   doi = {10.1016/0167-6423(87)90035-9},
 }
 
@@ -104,6 +100,5 @@
   booktitle = {Proceedings of the 13\textsuperscript{th} International Modelica Conference},
   pages = {277--288},
   address = {Regensburg, Germany},
-% url = {https://doi.org/10.3384/ecp19157277},
   doi = {10.3384/ecp19157277},
 }


### PR DESCRIPTION
Closes #3698 

I also changed references to doi when possible instead of url.
I don't know if there are doi for the other references, but if they exist it would be good to add them.

The doi-links are still clickable.

Note that one reference has both doi and url:
- The URL avoids a paywall.
- But the doi should be more stable.

