### PR TITLE
Proposal for improving pure situation,

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -225,16 +225,13 @@ The declaration of functions follow these rules:
 \item
   Functions defined in Modelica (non-external) are \emph{normally} assumed to be pure (the exception is the deprecated case below), if they are impure they shall be marked with the \lstinline!impure! keyword.
   They can be explicitly marked as \lstinline!pure!\indexinline{pure}.
-  \begin{nonnormative}
-  However, since functions as default are pure it is not recommended to explicitly declare them as \lstinline!pure!.
-  \end{nonnormative}
-\item
-  External functions must be explicitly declared with \lstinline!pure! or \lstinline!impure!.
 \item
   If a function is declared as \lstinline!impure! any function extending from it shall be declared as \lstinline!impure!.
 \item
-  A deprecated semantics is that external functions (and functions defined in Modelica directly or indirectly calling them) without \lstinline!pure! or \lstinline!impure! keyword are assumed to be impure, but without any restriction on calling them.
-  Except for the function \lstinline!Modelica.Utilities.Streams.print!, a diagnostic must be given if called in a simulation model.
+  External functions should be explicitly declared with \lstinline!pure! or \lstinline!impure!.
+  The case without the keyword is deprecated semantics described in the next item.
+\item
+  A deprecated semantics for functions without \lstinline!pure! or \lstinline!impure! keyword is that they assumed to be impure, but without any restriction on calling them for the following cases: external functions and functions defined in Modelica directly or indirectly (through functions without the \lstinline!pure! keyword) calling external functions without \lstinline!pure! keyword.
 \end{itemize}
 
 Calls of pure functions used inside expression may be skipped if the resulting expression will not depend on the possible returned value; ignoring the possibility of the function generating an error.


### PR DESCRIPTION
To ensure that current MSL is valid and that users can update.

Closes #3719

Note that in addition to the changes in the issue reordered the items and changed "must" to "should" for the deprecated semantic, and clearly indicated that the exception is the deprecated case. 
(Having a "must"-requirement and then have exceptions for it just seems wrong.)