### PR TITLE
Small cleanup of rules for input/output prefixes

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -245,15 +245,15 @@ Note that there are no specific restrictions if an operator record component has
 The prefixes \lstinline!input!\indexinline{input} and \lstinline!output!\indexinline{output} have a slightly different semantic meaning depending on the context where they are used:
 \begin{itemize}
 \item
-  In \emph{functions}, these prefixes define the computational causality of the function body, i.e., given the variables declared as \lstinline!input!, the variables declared as \lstinline!output! are computed in the function body, see \cref{function-call}.
+  In functions, these prefixes define the computational causality of the function body, i.e., given the variables declared as \lstinline!input!, the variables declared as \lstinline!output! are computed in the function body, see \cref{function-call}.
 \item
-  In \emph{simulation} \emph{models} and \emph{blocks} (i.e., on the top level of a model or block that shall be simulated), these prefixes define the interaction with the environment where the simulation model or block is used.
+  In \emph{simulation} models and blocks (i.e., on the top level of a model or block that shall be simulated), these prefixes define the interaction with the environment where the simulation model or block is used.
   Especially, the \lstinline!input! prefix defines that values for such a variable can be provided from the simulation environment, and the \lstinline!output! prefix defines that the values of the corresponding variable can be directly utilized in the simulation environment, see the notion of \emph{globally balanced} in \cref{balanced-models}.
   When the simulation environment does not provide a value for an input variable, the variable's \lstinline!start!-attribute is used instead.
   In case there is no \lstinline!start!-attribute, the recommended diagnostic for using the fallback value (see \cref{def:fallback-value}) should not be given during translation, but only during simulation provided it is actually used.
   Note that the simulation environment may impose restrictions on the diagnostics.
 \item
-  In component \emph{models} and \emph{blocks}, the \lstinline!input! prefix defines that a binding equation has to be provided for the corresponding variable when the component is utilized in order to guarantee a locally balanced model (i.e., the number of local equations is identical to the local number of unknowns), see \cref{balanced-models}.
+  In model and block \emph{components}, the \lstinline!input! prefix defines that a binding equation has to be provided for the corresponding variable when the component is utilized in order to guarantee a locally balanced model (i.e., the number of local equations is identical to the local number of unknowns), see \cref{balanced-models}.
 \begin{example}
 \begin{lstlisting}[language=modelica]
 block FirstOrder
@@ -266,13 +266,13 @@ model UseFirstOrder
 end UseFirstOrder;
 \end{lstlisting}
 \end{example}
-  The \lstinline!output! prefix does not have a particular effect in a model or block component and is ignored.
+  The \lstinline!output! prefix does not have a particular effect in a model or block component, and is ignored.
 \item
-  In \emph{connectors}, prefixes \lstinline!input! and \lstinline!output! define that the corresponding connectors can only be connected according to block diagram semantics, see \cref{connect-equations-and-connectors} (e.g., a connector with an \lstinline!output! variable can only be connected to a connector where the corresponding variable is declared as \lstinline!input!).
+  In connectors, the prefixes \lstinline!input! and \lstinline!output! define that the corresponding connectors can only be connected according to block diagram semantics, see \cref{connect-equations-and-connectors} (e.g., a connector with an \lstinline!output! variable can only be connected to a connector where the corresponding variable is declared as \lstinline!input!).
   There is the restriction that connectors which have at least one variable declared as \lstinline!input! must be externally connected, see \cref{balanced-models} (in order to get a locally balanced model, where the number of local unknowns is identical to the number of unknown equations).
   Together with the block diagram semantics rule this means, that such connectors must be connected \emph{exactly once externally}.
 \item
-  In \emph{records}, prefixes \lstinline!input! and \lstinline!output! are not allowed, since otherwise a record could not be, e.g., passed as input argument to a function.
+  In records, the prefixes \lstinline!input! and \lstinline!output! are not allowed, since otherwise a record could not be, e.g., passed as input argument to a function.
 \end{itemize}
 
 


### PR DESCRIPTION
This fixes some stylistic issues I noted when reviewing #3827.
