### PR TITLE
Propose Solution for connectorSizing

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1753,7 +1753,7 @@ The \lstinline!connectorSizing! annotation is used in cases where connections to
 The annotation allows a tool to perform these two actions in many cases automatically.
 This is, e.g., very useful for state machines and for certain components of fluid libraries.
 
-If a variable \lstinline!n! with \lstinline!connectorSizing = true! has multiple associated vectors of connectors, some of the graphical operations described below will not work reliably.
+If a variable \lstinline!n! with \lstinline!connectorSizing = true! would have multiple associated vectors of connectors, some of the graphical operations described below would not work reliably.
 If there is no associated vector of connectors, the user may choose to address this by removing the \lstinline!connectorSizing! annotation or the entire variable.
 \end{nonnormative}
 


### PR DESCRIPTION
Closes #3772 
It explains the existing use of `n+0`.

I use "should" to not discuss the edge-cases, in particular:
- Unused connectorSizing-variable could perhaps be used in a base-class, but it seems odd to me (how do you know that you will have such a connector without knowing name and type?)
- Multiple vector of connectors using `n` will work in some cases, but not in all cases.
