### PR TITLE
Extend connection annotation text

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1257,7 +1257,7 @@ In this example the diagram of \lstinline!A! contains the graphical primitives f
 
 \subsection{Connections}\label{connections1}
 
-A connection is specified with an annotation containing a \lstinline!Line!\index{Line@\robustinline{Line}!\robustinline{connect} annotation} primitive and optionally a \lstinline!Text! primitive, as specified below.
+A connection is specified with an annotation containing a \lstinline!Line!\index{Line@\robustinline{Line}!\robustinline{connect} annotation} primitive and optionally one or more \lstinline!Text! primitives, as specified below.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -1266,8 +1266,8 @@ connect(a.x, b.x)
 \end{lstlisting}
 \end{example}
 
-The optional \lstinline!Text!\index{Text@\robustinline{Text}!\robustinline{connect} annotation} primitive defines a text that will be written on the connection line.
-It has the following definition (it is not equal to the \lstinline!Text! primitive as part of graphics -- the differences are marked after \emph{Note} in the description-strings):
+The optional \lstinline!Text!\index{Text@\robustinline{Text}!\robustinline{connect} annotation} primitives define text that will be written on the connection line.
+They have the following definition (it is not equal to the \lstinline!Text! primitive as part of graphics -- the differences are marked after \emph{Note} in the description-strings):
 \begin{lstlisting}[language=modelica]
 record Text
   extends GraphicItem;


### PR DESCRIPTION
Today we allow a single Text annotation on a connection line. This change generalizes that to allow more than one, for example to be able to specify both %first and %second on a connection.