### PR TITLE
Limit arrays

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -776,6 +776,7 @@ where N represents arbitrary array dimensions, conceptually yields an array clas
 \end{lstlisting}
 
 Such an array class has exactly one anonymous component (\_); see also \cref{restriction-on-combining-base-classes-and-other-elements}.
+This is not legal for specialized class \lstinline!package! and \lstinline!function!.
 When a component of such an array class type is flattened, the resulting flattened component type is an array type with the same dimensions as \_ and with the optional modifier applied.
 
 \begin{example}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -833,7 +833,7 @@ There are basically four groups of built-in functions in Modelica:
 
 \section{Record Constructor Functions}\label{record-constructor-functions}
 
-Whenever a record is defined, a record constructor function with the same name and in the same scope as the record class is implicitly defined according to the following rules:
+Whenever a scalar record is defined, a record constructor function with the same name and in the same scope as the record class is implicitly defined according to the following rules:
 
 % Warning: 'partial flatteing' doesn't seem to be defined.  See 'partial instantitation'.
 The declaration of the record is partially flattened including inheritance, modifications, redeclarations, and expansion of all names referring to declarations outside of the scope of the record to their fully qualified names.
@@ -856,6 +856,7 @@ An instance of the record is declared as output parameter using a name not appea
 In the modification, all input parameters are used to set the corresponding record variables.
 
 A record constructor can only be called if the referenced record class is found in the global scope, and thus cannot be modified.
+The record constructor can be used in vectorized form according to \cref{scalar-functions-applied-to-array-arguments}.
 
 \begin{nonnormative}
 This allows constructing an instance of a record, with an optional modification, at all places where a function call is allowed.
@@ -981,6 +982,8 @@ Demo.Record2 r2 =
   Demo.Record2(1, 2, 2, 3, 1, 2, 5, 5, {1, 2}, {1, 2, 3});
 parameter Demo.Record2 r3 =
   Demo.Record2(c2 = 2, n2 = 1, r1 = 1, r4 = 4, r6 = 1 : 5, r7 = {1});
+parameter Demo.Record2 r4[2] =
+  Demo.Record2(c2 = 2, n2 = {1, 2}, r1 = 1, r4 = {4, 5}, r6 = 1 : 5, r7 = {1});
 \end{lstlisting}
 
 The above example is only used to show the different variants appearing with prefixes, but it is not very meaningful, because it is simpler to just use a direct modifier.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -503,7 +503,7 @@ See also \cref{type-conversion-of-enumeration-values-to-string-or-integer}.
 EnumTypeName($i$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-For any enumeration type \lstinline!EnumTypeName!, returns the enumeration value \lstinline!EnumTypeName.e! such that $\text{\lstinline!Integer(EnumTypeName.e)!} = i$.
+For any scalar enumeration type \lstinline!EnumTypeName!, returns the enumeration value \lstinline!EnumTypeName.e! such that $\text{\lstinline!Integer(EnumTypeName.e)!} = i$.
 Refer to the definition of \lstinline!Integer! above.
 
 It is an error to attempt to convert values of $i$ that do not correspond to values of the enumeration type.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -96,7 +96,7 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
   All identifiers of the rest of the name (e.g., \lstinline!B! and \lstinline!B.C!) must be classes.
   That is, the composite name is comprised of one or more component names (optionally with indexing), followed by one or more class names.
 \item
-  If the identifier denotes a class, that class is temporarily flattened (as if instantiating a component without modifiers of this class, see \cref{modification-environment} and using the enclosing classes of the denoted class).
+  If the identifier denotes a scalar class, that class is temporarily flattened (as if instantiating a component without modifiers of this class, see \cref{modification-environment} and using the enclosing classes of the denoted class).
   The rest of the name (e.g., \lstinline!B! or \lstinline!B.C!) is looked up among the declared named elements of the temporary flattened class.
   The lookup will only find the element (assuming it exists) in the following cases:
   \begin{itemize}


### PR DESCRIPTION
Closes #3820 
I think this covers all of the discussed cases.

As far as I can see it is also consistent with the previous intent, but just missed:
- Enumeration constructor is part of list that can be called vectorized.
- Record cast (but not record constructor) explicitly listed that it could be called vectorized
- Lookup of classes in components restricted it to scalar components; and lookup for classes is described as constructing a component of the class.