### PR TITLE
Fix language mistakes in "left hand side" and "similarly as"

### DIFF
--- a/RationaleMCP/0029/ReadMe.md
+++ b/RationaleMCP/0029/ReadMe.md
@@ -54,7 +54,7 @@ The following commits at the Git repository at https://github.com/modelica-3rdpa
    - It is recommended to use ModelicaPackage/Resource/Licenses as the directory for the license files.
 1. https://github.com/modelica-3rdparty/ExternData/commit/f38372d825b20eac4de01ce01b95560522b43ad2
    - The license file LICENSE_ExternData.txt of the Modelica package is referenced by the Modelica top-level class as new annotation License="modelica://ExternData/Resources/Licenses/LICENSE_ExternData.txt".
-     To introduce this new annotation on existing Modelica packages in a Modelica-compliant and vendorneutral way, the `__ModelicaAssociation` prefix was added (similar as `__ModelicaAssociation_Impure` in MSL v3.2.2).
+     To introduce this new annotation on existing Modelica packages in a Modelica-compliant and vendorneutral way, the `__ModelicaAssociation` prefix was added (similar to `__ModelicaAssociation_Impure` in MSL v3.2.2).
      This means, that library developers can adopt early to this proposal, for example a new MSL v3.2.3 can already introduce this new annotation and is not needed to be based on a new release of the Modelica language specification.
 1. https://github.com/modelica-3rdparty/ExternData/commit/d6dec789aec1c1333386161147c91cdd49b484d0
    - All third-party licenses are listed as new License annotation to the external functions.

--- a/RationaleMCP/Changes/3_7/3610.md
+++ b/RationaleMCP/Changes/3_7/3610.md
@@ -26,5 +26,5 @@ end foo;
 Real x=foo(time);
 ```
 
-The call of `bar` in `foo` is now illegal, similar to when appearing in a model.
+The call of `bar` in `foo` is now illegal, similar to using `bar` directly in a model.
 Note that in practice `foo` might contain both something generating event and the call to `bar`.

--- a/RationaleMCP/Changes/3_7/3610.md
+++ b/RationaleMCP/Changes/3_7/3610.md
@@ -6,7 +6,7 @@ Variability of functions with `GenerateEvents`.
 
 ## Reason
 
-Making it possible to create functions that generate events similarly as the built-in functions, and have rules consistent with them just being inlined.
+Making it possible to create functions that generate events similarly to the built-in functions, and have rules consistent with them just being inlined.
 
 ## Breaks
 
@@ -26,5 +26,5 @@ end foo;
 Real x=foo(time);
 ```
 
-The call of `bar` in `foo` is now illegal, similarly as in a model.
+The call of `bar` in `foo` is now illegal, similar to when appearing in a model.
 Note that in practice `foo` might contain both something generating event and the call to `bar`.

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -311,7 +311,7 @@ model ModifiedFiltersInSeries
   FiltersInSeries F34(F1.T=6, F2.T=11, F2.k=2); // alternative 2
 end ModifiedFiltersInSeries;
 ```
-The class concept is similar as in programming languages.
+The class concept is similar to classes in many other programming languages.
 It is used for many purposes in Modelica, such as model components, connection mechanisms, parameter sets, input-output blocks and functions.
 In order to make Modelica classes easier to read and to maintain, special keywords have been introduced for such special uses, model, connector, record, block, function, type and package.
 It should be noted though that the use of these keywords only apply certain restrictions, like records are not allowed to contain equations.
@@ -1234,7 +1234,7 @@ algorithm
 ```
 (In this case an equation would likely be preferable.)
 Here, the condition `h1 < hmax` has higher priority than the condition `pushbutton`, if both conditions become true at the same event instant.
