### PR TITLE
Workaround for LaTeXML issue with the babel package

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -3,7 +3,11 @@
 % change the layout that can wait
 \hfuzz=50pt
 
-\usepackage[english]{babel}
+% Work around LaTeXML issue with the babel package:
+% - https://github.com/brucemiller/LaTeXML/issues/2429 (marked as fixed as of commit c9b03438)
+%\usepackage[english]{babel}
+% This command was supposed to be provided by babel:
+\newcommand{\alsoname}{see also}
 
 \usepackage{fancyhdr}
 


### PR DESCRIPTION
This is a fix for the issue noted in https://github.com/modelica/ModelicaSpecification/pull/3831#issuecomment-3889794159.
