### PR TITLE
Introduce "potential" and then use it.

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -625,6 +625,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 \subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
+The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables. 
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the number of potential variables.
 The potential variables are counted after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -624,7 +624,8 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 
 \subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
-For each non-partial non-simple non-expandable connector class the number of flow variables shall be equal to the number of potential variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
+The potential variables for a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
+For each non-partial non-simple non-expandable connector class the number of flow variables shall be equal to the number of potential variables.
 The \emph{number of potential variables} is the number of all elements in the connector class after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -626,7 +626,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the number of potential variables.
-The \emph{number of potential variables} is the number of all potentival variables in the connector class after expanding all records and arrays to a set of scalars of primitive types.
+The potential variables are counted after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.
 \begin{nonnormative}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -624,8 +624,8 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 
 \subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
-The potential variables for a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
-For each non-partial non-simple non-expandable connector class the number of flow variables shall be equal to the number of potential variables.
+The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
+For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the number of potential variables.
 The \emph{number of potential variables} is the number of all elements in the connector class after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -627,8 +627,6 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
 The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables. 
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the sum of degrees of freedom over all potential variables.
-The potential variables are counted after expanding all records and arrays to a set of scalars of primitive types.
-The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.
 \begin{nonnormative}
 Expandable connector classes are excluded from this, since their component declarations are only a form of constraint.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -626,7 +626,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the number of potential variables.
-The \emph{number of potential variables} is the number of all elements in the connector class after expanding all records and arrays to a set of scalars of primitive types.
+The \emph{number of potential variables} is the number of all potentival variables in the connector class after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.
 \begin{nonnormative}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -626,7 +626,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
 The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables. 
-For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the number of potential variables.
+For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the sum of degrees of freedom over all potential variables.
 The potential variables are counted after expanding all records and arrays to a set of scalars of primitive types.
 The number of potential variables of an overdetermined type or record class (see \cref{overconstrained-equation-operators-for-connection-graphs}) is the size of the output argument of the corresponding \lstinline!equalityConstraint!() function.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -625,7 +625,7 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 \subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
-The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables. 
+The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables.
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the sum of degrees of freedom over all potential variables.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.
 \begin{nonnormative}

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -625,7 +625,11 @@ I.e., a connection set must -- unless the model or block is partial -- contain o
 \subsection{Balancing Restriction and Size of Connectors}\label{balancing-restriction-and-size-of-connectors}
 
 The potential variables of a connector are the variables that are neither \lstinline!parameter!, \lstinline!constant!, \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow!.
-The degrees of freedom of a potential variable of overdetermined record or array type is the number of scalars of the primitives types of the output argument of the corresponding \lstinline!equalityConstraint! function, and the number of scalars of the primitives types for non-overdetermined potential variables.
+The degrees of freedom is determined by the number of scalar variables in:
+\begin{itemize}
+\item The variable itself, for a non-overdetermined potential variable.
+\item The \lstinline!residue! output of the corresponding \lstinline!equalityConstraint! function, for a potential variable of overdetermined type (see \cref{overconstrained-equation-operators-for-connection-graphs}).
+\end{itemize}
 For each connector class which is neither partial, simple, nor expandable, the number of flow variables shall be equal to the sum of degrees of freedom over all potential variables.
 A simple connector class is not expandable, has some time-varying variables, and has neither \lstinline!input!, \lstinline!output!, \lstinline!stream! nor \lstinline!flow! variables.
 \begin{nonnormative}


### PR DESCRIPTION
In the previous text it looked as if "potential" was redundant, now it is instead formulated to first define "potential" variable and then use it.