### PR TITLE
Improve description of HTML encoded content

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -166,8 +166,7 @@ The \lstinline!revisions! documentation may be omitted in printed documentation.
 If the string starts with the tag \lstinline!<html>! or \lstinline!<HTML>!, the entire string is HTML encoded (assumed to end with \lstinline!</html>! or \lstinline!</HTML>!, but to be rendered as HTML even if the end-tag is missing).
 Otherwise, the entire string is rendered as is.
 HTML encoded content may contain links.
-For external links, see \cref{external-resources}.
-The Modelica-scheme may be used to refer to Modelica classes, e.g.,
+Modelica URIs may be used to refer to external resources (see \cref{external-resources}), as well as to refer to Modelica classes, e.g.,
 \begin{lstlisting}[language=modelica]
 <a href="modelica:/MultiBody.Tutorial">MultiBody.Tutorial</a>
 \end{lstlisting}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -163,10 +163,11 @@ Inside the \lstinline!Documentation! annotation, the \lstinline!info! annotation
 The \lstinline!revisions! documentation may be omitted in printed documentation.
 \end{nonnormative}
 
-If the string starts with the tag \lstinline!<html>! or \lstinline!<HTML>! the entire string is HTML encoded (and is assumed to end with \lstinline!</html>! or \lstinline!</HTML>! and shall be rendered as HTML even if the end-tags are missing), otherwise the entire string is rendered as is.
-The HTML encoded content may contain links.
+If the string starts with the tag \lstinline!<html>! or \lstinline!<HTML>!, the entire string is HTML encoded (assumed to end with \lstinline!</html>! or \lstinline!</HTML>!, but to be rendered as HTML even if the end-tag is missing).
+Otherwise, the entire string is rendered as is.
+HTML encoded content may contain links.
 For external links, see \cref{external-resources}.
-Links to Modelica classes may be defined with the HTML link command using scheme \lstinline!Modelica! (using its lower case form in the URI, see \cref{external-resources}), e.g.,
+The Modelica-scheme may be used to refer to Modelica classes, e.g.,
 \begin{lstlisting}[language=modelica]
 <a href="modelica:/MultiBody.Tutorial">MultiBody.Tutorial</a>
 \end{lstlisting}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -263,7 +263,7 @@ It follows that any \lstinline!within!-clause (\cref{the-within-clause}) in such
 
 \section{External Resources}\label{external-resources}
 
-In order to reference external resources from documentation (such as links and images in html-text) and/or to reference images in the \lstinline!Bitmap! annotation (see \cref{bitmap}).
+Examples of refereces to external resources include links and images in HTML documentation, and images in the \lstinline!Bitmap! annotation (see \cref{bitmap}).
 Absolute URIs should be used, for example \filename{file:///} and the URI scheme \filename{modelica:/} which can be used to retrieve resources associated with a package.
 According to the URI specification scheme names are case-insensitive, but the lower-case form should be used, that is \filename{Modelica:/} is allowed but \filename{modelica:/} is the recommended form.
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -263,7 +263,7 @@ It follows that any \lstinline!within!-clause (\cref{the-within-clause}) in such
 
 \section{External Resources}\label{external-resources}
 
-Examples of refereces to external resources include links and images in HTML documentation, and images in the \lstinline!Bitmap! annotation (see \cref{bitmap}).
+Examples of references to external resources include links and images in HTML documentation, and images in the \lstinline!Bitmap! annotation (see \cref{bitmap}).
 Absolute URIs should be used, for example \filename{file:///} and the URI scheme \filename{modelica:/} which can be used to retrieve resources associated with a package.
 According to the URI specification scheme names are case-insensitive, but the lower-case form should be used, that is \filename{Modelica:/} is allowed but \filename{modelica:/} is the recommended form.
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -64,7 +64,10 @@ Note:
   (Previously the grammar used underscore.)
 \end{itemize}
 
-If a description-string starts with the tag \lstinline!<html>! or \lstinline!<HTML>! the entire string is HTML encoded (and is assumed to end with \lstinline!</html>! or \lstinline!</HTML>! and shall be rendered as HTML even if the end-tags are missing), otherwise the entire string is rendered as is.
+If a description-string starts with the tag \lstinline!<html>! or \lstinline!<HTML>!, the entire string is HTML encoded (assumed to end with \lstinline!</html>! or \lstinline!</HTML>!, but to be rendered as HTML even if the end-tag is missing).
+Otherwise, the entire string is rendered as is.
+HTML encoded content may contain links in the same way as class documentation, see \cref{documentation}.
+
 
 \section{Grammar}\label{grammar}
 


### PR DESCRIPTION
This is a follow-up to #3691, as planned in https://github.com/modelica/ModelicaSpecification/pull/3691#discussion_r2097116822.

I also fixed a broken sentence in the linked and related section `\cref{external-resources}`.
