### PR TITLE
Also allow connectorSizing for constants

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1736,12 +1736,12 @@ If \lstinline!connectorSizing = true!, the corresponding variable must be declar
 \begin{nonnormative}
 The reason why \lstinline!connectorSizing! must be given a literal value is that if the value is an expression, the \lstinline!connectorSizing! functionality is conditional and this will then lead easily to wrong models.
 
-The default value of the variable must be zero since this annotation is designed for a parameter that is used as vector dimension, and the dimension of the vector should be zero when the component is dragged or redeclared.
+The default value of the variable must be zero since this annotation is designed for a variable that is used as vector dimension, and the dimension of the vector should be zero when the component is dragged or redeclared.
 Furthermore, when a tool does not support the \lstinline!connectorSizing! annotation, dragging will still result in a correct model.
 \end{nonnormative}
 
-If \lstinline!connectorSizing = true!, a tool may set the parameter value in a modifier automatically, if used as dimension size of a vector of connectors.
-In that case the parameter should not be modified by the user, and a tool may choose to not display that parameter in the dialog or display it with disabled input field.
+If \lstinline!connectorSizing = true!, a tool may set the variable value in a modifier automatically, if used as dimension size of a vector of connectors.
+In that case the value modifier should not be edited directly by the user, and a tool may choose to not display that variable in the dialog or display it with disabled input field.
 
 \begin{nonnormative}
 The \lstinline!connectorSizing! annotation is used in cases where connections to a vector of connectors shall be made and a new connection requires to resize the vector and to connect to the new index (unary connections).


### PR DESCRIPTION
Since `connectorSizing` is used for a variable _that is used as vector dimension_, it doesn't make sense that the declared variability cannot be `constant`.  I expect that lifting this restriction would be extremely simple for tools to implement.
