### PR TITLE
Generalize modern table presentation with application to Protection

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1096,12 +1096,11 @@ The default for \lstinline!iconTransformation! is to be the same as \lstinline!t
 \end{semantics}
 \end{annotationdefinition}
 
-%\begin{nonnormative}
-%A connector can be shown in both an icon layer and a diagram layer of a class.
-%Since the coordinate systems typically are different, placement information needs to be given using two different coordinate systems.
-%More flexibility than just using scaling and translation is needed since the abstraction views might need different visual placement of the connectors.
-%The attribute \lstinline!transformation! gives the placement in the diagram layer and \lstinline!iconTransformation! gives the placement in the icon layer.
-%\end{nonnormative}
+\begin{nonnormative}
+While it is possible to have independent placements of a connector in the icon and diagram layers, this freedom should be used with care.
+A user who wants to find out what hides behind the icon of a component by opening up the component's diagram view will benefit if the relative positioning of connectors are similar between icon and diagram.
+This way, intuitive understanding of the diagram layer is enabled without the need to pay attention to connector names.
+\end{nonnormative}
 
 The \lstinline!transformation! and \lstinline!iconTransformation! of the \lstinline!Placement! annotation have the following type:
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
This PR aims to make the presentation of the `Protection` annotation more similar to the presentation of other annotations, even though `Protection` only acts as a container for sub-annotations which are defined in more detail one by one.  If we can work this out for `Protection`, it should be straightforward to treat `Documentation` in the same manner.
