### PR TITLE
Vectorized min max

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -470,7 +470,6 @@ min($x$, $y$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Returns the least element of the scalars $x$ and $y$; as defined by \lstinline!<!.
-Vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
 \end{semantics}
 \end{operatordefinition*}
 
@@ -499,7 +498,6 @@ max($x$, $y$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 Returns the greatest element of the scalars $x$ and $y$; as defined by \lstinline!>!.
-Vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
 \end{semantics}
 \end{operatordefinition*}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -428,7 +428,7 @@ The mathematical functions and conversion operators listed below do not generate
 \end{tabular}
 \end{center}
 
-Except for the \lstinline!String! conversion operator they are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
+Except for the \lstinline!String! conversion operator, they are vectorizable according to \cref{scalar-functions-applied-to-array-arguments}.
 The \lstinline!min! and \lstinline!max! functions have array-specific variants which perform array reduction operations described in \cref{reduction-functions-and-operators}.
 
 Additional non-event generating mathematical functions are described in \cref{built-in-mathematical-functions-and-external-built-in-functions}, whereas the event-triggering mathematical functions are described in \cref{event-triggering-mathematical-functions}.


### PR DESCRIPTION
Looking at #3651 I realized that there is no real reason not to vectorize min/max with two arguments.
One use-case would be that you can ensure that each element of a vector is >=0 by using:    `max(0, x)`.