### PR TITLE
Make real interval clock similar to rational interval clock.

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -388,17 +388,29 @@ The input argument, $\mathit{interval}$, is a clocked component expression (\cre
 The $\mathit{interval}$ must be strictly positive ($\mathit{interval} > 0$) of type \lstinline!Real! with \lstinline!unit = "s"!.
 The result is of base type \lstinline!Clock! that ticks when \lstinline!time! becomes $t_{\mathrm{start}}$, $t_{\mathrm{start}} + \mathit{interval}_{1}$, $t_{\mathit{start}} + \mathit{interval}_{1} + \mathit{interval}_{2}$, \@\ldots{}
 The clock starts at the start of the simulation $t_{\mathrm{start}}$ or when the controller is switched on.
-Here the next clock tick is scheduled at $\mathit{interval}_{1}$ = \lstinline!previous($\mathit{interval}$)! = \lstinline!$\mathit{interval}$.start!.
-At the second clock tick at time $t_{\mathrm{start}} + \mathit{interval}_{1}$, the next clock tick is scheduled at $\mathit{interval}_{2}$ = \lstinline!previous($\mathit{interval}$)!, and so on.
+Here the next clock tick is scheduled at $\mathit{interval}_{1}$ = \lstinline!$\mathit{interval}$!.
+At the second clock tick at time $t_{\mathrm{start}} + \mathit{interval}_{1}$, the next clock tick is scheduled at $\mathit{interval}_{2}$ = \lstinline!$\mathit{interval}$!, and so on.
 If $\mathit{interval}$ is a parameter expression, the clock defines a periodic clock.
 
 \begin{nonnormative}
-Note, the clock is defined with \lstinline!previous($\mathit{interval}$)!.
-Therefore, for sorting the input argument is treated as known.
 The given interval and time shift can be modified by using the \lstinline!subSample!, \lstinline!superSample!, \lstinline!shiftSample! and \lstinline!backSample! operators on the returned clock, see \cref{sub-clock-conversion-operators}.
 There are restrictions where this operator can be used, see \lstinline!Clock! expressions below.
 Note that $\mathit{interval}$ does not have to an evaluable expression, since different real interval clocks are never compared.
 \end{nonnormative}
+
+\begin{example}
+\begin{lstlisting}[language=modelica]
+  // first clock tick: previous(realNextInterval) = 0.002
+  Real realNextInterval(start = 0.002);
+  Real y3(start = 0);
+equation
+  when Clock(realNextInterval) then
+    // interval clock that ticks at 0, 0.003, 0.007, 0.012, $\ldots$
+    realNextInterval = previous(realNextInterval) + 1e-3;
+    y3 = previous(y3) + 1;
+  end when;
+\end{lstlisting}
+\end{example}
 \end{semantics}
 \end{operatordefinition*}
 


### PR DESCRIPTION
As far as I understand it was intended to resolve it in #2022 - but for some reason the real interval clock part seemed to have been missed. But please verify that this is the intended semantics.

I continued the example to show the similarity.

Closes #3753 