### PR TITLE
Make it easier to see which operators that are not allowed inside functions

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -802,6 +802,7 @@ The edges of the virtual connection graph are implicitly defined by \lstinline!c
 Additionally, corresponding nodes of the virtual connection graph have to be defined as roots or as potential roots with functions \lstinline!Connections.root! and \lstinline!Connections.potentialRoot!, respectively.
 
 The overconstrained equation operators for connection graphs are listed below.
+None of these operators are not allowed inside \lstinline!function! classes.
 Here, \lstinline!a! and \lstinline!b! are connector instances that may be hierarchically structured, e.g., \lstinline!a! may be an abbreviation for \lstinline!enginePort.frame_a!.
 \begin{center}
 \begin{tabular}{l|l l}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -165,7 +165,8 @@ Modelica functions have the following restrictions compared to a general Modelic
   \begin{nonnormative}
   It is a quality of implementation how much analysis a tool performs in order to determine if the output variables are computed.
   \end{nonnormative}
-  A function \emph{cannot contain} calls to the Modelica \emph{built-in operators} \lstinline!der!, \lstinline!initial!, \lstinline!terminal!, \lstinline!sample!, \lstinline!pre!, \lstinline!edge!, \lstinline!change!, \lstinline!reinit!, \lstinline!delay!, \lstinline!cardinality!, \lstinline!inStream!, \lstinline!actualStream!, to the operators of the built-in package \lstinline!Connections!, to the operators defined in \cref{synchronous-language-elements} and \cref{state-machines}, and is not allowed to contain \lstinline!when!-statements.
+\item
+  There are many Modelica built-in operators that are not allowed to be used in functions, for example \lstinline!der! and \lstinline!pre!.
 \item
   The dimension \emph{sizes} not declared with colon (\lstinline!:!) of each array result or array local variable (i.e., a non-input component) of a function must be either given by the input formal parameters, or given by constant or parameter expressions, or by expressions containing combinations of those (\cref{initialization-and-binding-equations-of-components-in-functions}).
 \item

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -787,6 +787,7 @@ The time derivative of $\mathit{expr}$.
 If the expression $\mathit{expr}$ is a scalar it needs to be a subtype of \lstinline!Real!.
 The expression and all its time-varying subexpressions must be continuous and semi-differentiable.
 An exception is when the operator \lstinline!reinit! (\Cref{modelica:reinit}) is activated, as not even states are continuous.
+The operator is not allowed inside \lstinline!function! classes.
 If $\mathit{expr}$ is an array, the operator is applied to all elements of the array.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 \begin{nonnormative}
