### PR TITLE
Clarify that a fixed parameter cannot make use of fallback

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -782,6 +782,7 @@ In this case a diagnostic message is recommended in a simulation model, unless t
 \begin{nonnormative}
 This is used in libraries to give rudimentary defaults so that users can quickly combine models and simulate without setting parameters; but still easily find the parameters that should be set properly.
 The \lstinline!enable=false! case can be used to provide default values for parameters that are not used in the current configuration, while ensuring that they are explicitly given a value when used.
+Note that the fallback value handling must not be interpreted as all variables having a value for the \lstinline!start!-attribute, so only an explicit \lstinline!start!-attribute can be used for a parameter binding.
 \end{nonnormative}
 
 All variables declared as \lstinline!parameter! having \lstinline!fixed = false! are treated as unknowns during the initialization phase, i.e., there must be additional equations for them -- and the \lstinline!start!-value can be used as a guess-value during initialization.


### PR DESCRIPTION
This is a small follow-up to #3075, since it was still not clear to @maltelenz how to interpret the specification.
