### PR TITLE
Further clarify parameter and evaluable for synchronous.

### DIFF
--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -177,7 +177,7 @@ Clock c3 = subSample(c2, 4);
 \begin{definition}[Clocked variable]\label{def:clocked-variable}\index{clocked!variable}
 The elements of clocked variables $r(t_{i})$ are of base type \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, enumeration, \lstinline!String! that are associated uniquely with a clock $c(t_{i})$.
 A clocked variable can only be directly accessed at the event instant where the associated clock is active.
-A constant and a parameter can always be used at a place where a clocked variable is required.
+A constant or a parameter can always be used at a place where a clocked variable is required.
 \begin{nonnormative}
 Note that clock variables are not included in this list.
 This implies that clock variables cannot be used where clocked variables are required.
@@ -277,7 +277,7 @@ y6 = previous(R);     // error (component, not component expression)
 The named argument \lstinline!factor! of \lstinline!subSample! is restricted to be an evaluable expression.
 \begin{lstlisting}[language=modelica]
 Real u;
-parameter Real p=3;
+parameter Real p=3 annotation(Evaluate=true);
 $\ldots$
 y1 = subSample(u, factor = 3);         // fine (literal)
 y2 = subSample(u, factor = 2 * p - 3); // fine (evaluable expression)
@@ -340,7 +340,7 @@ The optional second argument $\mathit{resolution}$ (defaults to 1) is an evaluab
 If $\mathit{intervalCounter}$ is an evaluable expression with value zero, the period of the clock is derived by clock inference, see \cref{sub-clock-inferencing}.
 
 If $\mathit{intervalCounter}$ is an evaluable expression greater than zero, the clock defines a periodic clock.
-If $\mathit{intervalCounter}$ is a clocked component expression it must be greater than zero.
+If $\mathit{intervalCounter}$ is a clocked component expression (or not evaluated parameter expression) it must be greater than zero.
 The result is of base type \lstinline!Clock! that ticks when \lstinline!time! becomes $t_{\mathrm{start}}$, $t_{\mathrm{start}} + \mathit{interval}_{1}$, $t_{\mathrm{start}} + \mathit{interval}_{1} + \mathit{interval}_{2}$, \@\ldots{}
 The clock starts at the start of the simulation $t_{\mathrm{start}}$ or when the controller is switched on.
 At the first clock tick, $\mathit{intervalCounter}$ must be computed and the second clock tick is scheduled $\mathit{interval}_{1} = \mathit{intervalCounter}/\mathit{resolution}$ into the future.

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -277,7 +277,7 @@ y6 = previous(R);     // error (component, not component expression)
 The named argument \lstinline!factor! of \lstinline!subSample! is restricted to be an evaluable expression.
 \begin{lstlisting}[language=modelica]
 Real u;
-parameter Real p=3 annotation(Evaluate=true);
+parameter Real p=3;
 $\ldots$
 y1 = subSample(u, factor = 3);         // fine (literal)
 y2 = subSample(u, factor = 2 * p - 3); // fine (evaluable expression)


### PR DESCRIPTION
Clarification triggered by #3811 - but not part of original text.

Note that there's one special case that I haven't included, as I couldn't find a good text for it.

The special case is if the interval is zero for a non-evaluated rational clock - to me that should be handled as if it were a non-parameter expression that is zero, i.e., just an error, as it was intended to be inferred but there was nothing to infer it from.

