### PR TITLE
Define size(A, j) as syntactic sugar

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -254,8 +254,8 @@ The functions listed below operate on the array dimensions of the type of an exp
 \hline
 \hline
 {\lstinline!ndims($A$)!} & Number of dimensions & \Cref{modelica:ndims} \\
-{\lstinline!size($A$, $i$)!} & Size of single array dimension & \Cref{modelica:size-of-dim} \\
 {\lstinline!size($A$)!} & Sizes of all array dimensions & \Cref{modelica:size-vector} \\
+{\lstinline!size($A$, $i$)!} & Size of single array dimension & \Cref{modelica:size-of-dim} \\
 \hline
 \end{tabular}
 \end{center}
@@ -269,17 +269,6 @@ Returns the number of dimensions $k$ of expression $A$, with $k \geq 0$.
 \end{semantics}
 \end{operatordefinition}
 
-\begin{operatordefinition*}[size]\label{modelica:size-of-dim}\index{size@\robustinline{size}!of single array dimension}
-\begin{synopsis}\begin{lstlisting}
-size($A$, $i$)
-\end{lstlisting}\end{synopsis}
-\begin{semantics}
-Returns the size of dimension $i$ of array expression $A$ where $1 \leq i \leq$ \lstinline!ndims($A$)!.
-
-If $A$ refers to a component of an expandable connector, then the component must be a declared component of the expandable connector, and it must not use colon (\lstinline!:!) to specify the array size of dimension $i$.
-\end{semantics}
-\end{operatordefinition*}
-
 \begin{operatordefinition*}[size]\label{modelica:size-vector}\index{size@\robustinline{size}!of all array dimensions}
 \begin{synopsis}\begin{lstlisting}
 size($A$)
@@ -288,6 +277,16 @@ size($A$)
 Returns a vector of length \lstinline!ndims($A$)! containing the dimension sizes of $A$.
 
 If $A$ refers to a component of an expandable connector, then the component must be a declared component of the expandable connector, and it must not use colon (\lstinline!:!) to specify the size of any array dimension.
+\end{semantics}
+\end{operatordefinition*}
+
+\begin{operatordefinition*}[size]\label{modelica:size-of-dim}\index{size@\robustinline{size}!of single array dimension}
+\begin{synopsis}\begin{lstlisting}
+size($A$, $i$)
+\end{lstlisting}\end{synopsis}
+\begin{semantics}
+Syntactic sugar for \lstinline!(size($A$))[$i$]!, that is, the size of dimension $i$ of array expression $A$.
+(It follows that it is required that $1 \leq i \leq$ \lstinline!ndims($A$)!.)
 \end{semantics}
 \end{operatordefinition*}
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1617,7 +1617,7 @@ Evaluable expressions\index{evaluable expression}\index{expression variability!e
   Some function calls are evaluable expressions even if one or more arguments are not:
   \begin{itemize}
   \item
-    \lstinline!size(A)! (including \lstinline!size(A, j)! where \lstinline!j! is an evaluable expression) if \lstinline!A! is variable declared in a non-function class.
+    \lstinline!size(A)! if \lstinline!A! is variable declared in a non-function class.
   \item
     \lstinline!delay($x$, $\ldots$)! where $x$ is an evaluable expression.
   \item
@@ -1642,8 +1642,6 @@ Parameter expressions\index{parameter!expression}\index{expression variability!p
 \item
   Some function calls are parameter expressions even if one or more arguments are not:
   \begin{itemize}
-  \item
-    \lstinline!size(A, j)! where \lstinline!j! is a parameter expression, if \lstinline!A! is variable declared in a non-function class.
   \item
     \lstinline!delay($x$, $\ldots$)! where $x$ is a parameter expression.
   \end{itemize}


### PR DESCRIPTION
Fixes #3778.  As suggested in https://github.com/modelica/ModelicaSpecification/issues/3778#issuecomment-3607367633.
