### PR TITLE
Fix grammar and hyperref, remove unused defines

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -168,7 +168,7 @@ The new environment is the result of merging
 \end{itemize}
 in that order.
 
-Array dimensions shall be scalar non-negative evaluable expressions of type \lstinline!Integer!, a reference to a type (which must an enumeration type or \lstinline!Boolean!, see \cref{enumeration-types}), or the colon operator denoting that the array dimension is left unspecified (see \cref{array-declarations}).
+Array dimensions shall be scalar non-negative evaluable expressions of type \lstinline!Integer!, a reference to a type (which must be an enumeration type or \lstinline!Boolean!, see \cref{enumeration-types}), or the colon operator denoting that the array dimension is left unspecified (see \cref{array-declarations}).
 All variants can also be part of short class definitions.
 
 \begin{example}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -151,7 +151,7 @@ Modelica functions have the following restrictions compared to a general Modelic
   A function shall \emph{not be used in connections}, shall not have \emph{equations}, shall not have \emph{initial algorithms}.
 \item
   A function can have at most \emph{one algorithm} section or \emph{one external function interface} (not both), which, if present, is the body of the function.
-  The body of the function shall not contain \lstinline!when!-statements, see \label{where-a-when-statement-may-occur}.
+  The body of the function shall not contain \lstinline!when!-statements, see \cref{where-a-when-statement-may-occur}.
 \item
   A function may only contain components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!function!; and it must not contain, e.g., \lstinline!model!, \lstinline!block!, \lstinline!operator! or \lstinline!connector! components.
 \item

--- a/preamble.tex
+++ b/preamble.tex
@@ -191,13 +191,6 @@
 % Like \annotationindex, but also outputting the formatted name of the annotation.
 \newcommand{\fmtannotationindex}[1]{\lstinline{#1}\annotationindex{#1}}
 
-\def\S0#1#2{\hypertarget{#2}\chapter{#1}\label{#2}}
-\def\S1#1#2{\hypertarget{#2}\section{#1}\label{#2}}
-\def\S2#1#2{\hypertarget{#2}\subsection{#1}\label{#2}}
-\def\S3#1#2{\hypertarget{#2}\subsubsection{#1}\label{#2}}
-\def\S4#1#2{\hypertarget{#2}\paragraph{#1}\label{#2}}
-\def\S5#1#2{\hypertarget{#2}\subparagraph{#1}\label{#2}}
-
 % Simple numbering of lists, should preferably use \usepackage{enumitem}
 % https://stackoverflow.com/questions/2007627/latex-how-can-i-create-nested-lists-which-look-this-1-1-1-1-1-1-1-2-1-2
 %\usepackage{enumitem} % Package not available for continuous integration builds.


### PR DESCRIPTION
I suppose those `\def\S` are obsolete, since they are no longer used anywhere.