### PR TITLE
Update purity exception for Streams.print

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -290,11 +290,13 @@ With the prefix keyword \lstinline!impure!\indexinline{impure} it is stated that
   Binding equations for external objects.
 \end{itemize}
 
+An exception is made for \lstinline!Modelica.Utilities.Streams.print!, for which none of the impure function restrictions apply.
+
 It is an error if an impure function call is part of a systems of equations (including linear systems), even if called in agreement with the restrictions above.
 The reason is that solving systems of equations generally requires expressions to be evaluated an unknown number of times.
 This includes the special handling of \lstinline!when initial()! during initialization.
 
-There are two ways in which an impure function could be called in a system of equations, namely in the deprecated case of external functions assumed to be impure, and when using \lstinline!pure($\ldots$)! to call an impure function from within a pure function.
+There are three ways in which an impure function could be called in a system of equations, namely in the deprecated case of external functions assumed to be impure, when using \lstinline!pure($\ldots$)! to call an impure function from within a pure function, and the exception for \lstinline!Modelica.Utilities.Streams.print!.
 The side-effect semantics of the function call are then undefined.
 Specifically, the number of calls with external side-effects is unspecified.
 However, for impure functions where the outputs only depend on the inputs the system of equations should be solved correctly.


### PR DESCRIPTION
In https://specification.modelica.org/master/functions.html#pure-modelica-functions there is the following exception for `print`:
> A deprecated semantics is that external functions (and functions defined in Modelica directly or indirectly calling them) without `pure` or `impure` keyword are assumed to be impure, but without any restriction on calling them. Except for the function `Modelica.Utilities.Streams.print`, a diagnostic must be given if called in a simulation model.

The problem is that `Modelica.Utilities.Streams.print` is nowadays explicitly marked `impure`, so the exception is only causing confusion at the moment.

This PR updates the specification so that it applies to the current MSL.  The most important part, that there is a loophole for calling `print` anywhere, still applies to older MSL where `print` is not explicitly declared `impure`.  The only change for older MSL is that the deprecated semantics demands a diagnostic in this case – I find it better that tools act on their own on this matter than to elaborate the rules for diagnostics in the specification.
