### PR TITLE
Clarify role of when-clause conditions in event iteration

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -806,15 +806,6 @@ In the case a parameter has both a binding equation and \lstinline!fixed = false
 
 Continuous-time \lstinline!Real! variables \lstinline!vc! have exactly one initialization value since the rules above assure that during initialization \lstinline!vc = pre(vc) = vc.startExpression! (if \lstinline!fixed = true!).
 
-Before the start of the integration, it must be guaranteed that for all variables \lstinline!v!, \lstinline!v = pre(v)!.
-If this is not the case for some variables \lstinline!vi!, \lstinline!pre(vi) := vi! must be set and an event iteration at the initial time must follow, so the model is re-evaluated, until this condition is fulfilled.
-In detail this means that during initialization initial equations and normal equations are solved with \lstinline!v! and \lstinline!pre(v)! as unknowns without any event iterations.
-Then only the normal equations are solved repeatedly (each time after \lstinline!v! is copied to \lstinline!pre(v)!) until \lstinline!v = pre(v)!.
-
-\begin{nonnormative}
-Tools may optimize initialization by not computing unnecessary \lstinline!pre(v)!, and only performing the event iteration if necessary.
-\end{nonnormative}
-
 A Modelica translator may first transform the continuous equations of a model, at least conceptually, to state space form.
 This may require to differentiate equations for index reduction, i.e., additional equations and, in some cases, additional unknown variables are introduced.
 This whole set of equations, together with the additional constraints defined above, should lead to an algebraic system of equations where the number of equations and the number of all variables (including \lstinline!der! and \lstinline!pre! variables) is equal.
@@ -834,6 +825,13 @@ For example, variables assigned in a \lstinline!when!-clause which are not acces
 
 \begin{nonnormative}
 The goal is to be able to initialize the model, while satisfying the initial equations and fixed start values.
+\end{nonnormative}
+
+After the initialization problem has been solved, the transient analysis begins by performing an event iteration (see \cref{modelica:pre}).
+Note that the event iteration belongs to the transient analysis, and does not solve the initial equations again.
+
+\begin{nonnormative}
+Tools may optimize initialization by not computing unnecessary \lstinline!pre(v)!, and only performing the event iteration if necessary.
 \end{nonnormative}
 
 \begin{example}
@@ -935,6 +933,22 @@ During initialization this gives the following equations
   end if;
 \end{lstlisting}
 if \lstinline!steadyState! had not been an evaluable expression, both of those equations would have been illegal according to the restrictions in \cref{if-equations}.
+\end{example}
+
+\begin{example}
+A \lstinline!when!-clause triggering during initial event iteration:
+\begin{lstlisting}[language=modelica]
+  Boolean b = not initial();
+  Real x(start = 0.0, fixed = true);
+equation
+  der(x) = 0;
+  when b then
+    reinit(x, 5);
+  end when;
+\end{lstlisting}
+After solving the initialization problem, both \lstinline!b! and \lstinline!pre(b)! are false.
+During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from falso to true during the first round of the initial event iteration.
+This triggers the \lstinline!when!-clause, and \lstinline!x! gets reinitialized.
 \end{example}
 
 \subsection{Equations Needed for Initialization}\label{the-number-of-equations-needed-for-initialization}\label{equations-needed-for-initialization}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1451,14 +1451,19 @@ This can be applied to continuous-time variables in \lstinline!when!-clauses, se
 \end{nonnormative}
 The first value of \lstinline!pre($y$)! is determined in the initialization phase.
 
-A new event is triggered if there is at least for one variable \lstinline!v! such that \lstinline!pre(v) <> v! after the active model equations are evaluated at an event instant.
-In this case the model is at once reevaluated.
+After the model equations have been evaluated at an event instant, another round of model equation evaluation is triggered as long as there is at least one variable \lstinline!v! appearing inside \lstinline!pre($\ldots$)! and such that \lstinline!pre(v) <> v!.
+Before each new round of model evaluation, each \lstinline!pre(v)! is assigned the value of \lstinline!v!.
 This evaluation sequence is called \emph{event iteration}.
-The integration is restarted once \lstinline!pre(v) == v! for all \lstinline!v! appearing inside \lstinline!pre($\ldots$)!.
+When no more round of model equation evaluation is triggered, the processing of the event is completed and the transient analysis may proceed forward in time.
+
+For purposes of event iteration, each scalar expression in a \lstinline!when!-clause condition is treated as an implicit variable \lstinline!v!.
+Since the \lstinline!when!-clause is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
 
 \begin{nonnormative}
 If \lstinline!v! and \lstinline!pre(v)! are only used in \lstinline!when!-clauses, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
 It is a quality of implementation to find the minimal loops for event iteration, i.e., not all parts of the model need to be reevaluated.
+
+A consequence of the implicit \lstinline!when!-clause condition variables is that every time a \lstinline!when!-clause is triggered, there is a variable with \lstinline!v <> pre(v)!, meaning that another round of the iteration is triggered.
 
 The language allows mixed algebraic systems of equations where the unknown variables are of type \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean!, or an enumeration.
 These systems of equations can be solved by a global fix point iteration scheme, similarly to the event iteration, by fixing the \lstinline!Boolean!, \lstinline!Integer!, and/or enumeration unknowns during one iteration.


### PR DESCRIPTION
Fixes #3813.

While I do think that this should be sufficient to consider #3813 fixed, it leaves me a bit uneasy that my intuition about the event iteration is not captured in any non-normative section.  That is, the intuition is that event iteration must be continued when some computed solution to the model equations becomes invalid due to some of the updates taking place after the evaluation of the model equations.  The intuition is also that once none of the computed solutions become invalidated, it should in principle be a no-op to evaluate the model equations one more time, so tools should err on the side of iterating one extra time rather than one time too little.

The two things taking place after evaluation of the model equations are the `pre(v) := v` updates and the execution of `reinit` statements.  Thus, a tool erring on the side of iterating one time too much could simply test whether there is any change to a `pre(v)` or a state updated by a `reinit`.  By noting that execution of a `reinit` implies that there is a `pre(v)` which will be updated from false to true, the condition may be simplified to the current rule in the specification.

However, the intuition about invalidated solutions to the model equations is a more intuitive starting point for optimizing the iteration, and in my opinion also a more useful way to abstractly understand what it is that the event iteration achieves:
- **Event iteration ensures that the model equations are solved consistently before transient analysis may proceed forward in time after an event.**

In view of the text proposed in this PR, it is particularly worth noting that the intuition does not suggest that a triggered `when`-clause should necessarily trigger continued iteration; the usual sorting of equations is sufficient, except for `reinit` which may change a state after it has been used.  Hence, the conceptual idea of introducing implicit variables for the `when`-clause conditions is neither helpful for tools that want to avoid unnecessary iterator nor for users who are trying to understand optimized tool behavior.
