### PR TITLE
Add noneFromVersion to document index

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1938,7 +1938,7 @@ package-versions :
    | "{" PACKAGE-VERSION { "," PACKAGE-VERSION } "}"
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-\lstinline!conversion(noneFromVersion = $\mathit{fromVersion}$)! defines that models and packages using the $\mathit{fromVersion}$ can be upgraded to the $\mathit{currentVersion}$ of the current class without any changes.
+\lstinline!conversion(noneFromVersion = $\mathit{fromVersion}$)!\annotationindex{noneFromVersion} defines that models and packages using the $\mathit{fromVersion}$ can be upgraded to the $\mathit{currentVersion}$ of the current class without any changes.
 
 \lstinline!conversion(from(version = $\mathit{fromVersions}$, to = $\mathit{toVersion}$, $\mathit{conversionRules}$))! defines that models and packages using any of the $\mathit{fromVersions}$ can be upgraded to the $\mathit{toVersion}$ (if the $\mathit{toVersion}$ is omitted, this is the $\mathit{currentVersion}$) of the current class by applying the $\mathit{conversionRules}$.
 When $\mathit{conversionRules}$ is given as \lstinline!script = $\mathit{conversionScript}$!, the $\mathit{conversionScript}$ is the name of a file consisting of an unordered sequence of \lstinline[language=grammar]!conversion-rule ";"! and Modelica comments, where any comments should be ignored by tools.


### PR DESCRIPTION
On behalf of @maltelenz.

Note that we already have the conversion commands (`convertClass` etc) listed in the index, so also including `noneFromVersion` didn't seem excessive to me.  However, while I can see that someone could be interested in looking up `noneFromVersion` in the index, I found it less likely that anyone would look for its sibling `from` – one would probably look up `conversion` or one of the conversion commands instead.