-Similarly as for when-clauses in equation sections, the precise meaning of this when-clause in an algorithm can be expressed as:
+Similarly to when-clauses in equation sections, the precise meaning of this when-clause in an algorithm can be expressed as:
 ```Modelica
   Boolean open(start = false);
   Boolean b1 (start = h1.start < hmax);

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -732,7 +732,7 @@ end TestCase;
 If \lstinline!shouldPass! is \lstinline!false! it indicates that the translation or the simulation of the model should fail.
 If a tools checks a package where classes have \lstinline!shouldPass = false! they should not generate errors, and checking may even be skipped.
 On the other hand, models with \lstinline!shouldPass = false! may be useful for creation of negative tests in tool-specific ways.
-Similarly as a class with \lstinline!obsolete! annotation, a class with \lstinline!TestCase! annotation (regardless of the value of \lstinline!shouldPass!) shall not be used in other models, unless those models also have a \lstinline!TestCase! annotation.
+Similarly to a class with \lstinline!obsolete! annotation, a class with \lstinline!TestCase! annotation (regardless of the value of \lstinline!shouldPass!) shall not be used in other models, unless those models also have a \lstinline!TestCase! annotation.
 
 If the \lstinline!TestCase! annotation is missing it is a normal model -- there are thus no restrictions on the use of the model, and the model shall not contain errors.
 

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1099,7 +1099,7 @@ It is a quality of implementation for a tool to verify this property in general,
 \end{nonnormative}
 
 \begin{definition}[Globally balanced]\index{globally balanced}\index{balanced!globally}
-Similarly to locally balanced, but including all unknowns and equations from all components.
+Similar to locally balanced, but including all unknowns and equations from all components.
 The global number of unknowns is computed by expanding all unknowns (i.e., excluding parameters and constants) into a set of scalars of primitive types.
 This should match the global equation size defined as:
 \begin{itemize}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -1048,7 +1048,7 @@ The local equation size of a \lstinline!model! or \lstinline!block! class is the
 \begin{itemize}
 \item
   The number of equations defined locally (i.e., not in any \lstinline!model! or \lstinline!block! component), including binding equations, and equations generated from \lstinline!connect!-equations.
-  Similarly as for variables the count is after expanding to scalars of primitive types.
+  Similar to variable counting, the counting is done after expanding to scalars of primitive types.
   For calls of functions with multiple outputs, \cref{output-formal-parameters-of-functions} the number of equations is the total number of scalar primitive elements of the component references in the left hand side.
   For \lstinline!assert! and other empty functions calls \cref{empty-function-calls} the size is zero.
   \begin{nonnormative}
@@ -1099,7 +1099,7 @@ It is a quality of implementation for a tool to verify this property in general,
 \end{nonnormative}
 
 \begin{definition}[Globally balanced]\index{globally balanced}\index{balanced!globally}
-Similarly as locally balanced, but including all unknowns and equations from all components.
+Similarly to locally balanced, but including all unknowns and equations from all components.
 The global number of unknowns is computed by expanding all unknowns (i.e., excluding parameters and constants) into a set of scalars of primitive types.
 This should match the global equation size defined as:
 \begin{itemize}

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -954,7 +954,7 @@ end foo1; end foo;
 
 \end{itemize}
 
-Additionally only components which are of specialized classes \lstinline!record!, \lstinline!type!, \lstinline!operator record!, and connector classes based on any of those can be used as component references in normal expressions and in the left hand side of assignments, subject to normal type compatibility rules.
+Additionally only components which are of specialized classes \lstinline!record!, \lstinline!type!, \lstinline!operator record!, and connector classes based on any of those can be used as component references in normal expressions and in the left-hand side of assignments, subject to normal type compatibility rules.
 Additionally components of connectors may be arguments of \lstinline!connect!-equations, and any component can be used as argument to the \lstinline!ndims! and \lstinline!size!-functions, or for accessing elements of that component (possibly in combination with array indexing).
 
 \begin{example}

--- a/chapters/dae.tex
+++ b/chapters/dae.tex
@@ -174,7 +174,7 @@ loop
 end loop
 \end{lstlisting}
 
-Clocked variables are handled similarly as $z$ and $m$ (depending on type), but using \lstinline!previous! instead of \lstinline!pre! and only solved in the first event iteration.
+Clocked variables are handled similarly to $z$ and $m$ (depending on type), but using \lstinline!previous! instead of \lstinline!pre! and only solved in the first event iteration.
 
 Solving \eqref{eq:hydrid-dae} for the unknowns is non-trivial, because this set of equations contains not only \lstinline!Real!, but also discrete-valued unknowns.
 Usually, in a first step these equations are sorted and in many cases the discrete-valued unknowns $m$ can be just computed by a forward evaluation sequence.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -744,10 +744,10 @@ If the condition of the \lstinline!when!-clause contains \lstinline!initial()!, 
 The algorithmic statements within a \lstinline!when!-statement are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the \lstinline!when!-statement remain active during the whole initialization phase.
 
-An active \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly as for \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
+An active \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 
 \begin{nonnormative}
-That means that any subsequent \lstinline!elsewhen initial()! has no effect, similarly as \lstinline!when false then!.
+That means that any subsequent \lstinline!elsewhen initial()! has no effect, similarly to \lstinline!when false then!.
 \end{nonnormative}
 
 \begin{nonnormative}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -312,7 +312,7 @@ Additionally,
 \item
   The branches of an \lstinline!if!-equation inside \lstinline!when!-equations must have the same set of component references on the left-hand side, unless all switching conditions of the \lstinline!if!-equation are parameter expressions.
 \item
-  Any left hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be evaluable expressions.
+  Any left-hand side reference, (\lstinline!v!, \lstinline!out1!, \ldots), in a \lstinline!when!-clause must be a component reference, and any indices must be evaluable expressions.
 \end{itemize}
 
 \begin{nonnormative}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -110,7 +110,7 @@ For example, it is possible to modify and extend a \lstinline!function! class to
 \end{nonnormative}
 
 A special case is defining a \lstinline!function! as a short-class definition with modifiers for inputs inside a model.
-These default values, unless overridden in the function call, will then be considered for variability similarly as if they were given in the function call, see \cref{function-variability}.
+These default values, unless overridden in the function call, will then be considered for variability similarly to if they were given in the function call, see \cref{function-variability}.
 
 \begin{example}
 Demonstrating the variability implications.
@@ -2713,7 +2713,7 @@ The functions listed below produce a message in different ways.
 
 The \emph{Message}-functions only produce the message, but the \emph{Warning}- and \emph{Error}-functions combine this with error handling as follows.
 
-The \emph{Warning}-functions view the message as a warning and can skip duplicated messages similarly as an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Warning!} in the Modelica code.
+The \emph{Warning}-functions view the message as a warning and can skip duplicated messages similarly to an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Warning!} in the Modelica code.
 
 The \emph{Error}-functions never return to the calling function, but handle the error similarly to an {\lstinline!assert!} with {\lstinline!level = AssertionLevel.Error!} in the Modelica code.
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -110,7 +110,7 @@ For example, it is possible to modify and extend a \lstinline!function! class to
 \end{nonnormative}
 
 A special case is defining a \lstinline!function! as a short-class definition with modifiers for inputs inside a model.
-These default values, unless overridden in the function call, will then be considered for variability similarly to if they were given in the function call, see \cref{function-variability}.
+These default values, unless overridden in the function call, will then be considered for variability as if they were given in the function call, see \cref{function-variability}.
 
 \begin{example}
 Demonstrating the variability implications.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -252,7 +252,7 @@ A call to a function with no declared outputs is assumed to have desired side-ef
 
 \begin{nonnormative}
 A tool shall thus not remove such function calls, with exception of non-triggered assert calls.
-A pure function, used in an expression or used with a non-empty left hand side, need not be called if the output from the function call do not mathematically influence the simulation result, even if errors would be generated if it were called.
+A pure function, used in an expression or used with a non-empty left-hand side, need not be called if the output from the function call do not mathematically influence the simulation result, even if errors would be generated if it were called.
 \end{nonnormative}
 
 \begin{nonnormative}
@@ -598,8 +598,8 @@ end surfaceQuadrature;
 \subsection{Output Formal Parameters}\label{output-formal-parameters-of-functions}
 
 A function may have more than one output component, corresponding to multiple return values.
-The only way to use more than the first return value of such a function is to make the function call the right hand side of an equation or assignment.
-In this case, the left hand side of the equation or assignment shall contain a list of component references within parentheses:
+The only way to use more than the first return value of such a function is to make the function call the right-hand side of an equation or assignment.
+In this case, the left-hand side of the equation or assignment shall contain a list of component references within parentheses:
 
 \lstinline!(out1, out2, out3) = f($\ldots$);!
 
@@ -609,7 +609,7 @@ The type of each component reference in the list must agree with the type of the
 
 A function application may be used as expression whose value and type is given by the value and type of the first output component, if at least one return result is provided.
 
-It is possible to omit left hand side component references and/or truncate the left hand side list in order to discard outputs from a function call.
+It is possible to omit left-hand side component references and/or truncate the left-hand side list in order to discard outputs from a function call.
 
 \begin{nonnormative}
 Optimizations to avoid computation of unused output results can be automatically deduced by an optimizing compiler.
@@ -643,7 +643,7 @@ end eigen;
 \end{lstlisting}
 \end{example}
 
-The only permissible use of an expression in the form of a list of expressions in parentheses, is when it is used as the left hand side of an equation or assignment where the right hand side is an application of a function.
+The only permissible use of an expression in the form of a list of expressions in parentheses, is when it is used as the left-hand side of an equation or assignment where the right-hand side is an application of a function.
 
 \begin{example}
 The following are illegal:
@@ -1822,7 +1822,7 @@ end bad;
 \end{lstlisting}
 
 In \lstinline!M!, there will be an event when \lstinline!time! becomes greater or equal to \lstinline!1!, and thus the discrete-time variable \lstinline!b1! can be bound to this function call even though it involves the non-discrete time variable \lstinline!time!.
-Both \lstinline!b2! and \lstinline!b3! are illegal, since the right hand sides have non-discrete-time variability.
+Both \lstinline!b2! and \lstinline!b3! are illegal, since the right-hand sides have non-discrete-time variability.
 The variable \lstinline!z! is legal, since a \lstinline!Real! variable can have non-discrete time variability.
 The variable \lstinline!b4! is legal, since the function inputs have discrete-time variability.
 The function \lstinline!bad! demonstrates that similar restrictions (as for \lstinline!b2! and \lstinline!b3!) apply inside functions with {\lstinline!GenerateEvents = true!}.

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -18,7 +18,7 @@ The following properties are different to Lucid Synchrone 3.0:
   For this reason, the state machines in this chapter use \emph{immediate} (= the same as \emph{strong}) and \emph{delayed} transitions.
   Delayed transitions are \emph{immediate} transitions where the condition is automatically delayed with an implicit \lstinline!previous!.
 \item
-  Parallel state machines can be explicitly synchronized with a language element (similarly as parallel branches in Sequential Function Charts).
+  Parallel state machines can be explicitly synchronized with a language element (similarly to parallel branches in Sequential Function Charts).
   This often occurring operation can also be defined in Statecharts or in Lucid Synchrone state machines but only indirectly with appropriate conditions on transitions.
 \item
   Modelica blocks can be used as states.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -28,7 +28,7 @@ See \cref{initialization-initial-equation-and-initial-algorithm} for a descripti
 \subsection{An Algorithm in a Model}\label{execution-of-an-algorithm-in-a-model}\label{an-algorithm-in-a-model}
 
 An algorithm section is conceptually a code fragment that remains together and the statements of an algorithm section are executed in the order of appearance.
-Whenever an algorithm section is invoked, all variables appearing on the left hand side of the assignment operator \lstinline!:=! are initialized (at least conceptually):
+Whenever an algorithm section is invoked, all variables appearing on the left-hand side of the assignment operator \lstinline!:=! are initialized (at least conceptually):
 \begin{itemize}
 \item
   A continuous-time variable is initialized with the value of its \lstinline!start!-attribute.
@@ -37,7 +37,7 @@ Whenever an algorithm section is invoked, all variables appearing on the left ha
 \item
   A clocked variable \lstinline!v! in a discrete-time sub-partition, \cref{clocked-and-discretized-partition}, is initialized with \lstinline!previous(v)!.
 \item
-  If at least one element of an array appears on the left hand side of the assignment operator, then the complete array is initialized in this algorithm section.
+  If at least one element of an array appears on the left-hand side of the assignment operator, then the complete array is initialized in this algorithm section.
 \item
   In an initial algorithm, \cref{initialization-initial-equation-and-initial-algorithm}, any variable (including a parameter) is initialized with the value of its \lstinline!start!-attribute.
 \end{itemize}

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -64,7 +64,7 @@ when sample(0, 3) then
 end when;
 \end{lstlisting}
 
-Equations in a \lstinline!when!-clause with a \lstinline!Boolean! condition have the property that (a) variables on the left hand side of the equal sign are assigned a value when the when-condition becomes true and otherwise hold their value, (b) variables not assigned in the \lstinline!when!-clause are directly accessed (= automatic \lstinline!sample! semantics), and (c) the variables assigned in the \lstinline!when!-clause can be directly accessed outside of the \lstinline!when!-clause (= automatic \lstinline!hold! semantics).
+Equations in a \lstinline!when!-clause with a \lstinline!Boolean! condition have the property that (a) variables on the left-hand side of the equal sign are assigned a value when the when-condition becomes true and otherwise hold their value, (b) variables not assigned in the \lstinline!when!-clause are directly accessed (= automatic \lstinline!sample! semantics), and (c) the variables assigned in the \lstinline!when!-clause can be directly accessed outside of the \lstinline!when!-clause (= automatic \lstinline!hold! semantics).
 
 Using standard \lstinline!when!-clauses works well for individual simple sampled blocks, but the synchronous approach using clocks and clocked equations provide the following benefits (especially for large sampled systems):
 \begin{enumerate}
@@ -85,7 +85,7 @@ Using standard \lstinline!when!-clauses works well for individual simple sampled
   For a standard \lstinline!when!-clause all variables assigned in a \lstinline!when!-clause must have an initial value because they might be used, before they are assigned a value the first time.
   As a result, all these variables are ``discrete-time states'' although in reality only a subset of them need an initial value.
 \item
-  More general equations can be used, compared to standard \lstinline!when!-clauses that require a restricted form of equations where the left hand side has to be a variable, in order to identify the variables that are assigned in the \lstinline!when!-clause.
+  More general equations can be used, compared to standard \lstinline!when!-clauses that require a restricted form of equations where the left-hand side has to be a variable, in order to identify the variables that are assigned in the \lstinline!when!-clause.
   This restriction can be circumvented for standard \lstinline!when!-clauses, but is absent for clocked equations and make it more convenient to define nonlinear control algorithms.
 \item
   Clocked equations allow clock inference, meaning that the sampling need only be given once for a sub-system.


### PR DESCRIPTION
Fixing language mistakes encountered when working on #3763.  Making a separate PR for this, so that the PR fixing #3763 can be cleaner.
