### PR TITLE
Constrain use of 'delay' with zero delay time

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -945,7 +945,8 @@ For variable step size integrators, the buffer size is dynamic during integratio
 
 In order to avoid extrapolation in the delay buffer, the maximum step size of the integrator is limited by the delay time, making delay times close to zero a potential source of poor simulation performance.
 
-In the form where $\mathit{delayTime}$ is required to be evaluable, a tool can decide to evaluate $\mathit{delayTime}$ only when the value would be zero, and introduce a runtime check that it remains non-zero otherwise.
+It is a quality of implementation to avoid evaluating $\mathit{delayTime}$ when possible.
+A pragmatic approach is to only evaluate $\mathit{delayTime}$ in case the value would be zero, and to check at runtime that it is positive in case it was not evaluated.
 \end{nonnormative}
 
 \subsubsection{spatialDistribution}\label{spatialdistribution}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -825,8 +825,8 @@ delay($\mathit{expr}$, $\mathit{delayTime}$)
 Evaluates to \lstinline!$\mathit{expr}$(time - $\mathit{delayTime}$)! for $\text{\lstinline!time!} > \text{\lstinline!time.start!} + \mathit{delayTime}$ and \lstinline!$\mathit{expr}$(time.start)! for $\text{\lstinline!time!} \leq \text{\lstinline!time.start!} + \mathit{delayTime}$.
 The arguments, i.e., $\mathit{expr}$, $\mathit{delayTime}$ and $\mathit{delayMax}$, need to be subtypes of \lstinline!Real!.
 $\mathit{delayMax}$ shall be a parameter expression.
-If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ is required to be evaluable.
-It is required that $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, with $0 = \mathit{delayTime}$ only being allowed when $\mathit{delayMax}$ is not provided (that is, when $\mathit{delayTime}$ is required to be evaluable).
+If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ is required to be a parameter expression.
+It is required that $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, with $0 = \mathit{delayTime}$ only being allowed if $\mathit{delayTime}$ is evaluable and would evaluate to $0$.
 The operator is not allowed inside \lstinline!function! classes.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 For further details, see \cref{delay}.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -824,9 +824,9 @@ delay($\mathit{expr}$, $\mathit{delayTime}$)
 \begin{semantics}
 Evaluates to \lstinline!$\mathit{expr}$(time - $\mathit{delayTime}$)! for $\text{\lstinline!time!} > \text{\lstinline!time.start!} + \mathit{delayTime}$ and \lstinline!$\mathit{expr}$(time.start)! for $\text{\lstinline!time!} \leq \text{\lstinline!time.start!} + \mathit{delayTime}$.
 The arguments, i.e., $\mathit{expr}$, $\mathit{delayTime}$ and $\mathit{delayMax}$, need to be subtypes of \lstinline!Real!.
-$\mathit{delayMax}$ needs to be additionally a parameter expression.
-The following relation shall hold: $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, otherwise an error occurs.
-If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ needs to be a parameter expression.
+$\mathit{delayMax}$ shall be a parameter expression.
+If $\mathit{delayMax}$ is not supplied in the argument list, $\mathit{delayTime}$ is required to be evaluable.
+It is required that $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$, with $0 = \mathit{delayTime}$ only being allowed when $\mathit{delayMax}$ is not provided (that is, when $\mathit{delayTime}$ is required to be evaluable).
 The operator is not allowed inside \lstinline!function! classes.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 For further details, see \cref{delay}.
@@ -943,9 +943,9 @@ This gives an upper bound on the values of the delayed signals which have to be 
 For real-time simulation where fixed step size integrators are used, this information is sufficient to allocate the necessary storage for the internal buffer before the simulation starts.
 For variable step size integrators, the buffer size is dynamic during integration.
 
-In principle, \lstinline!delay! could break algebraic loops.
-For simplicity, this is not supported because the minimum delay time has to be given as additional argument to be fixed at compile time.
-Furthermore, the maximum step size of the integrator is limited by this minimum delay time in order to avoid extrapolation in the delay buffer.
+In order to avoid extrapolation in the delay buffer, the maximum step size of the integrator is limited by the delay time, making delay times close to zero a potential source of poor simulation performance.
+
+In the form where $\mathit{delayTime}$ is required to be evaluable, a tool can decide to evaluate $\mathit{delayTime}$ only when the value would be zero, and introduce a runtime check that it remains non-zero otherwise.
 \end{nonnormative}
 
 \subsubsection{spatialDistribution}\label{spatialdistribution}


### PR DESCRIPTION
This is a new take on #3245, picking up where it was left with the comment  https://github.com/modelica/ModelicaSpecification/issues/3245#issuecomment-1366255020.  (I am revisiting this now because of my ongoing test implementation of `delay` with event generation.)

I think this solves the issue with an acceptable tradeoff between backwards compatibility and feasibility of actually implementing according to specification:
- As @MarkusOlssonModelon seems to have suggested in [phone meeting](https://github.com/modelica/ModelicaSpecification/issues/3287#issuecomment-1351574969), `delayTime = 0` is forbidden for time-varying `delayTime`.
- In the two argument form `delay(u, delayTime)`, the "new" evaluable variability is used to constrain `delayTime`, making it possible for tools to determine at translation time whether `delayTime` has been set to zero, but not forcing tools to evaluate.
- By allowing `delayTime = 0` in the two argument form, we avoid the need to give complicated rules for when it is an error to have `delayTime = 0` in guarded expressions such as `if tau > 0 then delay(u, tau) else u`.
- In principle, the funky technique of only evaluating `delayTime` when the value would be zero can be avoided by generating different equation systems for the two cases, and make an initialization time decision of which case to use.  (Not expecting any tool to actually do it this way.)
