### PR TITLE
The MCP links were no longer working, when the branches are merged.

### DIFF
--- a/RationaleMCP/ReadMe.md
+++ b/RationaleMCP/ReadMe.md
@@ -18,16 +18,16 @@ but the rest of the development on a branch/pull-request before being accepted.
 
 ## List of existing MCPs
 
-|Status|Number|Name|Branch|Issue|
+|Status|Number|Name|Documents|Issue|
 |------|------|----|----|-|
 |Active|0039|Licensing and encryption|[MCP/0039](https://github.com/modelica/ModelicaSpecification/tree/MCP/0039/RationaleMCP/0039)|https://github.com/modelica/ModelicaSpecification/pull/2931|
 |Active|0038|Initialization of Clocked Partitions|[MCP/0038](https://github.com/modelica/ModelicaSpecification/tree/MCP/0038/RationaleMCP/0038)||
 |Active|0037|Generalized Modelica URIs|[MCP/0037](https://github.com/modelica/ModelicaSpecification/tree/MCP/0037/RationaleMCP/0037)|https://github.com/modelica/ModelicaSpecification/pull/2663|
 |Active|0036|Setting states|[MCP/0036](https://github.com/modelica/ModelicaSpecification/tree/MCP/0036/RationaleMCP/0036)|https://github.com/modelica/ModelicaSpecification/pull/3164|
-|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0035|Multilingual support of Modelica|[MCP/0035](https://github.com/modelica/ModelicaSpecification/tree/MCP/0035/RationaleMCP/0035)|https://github.com/modelica/ModelicaSpecification/pull/2956|
+|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0035|Multilingual support of Modelica|[MCP/0035](https://github.com/modelica/ModelicaSpecification/tree/master/RationaleMCP/0035)|https://github.com/modelica/ModelicaSpecification/pull/2956|
 |Active|0034|Ternary|[MCP/0034](https://github.com/modelica/ModelicaSpecification/tree/MCP/0034/RationaleMCP/0034)|https://github.com/modelica/ModelicaSpecification/pull/2477|
-|Added in [3.5](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.5)|0033|Annotations for Predefined Plots|[MCP/0033](https://github.com/modelica/ModelicaSpecification/tree/MCP/0033/RationaleMCP/0033)||
-|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0032|Selective Model Extension|[MCP/0032](https://github.com/modelica/ModelicaSpecification/tree/MCP/0032/RationaleMCP/0032)|https://github.com/modelica/ModelicaSpecification/pull/3166|
+|Added in [3.5](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.5)|0033|Annotations for Predefined Plots|[MCP/0033](https://github.com/modelica/ModelicaSpecification/tree/master/RationaleMCP/0033)||
+|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0032|Selective Model Extension|[MCP/0032](https://github.com/modelica/ModelicaSpecification/tree/master/RationaleMCP/0032)|https://github.com/modelica/ModelicaSpecification/pull/3166|
 |Active|0031|Base Modelica and MLS modularization|[MCP/0031](https://github.com/modelica/ModelicaSpecification/tree/MCP/0031/RationaleMCP/0031)|
 |On hold|0030|IsClocked Operator||[#2238](https://github.com/modelica/ModelicaSpecification/issues/2238)|
 |Active|0029|License Export|[MCP/0029](https://github.com/modelica/ModelicaSpecification/tree/MCP/0029/RationaleMCP/0029)|https://github.com/modelica/ModelicaSpecification/pull/2900|
@@ -45,12 +45,12 @@ but the rest of the development on a branch/pull-request before being accepted.
 |Active|0017|Portable import of FMUs|||
 |Active|0016|Semantic Versions|||
 |Active|0015|Language Version Header|[MCP/0015](https://github.com/modelica/ModelicaSpecification/tree/MCP/0015/RationaleMCP/0015)||
-|Added in [3.4](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.4)|0014|Conversion||[#1622](https://github.com/modelica/ModelicaSpecification/issues/1622)|
+|Added in [3.4](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.4)|0014|Conversion|[MCP/0014](https://github.com/modelica/ModelicaSpecification/tree/master/RationaleMCP/0014)|[#1622](https://github.com/modelica/ModelicaSpecification/issues/1622)|
 |On hold|0013|Introducing polymorphic functions||
 |Active|0012|Calling blocks as functions|[MCP/0012](https://github.com/modelica/ModelicaSpecification/tree/MCP/0012/RationaleMCP/0012)||
 |On hold|0011|Allow user-defined functions in reductions|||
 |On hold|0010|Adding guards to reductions|||
-|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0009|Undefined modification|[MCP/0009](https://github.com/modelica/ModelicaSpecification/tree/MCP/0009/RationaleMCP/0009)|https://github.com/modelica/ModelicaSpecification/pull/3167|
+|Accepted in [3.6](https://github.com/modelica/ModelicaSpecification/releases/tag/v3.6)|0009|Undefined modification|[MCP/0009](https://github.com/modelica/ModelicaSpecification/tree/master/RationaleMCP/0009)|https://github.com/modelica/ModelicaSpecification/pull/3167|
 |On hold|0008|Custom annotations|||
 |On hold|0007|Match expressions|||
 |On hold|0006|Atomic blocks|||


### PR DESCRIPTION
Changing to using the folder on master in that case, and changing header to "Documents".
We _could_ make a clearer distinction, or have a separate column for just the branch - but that's mostly internal and for external use this should suffice.
(Similarly removing the documents-folder once merged doesn't make sense for external use.)