@@ -841,6 +842,7 @@ The arguments, i.e., $\mathit{expr}$, $\mathit{delayTime}$ and $\mathit{delayMax
 $\mathit{delayMax}$ needs to be additionally a parameter expression.
 The following relation shall hold: $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, otherwise an error occurs.
 If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ needs to be a parameter expression.
+The operator is not allowed inside \lstinline!function! classes.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 For further details, see \cref{delay}.
 \end{semantics}
@@ -901,6 +903,7 @@ inStream($v$)
 \begin{semantics}
 \lstinline!inStream($v$)! is only allowed for stream variables $v$ defined in stream connectors, and is the value of the stream variable $v$ close to the connection point assuming that the flow is from the connection point into the component.
 This value is computed from the stream connection equations of the flow variables and of the stream variables.
+The operator is not allowed inside \lstinline!function! classes.
 The operator is vectorizable.
 For further details, see \cref{stream-operator-instream-and-connection-equations}.
 \end{semantics}
@@ -912,6 +915,7 @@ actualStream($v$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \lstinline!actualStream($v$)! returns the actual value of the stream variable $v$ for any flow direction.
+The operator is not allowed inside \lstinline!function! classes.
 The operator is vectorizable.
 For further details, see \cref{stream-operator-actualstream}.
 \end{semantics}
@@ -927,6 +931,7 @@ spatialDistribution(
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \lstinline!spatialDistribution! allows approximation of variable-speed transport of properties.
+The operator is not allowed inside \lstinline!function! classes.
 For further details, see \cref{spatialdistribution}.
 \end{semantics}
 \end{operatordefinition}
@@ -1112,6 +1117,7 @@ end Resistor;
 
 The cardinality is counted after removing conditional components, and shall not be applied to expandable connectors, elements in expandable connectors, or to arrays of connectors (but can be applied to the scalar elements of array of connectors).
 \lstinline!cardinality! should only be used in the condition of assert and \lstinline!if!-statements that do not contain \lstinline!connect! and similar operators, see \cref{connect-equations}).
+The operator is not allowed inside \lstinline!function! classes.
 
 \subsubsection{homotopy}\label{homotopy}
 
@@ -1347,6 +1353,7 @@ initial()
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Returns \lstinline!true! during the initialization phase and \lstinline!false! otherwise.
+The operator is not allowed inside \lstinline!function! classes.
 \begin{nonnormative}
 Hereby, \lstinline!initial()! triggers a time event at the beginning of a simulation.
 \end{nonnormative}
@@ -1359,6 +1366,7 @@ terminal()
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Returns \lstinline!true! at the end of a successful analysis.
+The operator is not allowed inside \lstinline!function! classes.
 \begin{nonnormative}
 Hereby, \lstinline!terminal()! ensures an event at the end of successful simulation.
 \end{nonnormative}
@@ -1416,6 +1424,7 @@ Returns \lstinline!true! and triggers time events at time instants $\mathit{star
 At event iterations after the first one at each event and during continuous integration the operator always returns \lstinline!false!.
 The starting time $\mathit{start}$ and the sample interval $\mathit{interval}$ must be parameter expressions and need to be a subtype of \lstinline!Real! or \lstinline!Integer!.
 The sample interval $\mathit{interval}$ must be a positive number.
+The operator is not allowed inside \lstinline!function! classes.
 \end{semantics}
 \end{operatordefinition*}
 
@@ -1428,7 +1437,8 @@ Returns the \emph{left limit} $y(t^{-})$ of variable $y(t)$ at a time instant $t
 At an event instant, $y(t^{-})$ is the value of $y$ after the last event iteration at time instant $t$ (see comment below).
 % Warning "component expression" is a term defined for synchronous operator argument restrictions; this seems to conflict with also defining the present argument restriction below.
 Any subscripts in the component expression $y$ must be parameter expressions.
-\lstinline!pre! can be applied if the following three conditions are fulfilled simultaneously: (a) variable $y$ is either a subtype of a simple type or is a record component, (b) $y$ is a discrete-time expression (c) the operator is \emph{not} applied in a \lstinline!function! class.
+The operator is not allowed inside \lstinline!function! classes.
+\lstinline!pre! can be applied to the variable $y$ only if $y$ is a discrete-time expression and $y$ is either a subtype of a simple type or is a record component.
 \begin{nonnormative}
 This can be applied to continuous-time variables in \lstinline!when!-clauses, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
 \end{nonnormative}
@@ -1466,7 +1476,7 @@ change(v)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Expands into \lstinline!($v$ <> pre($v$))!.
-The same restrictions as for \lstinline!pre! apply.
+The same restrictions as for \lstinline!pre! apply (e.g., not to be used in \lstinline!function! classes).
 \end{semantics}
 \end{operatordefinition}
 

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -35,6 +35,7 @@ All transitions leaving one state must have different priorities.
 One and only one instance in each state machine must be marked as initial by appearing in an \lstinline!initialState! statement.
 
 The special kinds of \lstinline!connect!-like equations listed below are used to define define a state machine.
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -50,6 +51,7 @@ The special kinds of \lstinline!connect!-like equations listed below are used to
 The \lstinline!transition!- and \lstinline!initialState!-equations can only be used in equations, and cannot be used inside \lstinline!if!-equations with conditions that are not parameter expressions, or in \lstinline!when!-equations.
 
 The operators listed below are used to query the status of the state machine.
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -418,7 +418,7 @@ Merging the \lstinline!when!-statements can lead to less efficient code and diff
 
 \begin{itemize}
 \item
-  A \lstinline!when!-statement shall not be used within a function.
+  A \lstinline!when!-statement shall not be used inside \lstinline!function! classes.
 \item
   A \lstinline!when!-statement shall not occur inside an initial algorithm.
 \item

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -291,6 +291,7 @@ They are not callable in functions.
 \section{Clock Constructors}\label{clock-constructors}
 
 The overloaded constructors listed below are available to generate clocks, and it is possible to call them with the specified named arguments, or with positional arguments (according to the order shown in the details after the table).
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -539,6 +540,7 @@ A component expression which is not a parameter, and to which \lstinline!previou
 \end{definition}
 
 The previous value of a clocked variable can be accessed with the \lstinline!previous! operator, listed below.
+This operator is not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -577,6 +579,7 @@ A set of \emph{clock conversion operators} together act as boundaries between di
 \subsection{Base-Clock Conversion Operators}\label{base-clock-conversion-operators}\index{base-clock!conversion-operators}\index{conversion-operators!base-clock}
 
 The operators listed below convert between a clocked and an unclocked representation and vice versa.
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -659,6 +662,7 @@ In such a scenario, accessing the left limit of \lstinline!u! in \lstinline!samp
 \subsection{Sub-Clock Conversion Operators}\label{sub-clock-conversion-operators}\index{sub-clock!conversion-operators}\index{conversion-operators!sub-clock}
 
 The operators listed below convert between synchronous clocks.
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline
@@ -1413,6 +1417,7 @@ Instead, initialization is performed in the following way:
 \section{Other Operators}\label{other-operators}
 
 A few additional utility operators are listed below.
+None of these operators are not allowed inside \lstinline!function! classes.
 \begin{center}
 \begin{tabular}{l|l l}
 \hline


### PR DESCRIPTION
I stumbled upon this again, so I thought it was time we get it fixed.

Fixes #3280.
