### PR TITLE
Disambiguate passing of constant protected component references in external call

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1942,7 +1942,7 @@ A component reference to a component that is part of an input or output is treat
 \subsection{Argument type Mapping}\label{argument-type-mapping}
 
 The arguments of the external function are declared in the same order as in the Modelica declaration, unless specified otherwise in an explicit external function call.
-Protected variables (i.e., temporaries) are passed in the same way as outputs, whereas constants and {\lstinline!size!} calls are passed as inputs.
+Values of constant expressions (including references to constant components) and \lstinline!size! calls are passed as inputs, whereas protected non-constant variables (i.e., temporaries) are passed in the same way as outputs.
 
 \subsubsection{Simple Types}\label{simple-types}
 


### PR DESCRIPTION
Fixes #3809. Fixes #3810.

Based on https://github.com/modelica/ModelicaSpecification/issues/3809#issuecomment-3789919930, but with more words to make it even more clear.
