### PR TITLE
Linkable grammar productions and lexical units

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -4,9 +4,9 @@ Annotations are intended for storing extra information about a model, such as gr
 The standard annotations (that is, all annotations except the vendor-specific ones, see \cref{vendor-specific-annotations}) shall only be used where their semantics is defined.
 A Modelica tool is free to define and use other annotations, in addition to those defined here, according to \cref{vendor-specific-annotations}.
 
-Annotations are optional in the Modelica grammar, and when present, indicated using the \lstinline!annotation!\indexinline{annotation} keyword, see \lstinline[language=grammar]!annotation-clause! in the grammar (\cref{expressions1}).
-The structure of the annotation content is the same as a class modification (\lstinline[language=grammar]!class-modification! in the grammar).
-(For replaceable class declarations with a \lstinline[language=grammar]!constraining-clause! also refer to \cref{constraining-clause-annotations}.)
+Annotations are optional in the Modelica grammar, and when present, indicated using the \lstinline!annotation!\indexinline{annotation} keyword, see \productionref{annotation-clause} in the grammar.
+The structure of the annotation content is the same as a class modification (\productionref{class-modification} in the grammar).
+(For replaceable class declarations with a \productionref{constraining-clause}, also refer to \cref{constraining-clause-annotations}.)
 The specification in this document defines the semantic meaning if a tool implements any of these annotations.
 
 
@@ -43,7 +43,7 @@ The allowed annotations for a short class definition is the union of the allowed
 
 \section{Semantic Restrictions of Annotation Syntax}\label{semantic-restrictions-of-annotation-syntax}
 
-The syntactic form of annotations, \lstinline[language=grammar]!annotation-clause!, uses the generic \lstinline[language=grammar]!class-modification! in \cref{modification}.
+The syntactic form of annotations, \productionref{annotation-clause}, uses the generic \productionref{class-modification} in the grammar.
 However, except where explicitly stated, the following constructs shall not be used in annotations:
 \begin{itemize}
 \item
@@ -54,13 +54,13 @@ For instance, neither \lstinline!final experiment(StopTime = 2.0)! nor \lstinlin
 When an annotation is given for an array component declaration, it applies to the array as a whole.
 Thus, neither should values be given in arrays matching the size of the declared component, nor should \lstinline!each! be used express that a scalar value applies to each element of the array.
 \item
-\lstinline[language=grammar]!element-redeclaration! in the grammar.
+\productionref{element-redeclaration} in the grammar.
 In particular, the keyword \lstinline!redeclare! cannot be used.
 \item
-\lstinline[language=grammar]!element-replaceable! in the grammar.
+\productionref{element-replaceable} in the grammar.
 In particular the keywords \lstinline!replaceable! and \lstinline!constrainedby! cannot be used.
 \item
-A \lstinline[language=grammar]!element-modification! without \lstinline[language=grammar]!modification! is deprecated without exceptions.
+\productionref{element-modification} without \productionref{modification} is deprecated without exceptions.
 The meaning of such annotations has never been defined.
 \end{itemize}
 
@@ -333,7 +333,7 @@ end Axis;
 
 When an axis bound is not provided, the tool computes one automatically.
 
-A non-empty \lstinline!unit! shall match \lstinline[language=grammar]!unit-expression! in \cref{unit-expressions}.
+A non-empty \lstinline!unit! shall match \productionref{unit-expression} in \cref{unit-expressions}.
 An empty \lstinline!unit! means that the axis is unitless, and each expression plotted against it may use its own unit determined by the tool.
 The tool is responsible for conveying the information about choice of unit for the different variables, for instance by attaching this information to curve legends.
 
@@ -406,7 +406,7 @@ record Curve
 end Curve;
 \end{lstlisting}
 
-The mandatory \lstinline!x! and \lstinline!y! expressions are restricted to be result references in the form of \lstinline[language=grammar]!result-reference! in the grammar (\cref{expressions1}), referring to a scalar variable (or a derivative thereof) or \lstinline!time!.
+The mandatory \lstinline!x! and \lstinline!y! expressions are restricted to be result references in the form of \productionref{result-reference} in the grammar, referring to a scalar variable (or a derivative thereof) or \lstinline!time!.
 It is an error if \lstinline!x! or \lstinline!y! does not designate a scalar result.
 If \lstinline!x! or \lstinline!y! is a derivative, \lstinline!der(v, $n$)!, then $n$ must not exceed the maximum amount of differentiation applied to \lstinline!v! in the model.
 A diagnostic is recommended in case the simulation result is missing a trajectory for a valid result reference.
@@ -482,8 +482,8 @@ This is similar to the \lstinline!Text! graphical primitive in \cref{text}.
 \end{center}
 \end{table}
 
-In \lstinline!%{$\mathit{variable}$}!, text markup escape sequences don't apply inside the $\mathit{variable}$, which has the form of \lstinline[language=grammar]!result-reference!.
-This means that a complete \lstinline[language=grammar]!result-reference! shall be scanned before looking for the terminating closing brace.
+In \lstinline!%{$\mathit{variable}$}!, text markup escape sequences don't apply inside the $\mathit{variable}$, which has the form of \productionref{result-reference}.
+This means that a complete \productionref{result-reference} shall be scanned before looking for the terminating closing brace.
 
 \begin{example}
 The variable replacement \lstinline!%{'%%'}! references the variable \lstinline!'%%'!, not the variable \lstinline!'%'!.
@@ -519,7 +519,7 @@ Links take the form \lstinline!%[$\mathit{text}$]($\mathit{link}$)!, where the \
 The $\mathit{link}$ can be in either of the following forms, where the interpretation is given by the first matching form:
 \begin{itemize}
 \item
-A \lstinline!variable:$\mathit{id}$!, where $\mathit{id}$ is a component reference in the form of \lstinline[language=grammar]!result-reference! in the grammar, such as \lstinline!inertia1.w!.
+A \lstinline!variable:$\mathit{id}$!, where $\mathit{id}$ is a component reference in the form of \productionref{result-reference} in the grammar, such as \lstinline!inertia1.w!.
 \item
 % The 'plot:id' form below should be deprecated in favor of using an improved form of Modelica URI reference in the future, making 'variable:id' the only non-URI reference.
 A \lstinline!plot:$\mathit{id}$!, where $\mathit{id}$ is the identifier of a \lstinline!Plot! in the current \lstinline!Figure!.
@@ -1437,7 +1437,7 @@ parameter Real t(unit = "s", displayUnit = "ms") = 0.1
   If \lstinline!par = "Modelica.Blocks.Types.Enumeration.Periodic"!, then \%\emph{par} should be displayed as \emph{Periodic}.
   \end{example}
   When quoted identifiers (e.g., \lstinline'quoted ident'! or \lstinline!'}'!) or composite names (i.e., not simple identifiers) are involved, the form \%\{\emph{par}\} must be used.
-  Here, \emph{par} is a general \lstinline[language=grammar]!component-reference!, and \lstinline!%{a.p}! gives the value of the parameter \lstinline!p! in the component \lstinline!a!.
+  Here, \emph{par} is a general \productionref{component-reference}, and \lstinline!%{a.p}! gives the value of the parameter \lstinline!p! in the component \lstinline!a!.
   The macro can be directly followed by a letter.
   Thus \lstinline!%{w}x%{h}! gives the value of \lstinline!w! directly followed by \emph{x} and the value of \lstinline!h!, while \lstinline!%wxh! gives the value of the parameter \lstinline!wxh!.
   If the parameter does not exist it is an error.
@@ -1674,7 +1674,7 @@ If not specified, the names of new components are tool-specific.
 /*literal*/ constant String defaultComponentPrefixes;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The class annotation \lstinline!defaultComponentPrefixes! gives a whitespace separated list of recommended type prefixes to include in the \lstinline[language=grammar]!type-prefix! part of a \lstinline[language=grammar]!component-clause1! generated when creating a component of the class:
+The class annotation \lstinline!defaultComponentPrefixes! gives a whitespace separated list of recommended type prefixes to include in the \productionref{type-prefix} part of a \productionref{component-clause1} generated when creating a component of the class:
 \begin{lstlisting}[language=grammar]
 type-prefix type-specifier component-declaration
 \end{lstlisting}

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -1674,10 +1674,7 @@ If not specified, the names of new components are tool-specific.
 /*literal*/ constant String defaultComponentPrefixes;
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-The class annotation \lstinline!defaultComponentPrefixes! gives a whitespace separated list of recommended type prefixes to include in the \productionref{type-prefix} part of a \productionref{component-clause1} generated when creating a component of the class:
-\begin{lstlisting}[language=grammar]
-type-prefix type-specifier component-declaration
-\end{lstlisting}
+The class annotation \lstinline!defaultComponentPrefixes! gives a whitespace separated list of recommended type prefixes to include in the \productionref{type-prefix} part of a \productionref{component-clause1} generated when creating a component of the class.
 
 The following prefixes may be included in the \lstinline!defaultComponentPrefixes! string: \lstinline!inner!, \lstinline!outer!, \lstinline!replaceable!, \lstinline!constant!, \lstinline!parameter!, \lstinline!discrete!.
 The default is an empty string.

--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -2042,15 +2042,30 @@ This can be used by a tool to guarantee that consistent versions are used, and i
 \subsection{Version Numbering}\label{version-numbering}
 
 Version number strings can be in one of several forms:
-\begin{lstlisting}[language=grammar]
-PACKAGE-VERSION = MAIN-VERSION | PRE-RELEASE-VERSION | UNORDERED-VERSION
 
-MAIN-VERSION = UNSIGNED-INTEGER { "." UNSIGNED-INTEGER }
-
-PRE-RELEASE-VERSION = MAIN-VERSION " " { S-CHAR }
-
-UNORDERED-VERSION = NON-DIGIT { S-CHAR }
+\begin{lexicalunit}{PACKAGE-VERSION}
+\begin{lstlisting}
+MAIN-VERSION | PRE-RELEASE-VERSION | UNORDERED-VERSION
 \end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{MAIN-VERSION}
+\begin{lstlisting}
+UNSIGNED-INTEGER { "." UNSIGNED-INTEGER }
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{PRE-RELEASE-VERSION}
+\begin{lstlisting}
+MAIN-VERSION " " { S-CHAR }
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{UNORDERED-VERSION}
+\begin{lstlisting}
+NON-DIGIT { S-CHAR }
+\end{lstlisting}
+\end{lexicalunit}
 
 Examples:
 \begin{itemize}
@@ -2076,7 +2091,7 @@ In a top-level class, the version number and the dependency to earlier versions 
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 \lstinline!version = $\mathit{currentVersion}$! defines the version number of the model or package.
-The $\mathit{currentVersion}$ shall be a \lstinline[language=grammar]!PACKAGE-VERSION!.
+The $\mathit{currentVersion}$ shall be a \lexicalunitref{PACKAGE-VERSION}.
 All classes within this top-level class have this version number.
 \end{semantics}
 \end{annotationdefinition}
@@ -2393,7 +2408,7 @@ If the parameter had no impact on the model it can be removed using \lstinline!c
 
 \subsection{Versions in the File System}\label{mapping-of-versions-to-file-system}\label{versions-in-the-File-System}
 
-The top-level class $\mathit{packageName}$ with version $\mathit{packageVersion}$ (matching \lstinline[language=grammar]!PACKAGE-VERSION! defined in \cref{version-numbering}) can be stored in one of the following ways in a directory given in the \lstinline!MODELICAPATH! (\cref{the-modelica-library-path-modelicapath}):
+The top-level class $\mathit{packageName}$ with version $\mathit{packageVersion}$ (matching \lexicalunitref{PACKAGE-VERSION} defined in \cref{version-numbering}) can be stored in one of the following ways in a directory given in the \lstinline!MODELICAPATH! (\cref{the-modelica-library-path-modelicapath}):
 \begin{itemize}
 \item
   The file $\mathit{packageName}$\filename{.mo}\\

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -576,26 +576,26 @@ The type of \lstinline!product($e$($i$, $\ldots$, $j$) for $i$ in $u$, $\ldots$,
 
 \subsubsection{Reduction Expressions}\label{reduction-expressions}
 
-An expression:
-\begin{lstlisting}[language=grammar]
-function-name "(" expression1 for iterators ")"
+The following special case of \productionref{function-call} in the grammar, where $\mathit{iterators}$ should match \productionref{for-indices},
+\begin{lstlisting}[language=modelica]
+$\mathit{reduction}$($expr$ for $\mathit{iterators}$)
 \end{lstlisting}%
 \index{for@\robustinline{for}!reduction expression}
 is a \firstuse{reduction expression}.
-The expressions in the iterators of a reduction expression shall be vector expressions.
+The expressions in $\mathit{iterators}$ shall be vector expressions.
 They are evaluated once for each reduction expression, and are evaluated in the scope immediately enclosing the reduction expression.
-If \lstinline!expression1! contains event-generating expressions, the expressions inside the iterators shall be evaluable.
+If $expr$ contains event-generating expressions, the expressions inside $\mathit{iterators}$ shall be evaluable.
 
-For an iterator:
-\begin{lstlisting}[language=grammar]
-IDENT in expression2
+For an iterator (matching \productionref{for-index} in the grammar),
+\begin{lstlisting}[language=modelica]
+$\mathit{ident}$ in $\mathit{arr}$
 \end{lstlisting}%
 \index{in@\robustinline{in}!reduction expression}
-the loop-variable, \lstinline!IDENT!, is in scope inside \lstinline!expression1!.
+the loop-variable, $\mathit{ident}$, is in scope inside $\mathit{arr}$.
 The loop-variable may hide other variables, as in \lstinline!for!-loops.
-The result depends on the \lstinline!function-name!, and currently the only legal function-names are the built-in operators \lstinline!array!, \lstinline!sum!, \lstinline!product!, \lstinline!min!, and \lstinline!max!.
+The result depends on the $\mathit{reduction}$, and the only legal reductions are given by the identifiers \lstinline!array!, \lstinline!sum!, \lstinline!product!, \lstinline!min!, and \lstinline!max!.
 For array, see \cref{vector-matrix-and-array-constructors}.
-If \lstinline!function-name! is \lstinline!sum!, \lstinline!product!, \lstinline!min!, or \lstinline!max! the result is of the same type as \lstinline!expression1! and is constructed by evaluating \lstinline!expression1! for each value of the loop-variable and computing the \lstinline!sum!, \lstinline!product!, \lstinline!min!, or \lstinline!max! of the computed elements.
+If $\mathit{reduction}$ is \lstinline!sum!, \lstinline!product!, \lstinline!min!, or \lstinline!max! the result is of the same type as $expr$ and is constructed by evaluating $expr$ for each value of the loop-variable and computing the \lstinline!sum!, \lstinline!product!, \lstinline!min!, or \lstinline!max! of the computed elements.
 For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using types as ranges see \cref{types-as-iteration-ranges}.
 
 \begin{table}[H]
@@ -605,7 +605,7 @@ For deduction of ranges, see \cref{implicit-iteration-ranges}; and for using typ
 \begin{center}
 \begin{tabular}{l l l}
 \hline
-\tablehead{Reduction} & \tablehead{Restriction on \lstinline!expression1!} & \tablehead{Result for empty \lstinline!expression2!}\\
+\tablehead{Reduction} & \tablehead{Restriction on $expr$} & \tablehead{Result for empty $\mathit{arr}$}\\
 \hline
 \hline
 {\lstinline!sum!} & {\lstinline!Integer!} or {\lstinline!Real!} & {\lstinline!zeros($\ldots$)!}\\
@@ -755,27 +755,27 @@ Angle[3] a = {1.0, alpha, 4}; // type of a is Real[3].
 
 \subsection{Constructor with Iterators}\label{array-constructor-with-iterators}\label{constructor-with-iterators}
 
-An expression:
-\begin{lstlisting}[language=grammar]
-"{" expression for iterators "}"
+An expression (the case of \productionref{primary} in the grammar where \productionref{array-arguments} is used) of the form
+\begin{lstlisting}[language=modelica]
+{$\mathit{expr}$ for $\mathit{iterators}$}
 \end{lstlisting}
-or
-\begin{lstlisting}[language=grammar]
-array "(" expression for iterators ")"
+or (special case of \productionref{function-call} in the grammar)
+\begin{lstlisting}[language=modelica]
+array($\mathit{expr}$ for $\mathit{iterators}$)
 \end{lstlisting}
-is an \firstuse[array!constructor!with iterators]{array constructor with iterators}.
-The expressions inside the iterators of an array constructor shall be vector expressions.
-If \lstinline!expression! contains event-generating expressions, the expressions inside the iterators shall be evaluable.
+where $\mathit{iterators}$ should match \productionref{for-indices}, is an \firstuse[array!constructor!with iterators]{array constructor with iterators}.
+The expressions inside $\mathit{iterators}$ shall be vector expressions.
+If $\mathit{expr}$ contains event-generating expressions, the expressions inside $\mathit{iterators}$ shall be evaluable.
 They are evaluated once for each array constructor, and are evaluated in the scope immediately enclosing the array constructor.
 
-For an iterator:
+For an iterator (matching \productionref{for-index} in the grammar),
 \begin{lstlisting}[language=modelica]
-IDENT in array_expression
+$\mathit{ident}$ in $\mathit{arr}$
 \end{lstlisting}
-the loop-variable, \lstinline!IDENT!, is in scope inside expression in the array construction.
+the loop-variable, $\mathit{ident}$, is in scope inside the expression $\mathit{arr}$.
 The loop-variable may hide other variables, as in \lstinline!for!-loops.
-The loop-variable has the same type as the type of the elements of \lstinline!array_expression!; and can be simple type as well as a record type.
-The loop-variable will have the same type for the entire loop -- i.e., for an \lstinline!array_expression! \lstinline!{1, 3.2}! the iterator will have the type of the type-compatible expression (\lstinline!Real!) for all iterations.
+The loop-variable has the same type as the type of the elements of the array expression $\mathit{arr}$; and can be simple type as well as a record type.
+The loop-variable will have the same type for the entire loop -- i.e., if $\mathit{arr}$ is given by \lstinline!{1, 3.2}!, the iterator will have the type of the type-compatible expression (\lstinline!Real!) for all iterations.
 For deduction of ranges, see
 \cref{implicit-iteration-ranges}; and for using types as range see \cref{types-as-iteration-ranges}.
 

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -900,7 +900,7 @@ Vectors can be constructed with the general array constructor, e.g.,
 \begin{lstlisting}[language=modelica]
 Real[3] v = {1, 2, 3};
 \end{lstlisting}
-The range vector operator or colon operator of \lstinline[language=grammar]!simple-expression! can be used instead of or in combination with this general constructor to construct \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean! or enumeration type vectors.
+The range vector operator or colon operator of \productionref{simple-expression} can be used instead of or in combination with this general constructor to construct \lstinline!Real!, \lstinline!Integer!, \lstinline!Boolean! or enumeration type vectors.
 Semantics of the colon operator:
 \begin{itemize}
 \item
@@ -952,7 +952,7 @@ The number of dimensions of the expression is reduced by the number of scalar in
 If the number of index arguments is smaller than the number of dimensions of the array, the trailing indices will use `\lstinline!:!'.
 
 It is possible to index a general expression by enclosing it in parenthesis.
-Note that while the subscripts are applied to an \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
+Note that while the subscripts are applied to an \productionref{output-expression-list} in the grammar, it is only semantically valid when the \productionref{output-expression-list} represents an expression.
 
 It is also possible to use the array access operator to assign to element/elements of an array in algorithm sections.
 This is called an \firstuse[assignment statement!indexed]{indexed assignment statement}.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -124,10 +124,10 @@ declaration :
 
 \begin{nonnormative}
 The declaration of a component states the type, access, variability, data flow, and other properties of the component.
-A \lstinline[language=grammar]!component-clause!, i.e., the whole declaration, contains type prefixes followed by a \lstinline[language=grammar]!type-specifier! with optional \lstinline[language=grammar]!array-subscripts! followed by a \lstinline[language=grammar]!component-list!.
+A \productionref{component-clause}, i.e., the whole declaration, contains type prefixes followed by a \productionref{type-specifier} with optional \productionref{array-subscripts} followed by a \productionref{component-list}.
 
 There is no semantic difference between variables declared in a single declaration or in multiple declarations.
-For example, regard the following single declaration (\lstinline[language=grammar]!component-clause!) of two matrix variables:
+For example, regard the following single declaration (\productionref{component-clause}) of two matrix variables:
 \begin{lstlisting}[language=modelica]
 Real[2,2] A, B;
 \end{lstlisting}
@@ -149,14 +149,14 @@ Real a, B[2,2];
 
 \subsection{Static Semantics}\label{component-declaration-static-semantics}
 
-If the \lstinline[language=grammar]!type-specifier! of the component declaration denotes a built-in type (\lstinline!RealType!, \lstinline!IntegerType!, etc.), the flattened or instantiated component has the same type.
+If the \productionref{type-specifier} of the component declaration denotes a built-in type (\lstinline!RealType!, \lstinline!IntegerType!, etc.), the flattened or instantiated component has the same type.
 
 % Seems sufficient to just have \indexinline variant of 'partial' in index.
-A class defined with \lstinline!partial!\indexinline{partial} in the \lstinline[language=grammar]!class-prefixes! is called a \firstuse[---]{partial} class.
+A class defined with \lstinline!partial!\indexinline{partial} in the \productionref{class-prefixes} is called a \firstuse[---]{partial} class.
 Such a class is allowed to be incomplete, and cannot be instantiated in a simulation model; useful, e.g., as a base class.
 See \cref{short-class-definitions} regarding short class definition semantics of propagating \lstinline!partial!.
 
-If the \lstinline[language=grammar]!type-specifier! of the component does not denote a built-in type, the name of the type is looked up (\cref{static-name-lookup}).
+If the \productionref{type-specifier} of the component does not denote a built-in type, the name of the type is looked up (\cref{static-name-lookup}).
 The found type is flattened with a new environment and the partially flattened enclosing class of the component.
 It is an error if the type is partial in a simulation model, or if a simulation model itself is partial.
 The new environment is the result of merging
@@ -802,7 +802,7 @@ Load R; // Error unless Load is redeclared since TwoPin is a partial class.
 
 If a short class definition does not specify any specialized class the new class definition will inherit the specialized class (this rule applies iteratively and also for redeclare).
 
-A \lstinline[language=grammar]!base-prefix! applied in the \lstinline[language=grammar]!short-class-definition! does not influence its type, but is applied to components declared of this type or types derived from it; see also \cref{restriction-on-combining-base-classes-and-other-elements}.
+A \productionref{base-prefix} applied in the \productionref{short-class-definition} does not influence its type, but is applied to components declared of this type or types derived from it; see also \cref{restriction-on-combining-base-classes-and-other-elements}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -822,7 +822,7 @@ Real x[:]=foo(time);
 
 \subsection{Combining Base Classes and Other Elements}\label{restriction-on-combining-base-classes-and-other-elements}\label{combining-base-classes-and-other-elements}
 
-It is not legal to combine equations, algorithms, components, non-empty base classes (see below), or protected elements with an extends from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \lstinline[language=grammar]!base-prefix!, or a simple type.
+It is not legal to combine equations, algorithms, components, non-empty base classes (see below), or protected elements with an extends from an array class, a class with non-empty \productionref{base-prefix}, a \firstuse{simple type} (\lstinline!Real!, \lstinline!Boolean!, \lstinline!Integer!, \lstinline!String! and enumeration types), or any class transitively extending from an array class, a class with non-empty \productionref{base-prefix}, or a simple type.
 
 \begin{definition}[Empty class]\index{empty class}\label{empty-class}
 A class without equations, algorithms, or components, and where any base-classes are themselves empty.
@@ -1546,7 +1546,7 @@ The following attributes shall be evaluable: \lstinline!quantity!, \lstinline!un
 
 The \lstinline!quantity!-attribute is used to impose a constraint on connection sets, see \cref{connect-set-quantity-rule}.
 
-The \lstinline!unit!- and \lstinline!displayUnit!-attributes may be either the empty string or a string matching \lstinline[language=grammar]!unit-expression! in \cref{unit-expressions}.
+The \lstinline!unit!- and \lstinline!displayUnit!-attributes may be either the empty string or a string matching \productionref{unit-expression} in \cref{unit-expressions}.
 The meaning of the empty string depends on the context.
 For the input and output components of a function, the empty string allows different units to be used in different calls to the function.
 For a non-function component, the empty string allows the unit (or display unit) to be inferred by the tool.

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -96,36 +96,10 @@ Special kinds of components are scalar, array, and attribute.
 
 \subsection{Syntax}\label{component-declaration-syntax}\label{syntax-and-examples-of-component-declarations}
 
-The formal syntax of a component declaration clause is given by the following syntactic rules:
-\begin{lstlisting}[language=grammar]
-component-clause :
-  type-prefix type-specifier [ array-subscripts ] component-list
-
-type-prefix :
-  [ flow | stream ]
-  [ discrete | parameter | constant ]
-  [ input | output ]
-
-type-specifier :
-  ["."] name
-
-component-list :
-  component-declaration { "," component-declaration }
-
-component-declaration :
-  declaration [ condition-attribute ] description
-
-condition-attribute :
-  if expression
-
-declaration :
-  IDENT [ array-subscripts ] [ modification ]
-\end{lstlisting}
+A component declaration states the type, access, variability, data flow, and other properties of the declared component or components.
+The formal syntax of is given by \productionref{component-clause} in the grammar.
 
 \begin{nonnormative}
-The declaration of a component states the type, access, variability, data flow, and other properties of the component.
-A \productionref{component-clause}, i.e., the whole declaration, contains type prefixes followed by a \productionref{type-specifier} with optional \productionref{array-subscripts} followed by a \productionref{component-list}.
-
 There is no semantic difference between variables declared in a single declaration or in multiple declarations.
 For example, regard the following single declaration (\productionref{component-clause}) of two matrix variables:
 \begin{lstlisting}[language=modelica]
@@ -677,54 +651,9 @@ end ClassName;
 
 The following is the formal syntax of class definitions, including the special variants described in later sections.
 
-An \firstuse{element} is part of a class definition, and is one of: class definition, component declaration, or \lstinline!extends!-clause.
+An \firstuse{element} is part of a class definition (see \productionref{class-definition} in the grammar), and is one of: class definition, component declaration, or \lstinline!extends!-clause (see \productionref{element} in the grammar).
 Component declarations and class definitions are called \firstuse[named element]{named elements}.
 An element is either inherited from a base class or local.
-
-\begin{lstlisting}[language=grammar]
-class-definition :
-  [ encapsulated ] class-prefixes class-specifier
-
-class-prefixes :
-  [ partial ]
-  ( class | model | [ operator ] record | block | [ expandable ] connector | type |
-  package | [ ( pure | impure ) ] [ operator ] function | operator )
-
-class-specifier :
-  long-class-specifier | short-class-specifier | der-class-specifier
-
-long-class-specifier :
-  IDENT description-string composition end IDENT
-  | extends IDENT [ class-modification ] description-string composition
-    end IDENT
-
-short-class-specifier :
-  IDENT "=" base-prefix type-specifier [ array-subscripts ]
-  [ class-modification ] description
-  | IDENT "=" enumeration "(" ( [enum-list] | ":" ) ")" description
-
-der-class-specifier :
-  IDENT "=" der "(" type-specifier "," IDENT { "," IDENT } ")" description
-
-base-prefix :
-  [ input | output ]
-
-enum-list : enumeration-literal { "," enumeration-literal}
-
-enumeration-literal : IDENT description
-
-composition :
-  element-list
-  { public element-list |
-    protected element-list |
-    equation-section |
-    algorithm-section
-  }
-  [ external [ language-specification ]
-    [ external-function-call ] [ annotation-clause ] ";"
-  ]
-  [ annotation-clause ";" ]
-\end{lstlisting}
 
 \subsection{Short Class Definitions}\label{short-class-definitions}
 

--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -8,22 +8,18 @@ However, the graphical part is optional and found in \cref{annotations}.
 \section{Connect-Equations and Connectors}\label{connect-equations-and-connectors}
 
 Connections between objects are introduced by \lstinline!connect!-equations in the equation part of a class.
-A \lstinline!connect!-equation\index{connect@\robustinline{connect}!equation} has the following syntax:
-\begin{lstlisting}[language=grammar]
-connect "(" component-reference "," component-reference ")" ";"
-\end{lstlisting}
-
-\begin{nonnormative}
-A \emph{connector} is an instance of a \lstinline!connector!\indexinline{connector} class.
-\end{nonnormative}
-
-The \lstinline!connect!-equation construct takes two references to connectors, each of which is either of the following forms:
+The syntax of a \lstinline!connect!-equation\index{connect@\robustinline{connect}!equation} is given by \productionref{connect-equation} in the grammar.
+The construct takes two references to connectors, each of which is either of the following forms:
 \begin{itemize}
 \item
   \lstinline!$c_1$.$c_2$.$\ldots{}$.$c_n$!, where $c_1$ is a connector of the class, $n \geq 1$ and $c_{i+1}$ is a connector element of $c_i$ for $i = 1,\, \ldots,\, (n - 1)$.
 \item
   \lstinline!m.c!, where \lstinline!m! is a non-connector element in the class and \lstinline!c! is a connector element of \lstinline!m!.
 \end{itemize}
+
+\begin{nonnormative}
+A \emph{connector} is an instance of a \lstinline!connector!\indexinline{connector} class.
+\end{nonnormative}
 
 There may optionally be array subscripts on any of the components; the array subscripts shall be evaluable expressions or the special operator \lstinline!:!.
 If the connect construct references array of connectors, the array dimensions must match, and each corresponding pair of elements from the arrays is connected as a pair of scalar connectors.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -131,22 +131,11 @@ The \lstinline!for!-equations/\lstinline!if!-equations are expanded.
 
 The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connections.root!, and \lstinline!Connections.potentialRoot!; which after expansion are handled according to \cref{equation-operators-for-overconstrained-connection-based-equation-systems1}.
 
+
 \subsection{If-Equations}\label{if-equations}
 
-The \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} have the following syntax:
-\begin{lstlisting}[language=grammar]
-if expression then
-  { some-equation ";" }
-{ elseif expression then
-  { some-equation ";" }
-}
-[ else
-  { some-equation ";" }
-]
-end if ";"
-\end{lstlisting}
-
-The \lstinline!expression! of an \lstinline!if!- or \lstinline!elseif!-clause must be a scalar \lstinline!Boolean! expression.
+The syntax of an \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
+Here, each \productionref{expression} in the grammar (representing the condition of an \lstinline!if!- or \lstinline!elseif!-clause) must be a scalar \lstinline!Boolean! expression.
 One \lstinline!if!-clause, and zero or more \lstinline!elseif!-clauses, and an optional \lstinline!else!-clause together form a list of branches.
 One or zero of the bodies of these \lstinline!if!-, \lstinline!elseif!- and \lstinline!else!-clauses is selected, by evaluating the conditions of the \lstinline!if!- and \lstinline!elseif!-clauses sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the body of the \lstinline!else!-clause is selected (if an \lstinline!else!-clause exists, otherwise no body is selected).
@@ -170,6 +159,7 @@ Additional restrictions apply in combination with \lstinline!when!-equations, se
 If the first condition is violated, the single assignment rule would not hold, because the number of equations may change during simulation although the number of unknowns remains the same.
 The second condition provides the generalization of \eqref{eq:dae-discrete-valued} to \lstinline!if!-equations.
 \end{nonnormative}
+
 
 \subsection{When-Equations}\label{when-equations}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -61,28 +61,19 @@ Note: According to the grammar the if-then-else expression in the second example
 Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling functions with several results in assignment statements.
 \end{nonnormative}
 
+
 \subsection{For-Equations -- Repetitive Equation Structures}\label{for-equations-repetitive-equation-structures}
 
-The syntax of a \lstinline!for!-equation\index{for@\robustinline{for}!equation}\index{loop@\robustinline{loop}!for-equation@\robustinline{for}-equation} is as follows:
-\begin{lstlisting}[language=grammar]
-for for-indices loop
-  { some-equation ";" }
-end for ";"
-\end{lstlisting}
+The syntax of a \lstinline!for!-equation\index{for@\robustinline{for}!equation}\index{loop@\robustinline{loop}!for-equation@\robustinline{for}-equation} is given by \productionref{for-equation} in the grammar.
 
-A \lstinline!for!-equation may optionally use several iterators (\productionref{for-indices})\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
-\begin{lstlisting}[language=grammar]
-for-indices:
-   for-index { "," for-index }
+A \lstinline!for!-equation may optionally use several iterators (\productionref{for-indices})\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information.
 
-for-index:
-   IDENT [ in expression ]
-\end{lstlisting}
-
-The following is one example of a prefix of a \lstinline!for!-equation:
+% FIXME: It is weird to give an example in the form of grammar like this:
+The following is an example of a prefix of a \lstinline!for!-equation:
 \begin{lstlisting}[language=grammar]
 for IDENT in expression loop
 \end{lstlisting}
+
 
 \subsubsection{Explicit Iteration Ranges of For-Equations}\label{explicit-iteration-ranges-of-for-equations}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -86,7 +86,7 @@ for for-indices loop
 end for ";"
 \end{lstlisting}
 
-A \lstinline!for!-equation may optionally use several iterators (\lstinline[language=grammar]!for-indices!)\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
+A \lstinline!for!-equation may optionally use several iterators (\productionref{for-indices})\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
 \begin{lstlisting}[language=grammar]
 for-indices:
    for-index { "," for-index }

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -163,17 +163,8 @@ The second condition provides the generalization of \eqref{eq:dae-discrete-value
 
 \subsection{When-Equations}\label{when-equations}
 
-The \lstinline!when!-equations\index{when@\robustinline{when}!equation}\index{then@\robustinline{then}!when-equation@\robustinline{when}-equation}\index{elsewhen@\robustinline{elsewhen}!when-equation@\robustinline{when}-equation} have the following syntax:
-\begin{lstlisting}[language=grammar]
-when expression then
-  { some-equation ";" }
-{ elsewhen expression then
-  { some-equation ";" }
-}
-end when ";"
-\end{lstlisting}
-
-The \lstinline!expression! of a \lstinline!when!-equation shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
+The syntax of a \lstinline!when!-equations\index{when@\robustinline{when}!equation}\index{then@\robustinline{then}!when-equation@\robustinline{when}-equation}\index{elsewhen@\robustinline{elsewhen}!when-equation@\robustinline{when}-equation} is given by \productionref{when-equation} in the grammar.
+Here, each \productionref{expression} in the grammar (representing one or more triggering conditions of a branch) shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
 If \lstinline!expression! is a clocked expression, the equation is referred to as a \emph{clocked \lstinline!when!-clause} (\cref{clocked-when-clause}) rather than a \lstinline!when!-equation, and is handled differently.
 The equations within a \lstinline!when!-equation are activated only at the instant when the scalar expression or any of the elements of the vector expression becomes true.
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -121,13 +121,10 @@ equation
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Connect-Equations}\label{connect-equations}
 
-A \lstinline!connect!-equation has the following syntax:
-\begin{lstlisting}[language=grammar]
-connect "(" component-reference "," component-reference ")" ";"
-\end{lstlisting}
-
+The syntax of a \lstinline!connect!-equation is given by \productionref{connect-equation} in the grammar.
 These can be placed inside \lstinline!for!-equations and \lstinline!if!-equations; provided the indices of the \lstinline!for!-loop and conditions of the \lstinline!if!-equation are evaluable expressions that do not depend on \lstinline!cardinality!, \lstinline!rooted!, \lstinline!Connections.rooted!, or \lstinline!Connections.isRoot!.
 The \lstinline!for!-equations/\lstinline!if!-equations are expanded.
 \lstinline!connect!-equations are described in detail in \cref{connect-equations-and-connectors}.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -68,12 +68,6 @@ The syntax of a \lstinline!for!-equation\index{for@\robustinline{for}!equation}\
 
 A \lstinline!for!-equation may optionally use several iterators (\productionref{for-indices})\index{in@\robustinline{in}!for-equation@\robustinline{for}-equation}, see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information.
 
-% FIXME: It is weird to give an example in the form of grammar like this:
-The following is an example of a prefix of a \lstinline!for!-equation:
-\begin{lstlisting}[language=grammar]
-for IDENT in expression loop
-\end{lstlisting}
-
 
 \subsubsection{Explicit Iteration Ranges of For-Equations}\label{explicit-iteration-ranges-of-for-equations}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -182,6 +182,7 @@ equation
 \end{lstlisting}
 \end{example}
 
+
 \subsubsection{Defining When-Equations by If-Expressions in Equality Equations}\label{defining-when-equations-by-if-expressions-in-equality-equations}
 
 A \lstinline!when!-equation:
@@ -224,6 +225,7 @@ However, \lstinline!pre(u)! is legal within the \lstinline!when!-clause, since t
 The start values of the introduced \lstinline!Boolean! variables are defined by the taking the start value of the when-condition, as above where \lstinline!b! is a parameter variable.
 The start value of the special functions \lstinline!initial!, \lstinline!terminal!, and \lstinline!sample! is \lstinline!false!.
 
+
 \subsubsection{Where a When-Equation May Occur}\label{restrictions-on-where-a-when-equation-may-occur}\label{where-a-when-equation-may-occur}
 
 \begin{itemize}
@@ -245,6 +247,7 @@ when x > 2 then
 end when;
 \end{lstlisting}
 \end{example}
+
 
 \subsubsection{Equations within When-Equations}\label{restrictions-on-equations-within-when-equations}\label{equations-within-when-equations}
 
@@ -334,6 +337,7 @@ equation
 \end{lstlisting}
 \end{example}
 
+
 \subsubsection{Single Assignment Rule Applied to When-Equations}\label{application-of-the-single-assignment-rule-to-when-equations}\label{single-assignment-rule-applied-to-when-equations}
 
 The Modelica single-assignment rule (\cref{synchronous-data-flow-principle-and-single-assignment-rule}) has implications for \lstinline!when!-equations:
@@ -401,6 +405,7 @@ end WhenPriorityAlg;
 \end{nonnormative}
 \end{itemize}
 
+
 \subsection{reinit}\label{reinit}
 
 \lstinline!reinit! can only be used in the body of a \lstinline!when!-equation.
@@ -433,6 +438,7 @@ when h < 0 then
 end when
 \end{lstlisting}
 \end{example}
+
 
 \subsection{assert}\label{assert}
 
@@ -490,6 +496,7 @@ It is recommended that asserts have a simple message as above, formulated with t
 Writing \lstinline!assert(T<500, "Temperature = "+String(T)+" was above 500")! is thus not recommended, and is likely to lead to duplicated information.
 \end{nonnormative}
 
+
 \subsection{terminate}\label{terminate}
 
 The \lstinline!terminate!\index{terminate@\robustinline{terminate}!equation@\robustinline{equation}}-equation or statement (using function syntax) successfully terminates the analysis which was carried out, see also \cref{assert}.
@@ -515,9 +522,11 @@ end ThrowingBall;
 \end{lstlisting}
 \end{example}
 
+
 \subsection{Equation Operators for Overconstrained Connection-Based Equation Systems}\label{equation-operators-for-overconstrained-connection-based-equation-systems}
 
 See \cref{equation-operators-for-overconstrained-connection-based-equation-systems1} for a description of this topic.
+
 
 \section{Synchronous Data-Flow Principle and Single Assignment Rule}\label{synchronous-data-flow-principle-and-single-assignment-rule}
 
@@ -537,6 +546,7 @@ If computation or communication time has to be simulated, this property has to b
 \item There must exist a perfect matching of variables to equations after flattening, where a variable can only be matched to equations that can contribute to solving for the variable
 (\firstuse{perfect matching rule} -- previously called \emph{single assignment rule}\index{single assignment rule|see{perfect matching rule}}); see also globally balanced \cref{balanced-models}.
 \end{enumerate}
+
 
 \section{Events and Synchronization}\label{events-and-synchronization}
 
@@ -890,6 +900,7 @@ During initialization this gives the following equations
 if \lstinline!steadyState! had not been an evaluable expression, both of those equations would have been illegal according to the restrictions in \cref{if-equations}.
 \end{example}
 
+
 \subsection{Equations Needed for Initialization}\label{the-number-of-equations-needed-for-initialization}\label{equations-needed-for-initialization}
 
 \begin{nonnormative}
@@ -915,6 +926,7 @@ Regarding DAEs, only that at most $n$ additional equations are needed to arrive 
 The reason is that in a higher index DAE problem the number of dynamic continuous-time state variables might be less than the number of state variables $n$.
 As noted in \cref{initialization-initial-equation-and-initial-algorithm} a tool may add/remove initial equations to fulfill this requirement, if appropriate diagnostics are given.
 \end{example}
+
 
 \subsection{Start Value Recommended Priority}\label{recommended-selection-of-start-values}\label{start-value-recommended-priority}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -41,12 +41,9 @@ No statements are allowed in equation sections, including the assignment stateme
 \subsection{Simple Equality Equations}\label{simple-equality-equations}
 
 Simple equality equations are the traditional kinds of equations known from mathematics that express an equality relation between two expressions.
-There are two syntactic forms of such equations in Modelica.
-The first form below is \emph{equality} equations between two expressions, whereas the second form is used when calling a function with \emph{several} results.
-The syntax for simple equality equations is as follows:
-\begin{lstlisting}[language=grammar]
-simple-expression "=" expression
-\end{lstlisting}
+The syntax is given by \productionref{simple-equation} in the grammar, and can be divided into two cases depending on the form of the left-hand side \productionref{simple-expression}.
+If the left-hand side is a parenthesized \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with several outputs.
+Otherwise, the equation expresses a single equality between the left-hand side and right-hand side expressions.
 The types of the left-hand-side and the right-hand-side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 
 Three examples:

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -30,29 +30,13 @@ A flattened equation is identical to the corresponding nonflattened equation.
 
 Names in an equation shall be found by looking up in the partially flattened enclosing class of the equation.
 
+
 \section{Equations in Equation Sections}\label{equations-in-equation-sections}
 
 An equation section is comprised of the keyword \lstinline!equation!\index{equation@\robustinline{equation}} followed by a sequence of equations.
-The formal syntax is as follows:
-\begin{lstlisting}[language=grammar]
-equation-section :
-   [ initial ] equation { some-equation ";" }
-\end{lstlisting}
+The syntax is given by \productionref{equation-section} in the grammar, and the different kinds of equatins that may occur within are given by \productionref{some-equation}.
+No statements are allowed in equation sections, including the assignment statement using the \lstinline!:=! operator.
 
-The following kinds of equations may occur in equation sections.
-The syntax is defined as follows:
-\begin{lstlisting}[language=grammar]
-some-equation :
-   ( simple-expression "=" expression
-     | if-equation
-     | for-equation
-     | connect-equation
-     | when-equation
-     | component-reference function-call-args
-   )
-   description
-\end{lstlisting}
-No statements are allowed in equation sections, including the assignment statement using the := operator.
 
 \subsection{Simple Equality Equations}\label{simple-equality-equations}
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -364,30 +364,11 @@ Function classes and record constructors (\cref{record-constructor-functions}) a
 
 \subsection{Positional or Named Input Arguments}\label{positional-or-named-input-arguments-of-functions}
 
-A function call has optional positional arguments followed by zero, one or more named arguments, such as
-
+A function call has optional positional arguments followed by zero, one or more named arguments, such as:
 \begin{lstlisting}[language=modelica]
 f(3.5, 5.76, arg3=5, arg6=8.3);
 \end{lstlisting}
-
-The formal syntax of a function call (simplified by removing reduction expression, \cref{reduction-expressions}):
-\begin{lstlisting}[language=grammar]
-primary :
-   component-reference function-call-args
-
-function-call-args :
-   "(" [ function-arguments ] ")"
-
-function-arguments :
-   function-argument [ "," function-arguments]
-   | named-arguments
-
-named-arguments: named-argument [ "," named-arguments ]
-
-named-argument: IDENT "=" function-argument
-
-function-argument : function-partial-application | expression
-\end{lstlisting}
+The formal syntax is given by \productionref{function-call} in the grammar, and is shared by the reduction expressions in \cref{reduction-expressions}.
 
 The interpretation of a function call is as follows: First, a list of unfilled slots is created for all formal input parameters.
 If there are $N$ positional arguments, they are placed in the first $N$ slots, where the order of the parameters is given by the order of the component declarations in the function definition.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1501,7 +1501,7 @@ The $u_{i}$ are applied in increasing order of $i$ (although the partial derivat
 In mathematical notation, the order of partial differentiation is reversed compared to the function definition; \lstinline!der($g$, $x$, $y$)! means $\frac{\partial}{\partial y}\frac{\partial}{\partial x}g$.
 \end{nonnormative}
 
-The \lstinline[language=grammar]!comment! has the same semantics as in a short class definition, for instance allowing the function to be given a description string, as well as \lstinline!Documentation! and \lstinline!Icon! annotations.
+The \productionref{comment} has the same semantics as in a short class definition, for instance allowing the function to be given a description string, as well as \lstinline!Documentation! and \lstinline!Icon! annotations.
 
 \begin{example}
 The specific enthalpy can be computed from a Gibbs-function as follows:
@@ -1900,7 +1900,7 @@ Just as for any other function, components in the public part of an external fun
 Protected components can be passed to the external function without being initialized by means of a declaration equation, which is useful for passing workspace memory to functions with FORTRAN style memory management, and the reason for passing them in the same (writable) way as output components (see \cref{argument-type-mapping}).
 The value of a protected component passed to the external function should be considered undefined (destroyed) after the external function call.
 
-The {\lstinline[language=grammar]!language-specification!} must currently be one of {\lstinline!"builtin"!} (deprecated), {\lstinline!"C"!}, {\lstinline!"C$\ldots$"!} (for one of the specific C standards like C89, C99, and C11 -- specifying that it relies on the C standard library of that version) or {\lstinline!"FORTRAN 77"!}.
+The \productionref{language-specification} must currently be one of {\lstinline!"builtin"!} (deprecated), {\lstinline!"C"!}, {\lstinline!"C$\ldots$"!} (for one of the specific C standards like C89, C99, and C11 -- specifying that it relies on the C standard library of that version) or {\lstinline!"FORTRAN 77"!}.
 Unless the external language is specified, it is assumed to be {\lstinline!"C"!}.
 
 \begin{nonnormative}
@@ -1934,7 +1934,7 @@ end UserModel;
 \end{lstlisting}
 \end{example}
 
-The {\lstinline[language=grammar]!external-function-call!} specification allows functions whose prototypes do not match the default assumptions as defined below to be called.
+The \productionref{external-function-call} specification allows functions whose prototypes do not match the default assumptions as defined below to be called.
 It also gives the name used to call the external function.
 If the external call is not given explicitly, this name is assumed to be the same as the Modelica name.
 
@@ -2350,7 +2350,7 @@ A deprecated feature is that if multiple \lstinline!Include! annotations -- poss
 In case calls to several external functions are generated in the same translation unit, the \lstinline!Include! annotations of the different functions must not define the same function -- except when relying on the deprecated behavior.
 
 The included code should be valid C89 code.
-If the \lstinline[language=grammar]!external-function-call! contains any \lstinline!size!-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
+If the \productionref{external-function-call} contains any \lstinline!size!-expression, the tool is responsible for ensuring that a C-header defining \lstinline[language=C]!size_t! is included before the \lstinline!"insertedCode"!.
 The \lstinline!"insertedCode"!, conditionally preceded by a header for \lstinline[language=C]!size_t!, must be a valid translation unit.
 
 When an \lstinline!Include! annotation is present, it shall provide a prototype for the external function, and hence the tool shall not produce an automatically generated prototype in the generated code in this case.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1468,11 +1468,7 @@ Therefore {\lstinline!h!} indirectly includes the derivative with respect to {\l
 
 \subsection{Partial Derivatives of Functions}\label{partial-derivatives-of-functions}\index{partial derivative}\index{der@\robustinline{der}!partial derivative}
 
-A function class defined as follows is a partial derivative of another function:
-\begin{lstlisting}[language=grammar]
-IDENT "=" der "(" name "," IDENT { "," IDENT } ")" description
-\end{lstlisting}
-
+A function class defined using \productionref{der-class-specifier} in the grammar is a partial derivative of another function.
 In \lstinline!$f$ = der($g$, $u_{1}, \ldots$)!, the function being defined is named $f$, and the function being differentiated is $g$.
 The name $g$ is looked up in the same way as a in short class definition, and the referenced class must be a function.
 Each $u_{i}$ must be a scalar {\lstinline!Real!} input to the function, and corresponds mathematically to prepending $\frac{\partial}{\partial u_{i}}$ to the function call.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1863,19 +1863,7 @@ The Modelica external function call interface provides the following:
   \end{nonnormative}
 \end{itemize}
 
-The format of an external function declaration is as follows.
-\begin{lstlisting}[language=grammar]
-function IDENT description-string
-  { component-clause ";" }
-  [ protected { component-clause ";" } ]
-external [ language-specification ]
-  [ external-function-call ]
-    [ annotation-clause ] ";"
-  [ annotation-clause ";" ]
-end IDENT;
-\end{lstlisting}%
-\indexinline{external}
-
+The syntax for declaring an external function is a function declaration where the optional \productionref{external-function-call}\indexinline{external} of \productionref{composition} in the grammar is present.
 Just as for any other function, components in the public part of an external function declaration shall be declared either as {\lstinline!input!} or {\lstinline!output!}.
 
 Protected components can be passed to the external function without being initialized by means of a declaration equation, which is useful for passing workspace memory to functions with FORTRAN style memory management, and the reason for passing them in the same (writable) way as output components (see \cref{argument-type-mapping}).

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1115,7 +1115,7 @@ derivative-constraints :
    "(" derivative-constraint { "," derivative-constraint } ")"
 
 derivative-constraint :
-   "order" = unsigned-number
+   "order" = UNSIGNED-INTEGER
    | "noDerivative" = IDENT
    | "zeroDerivative" = IDENT
 \end{lstlisting}\end{synopsis}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1087,13 +1087,13 @@ Partial derivatives are not provided via annotations, but using a certain type o
 
 \begin{annotationdefinition}[smoothOrder]
 \begin{synopsis}[grammar]\begin{lstlisting}
-"smoothOrder" "=" UNSIGNED-NUMBER
+"smoothOrder" "=" unsigned-number
 "smoothOrder"
    "("
       "normallyConstant" "=" IDENT
       { "," "normallyConstant" "=" IDENT }
    ")"
-   "=" UNSIGNED-NUMBER
+   "=" unsigned-number
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 This annotation has only an effect within a function declaration.
@@ -1134,7 +1134,7 @@ derivative-constraints :
    "(" derivative-constraint { "," derivative-constraint } ")"
 
 derivative-constraint :
-   "order" = UNSIGNED-NUMBER
+   "order" = unsigned-number
    | "noDerivative" = IDENT
    | "zeroDerivative" = IDENT
 \end{lstlisting}\end{synopsis}

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1074,7 +1074,7 @@ Partial derivatives are not provided via annotations, but using a certain type o
       "normallyConstant" "=" IDENT
       { "," "normallyConstant" "=" IDENT }
    ")"
-   "=" unsigned-number
+   "=" UNSIGNED-INTEGER
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
 This annotation has only an effect within a function declaration.

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1489,7 +1489,7 @@ Therefore {\lstinline!h!} indirectly includes the derivative with respect to {\l
 
 A function class defined as follows is a partial derivative of another function:
 \begin{lstlisting}[language=grammar]
-IDENT "=" der "(" name "," IDENT { "," IDENT } ")" comment
+IDENT "=" der "(" name "," IDENT { "," IDENT } ")" description
 \end{lstlisting}
 
 In \lstinline!$f$ = der($g$, $u_{1}, \ldots$)!, the function being defined is named $f$, and the function being differentiated is $g$.
@@ -1501,7 +1501,7 @@ The $u_{i}$ are applied in increasing order of $i$ (although the partial derivat
 In mathematical notation, the order of partial differentiation is reversed compared to the function definition; \lstinline!der($g$, $x$, $y$)! means $\frac{\partial}{\partial y}\frac{\partial}{\partial x}g$.
 \end{nonnormative}
 
-The \productionref{comment} has the same semantics as in a short class definition, for instance allowing the function to be given a description string, as well as \lstinline!Documentation! and \lstinline!Icon! annotations.
+The \productionref{description} has the same semantics as in a short class definition, for instance allowing the function to be given a description string, as well as \lstinline!Documentation! and \lstinline!Icon! annotations.
 
 \begin{example}
 The specific enthalpy can be computed from a Gibbs-function as follows:

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -1068,7 +1068,7 @@ Partial derivatives are not provided via annotations, but using a certain type o
 
 \begin{annotationdefinition}[smoothOrder]
 \begin{synopsis}[grammar]\begin{lstlisting}
-"smoothOrder" "=" unsigned-number
+"smoothOrder" "=" UNSIGNED-INTEGER
 "smoothOrder"
    "("
       "normallyConstant" "=" IDENT

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -23,14 +23,14 @@ extends-clause :
 \end{lstlisting}%
 \indexinline{extends}
 The name of the base class is looked up in the partially flattened enclosing class (\cref{enclosing-classes}) of the \lstinline!extends!-clause.
-If the optional \lstinline[language=grammar]!class-or-inheritance-modification! contains any \lstinline[language=grammar]!inheritance-modification! the base class is then modified as described in \cref{selective-model-extension}.
+If the optional \productionref{class-or-inheritance-modification} contains any \productionref{inheritance-modification} the base class is then modified as described in \cref{selective-model-extension}.
 The possibly modified found base class is flattened with a new environment and the partially flattened enclosing class of the \lstinline!extends!-clause.
 The new environment is the result of merging
 \begin{itemize}
 \item
   arguments of all enclosing class environments that match names in the flattened base class
 \item
-  a \lstinline[language=grammar]!class-modification! constructed from all \lstinline!argument! of the \lstinline[language=grammar]!inheritance-modification!
+  a \productionref{class-modification} constructed from all \lstinline!argument! of the \productionref{inheritance-modification}
 \end{itemize}
 in that order.
 
@@ -221,14 +221,14 @@ end ModelB;
 \subsection{Require Transitively Non-Replaceable}\label{restrictions-on-base-classes-and-constraining-types-to-be-transitively-non-replaceable}\label{require-transitively-non-replaceable}
 
 The class name used after \lstinline!extends! for base classes and for constraining classes must use a class reference considered transitively non-replaceable, see definition in \cref{transitively-non-replaceable}.
-For a replaceable component declaration without \lstinline[language=grammar]!constraining-clause! the class must use a class reference considered transitively non-replaceable.
+For a replaceable component declaration without \productionref{constraining-clause} the class must use a class reference considered transitively non-replaceable.
 
 \begin{nonnormative}
 The requirement to use a transitively non-replaceable name excludes the long form of redeclare, i.e., \lstinline!redeclare model extends M $\ldots$! where \lstinline!M! must be an inherited replaceable class.
 \end{nonnormative}
 
 \begin{nonnormative}
-The rule for a replaceable component declaration without \lstinline[language=grammar]!constraining-clause! implies that constraining classes are always transitively non-replaceable -- both if explicitly given or implicitly by the declaration.
+The rule for a replaceable component declaration without \productionref{constraining-clause} implies that constraining classes are always transitively non-replaceable -- both if explicitly given or implicitly by the declaration.
 \end{nonnormative}
 
 
@@ -696,7 +696,7 @@ A \lstinline!redeclare!\indexinline{redeclare} construct in a modifier replaces 
 A \lstinline!redeclare! construct as an element replaces the declaration of a local class or component with another declaration.
 Both \lstinline!redeclare! constructs work in the same way.
 The \lstinline!redeclare! construct as an element requires that the element is inherited, and cannot be combined with a modifier of the same element in the \lstinline!extends!-clause.
-For modifiers, the redeclare of classes uses the \lstinline[language=grammar]!short-class-definition! construct, which is a special case of normal class definitions and semantically behaves as the corresponding \lstinline[language=grammar]!class-definition!.
+For modifiers, the redeclare of classes uses the \productionref{short-class-definition} construct, which is a special case of normal class definitions and semantically behaves as the corresponding \productionref{class-definition}.
 
 A modifier with the keyword \lstinline!replaceable!\indexinline{replaceable} is automatically seen as being a \lstinline!redeclare!.
 
@@ -901,11 +901,11 @@ To detect this issue the rule on lookup of composite names (\cref{composite-name
 
 \subsection{Constraining Type}\label{constraining-type}
 
-In a replaceable declaration the optional \lstinline[language=grammar]!constraining-clause! defines a constraining type.
+In a replaceable declaration the optional \productionref{constraining-clause} defines a constraining type.
 Any modifications following the constraining type name are applied both for the purpose of defining the actual constraining type and they are automatically applied in the declaration and in any subsequent redeclaration.
 The precedence order is that declaration modifiers override constraining type modifiers.
 
-If the \lstinline[language=grammar]!constraining-clause! is not present in the original declaration (i.e., the non-redeclared declaration):
+If the \productionref{constraining-clause} is not present in the original declaration (i.e., the non-redeclared declaration):
 \begin{itemize}
 \item
   The type of the declaration is also used as a constraining type.
@@ -913,7 +913,7 @@ If the \lstinline[language=grammar]!constraining-clause! is not present in the o
   If modifiers are present in the original declaration, they also become modifiers on the constraining type.
 \end{itemize}
 
-The syntax of a \lstinline[language=grammar]!constraining-clause!\indexinline{constrainedby} is as follows:
+The syntax of a \productionref{constraining-clause}\indexinline{constrainedby} is as follows:
 \begin{lstlisting}[language=grammar]
 constraining-clause :
    constrainedby name [ class-modification ]
@@ -1025,7 +1025,7 @@ Thus if \lstinline!T2! is a scalar type (e.g., \lstinline!type T2 = Real!) then 
 
 \subsubsection{Constraining-Clause Annotations}\label{constraining-clause-annotations}
 
-Description and annotations on the \lstinline[language=grammar]!constraining-clause! are applied to the entire declaration, and it is an error if they also appear on the definition.
+Description and annotations on the \productionref{constraining-clause} are applied to the entire declaration, and it is an error if they also appear on the definition.
 
 \begin{nonnormative}
 The intent is that the description and/or annotation are at the end of the declaration, but it is not straightforward to specify this in the grammar.
@@ -1229,7 +1229,7 @@ The goal of selective model extension is to enable unforeseen structural variabi
 This is done by deselecting specific elements from a base class, described here, combined with adding elements as normal.
 \end{nonnormative}
 
-Selective model extension is activated by using one (or more) \lstinline[language=grammar]!inheritance-modification! in the optional \lstinline[language=grammar]!class-or-inheritance-modification! of an \lstinline!extends!-clause.
+Selective model extension is activated by using one (or more) \productionref{inheritance-modification} in the optional \productionref{class-or-inheritance-modification} of an \lstinline!extends!-clause.
 
 \begin{nonnormative}
 There is no corresponding mechanism for component modifications, short class definitions, or constrainedby.

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -780,7 +780,7 @@ Since the rule about applying the optional class-modification implies that all d
 For \lstinline!redeclare class extends B($\ldots$)! the inherited class is subject to the same restrictions as a redeclare of the inherited element, and the original class \lstinline!B! should be \firstuse{replaceable}, and the new element is only replaceable if the new definition is replaceable.
 In contrast to normal extends it is not subject to the restriction that \lstinline!B! should be transitively non-replaceable (since \lstinline!B! should be replaceable).
 
-The syntax rule for \lstinline!class extends! construct is in the definition of the \lstinline!class-specifier! nonterminal (see also class declarations in \cref{class-declarations}):
+The syntax rule for \lstinline!class extends! construct is in the definition of \productionref{class-specifier} in the grammar (see also class declarations in \cref{class-declarations}):
 \begin{lstlisting}[language=grammar]
 class-definition :
    [ encapsulated ] class-prefixes
@@ -792,7 +792,7 @@ long-class-specifier : $\ldots$
     | extends IDENT [ class-modification ] description-string
       composition end IDENT
 \end{lstlisting}
-The nonterminal \lstinline!class-definition! is referenced in several places in the grammar, including the following case which is used in some examples below, including \lstinline!package extends! and \lstinline!model extends!:
+The \productionref{class-definition} is referenced in several places in the grammar, including the following case which is used in some examples below, including \lstinline!package extends! and \lstinline!model extends!:
 \begin{lstlisting}[language=grammar]
 element :
    import-clause |

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -876,7 +876,7 @@ To detect this issue the rule on lookup of composite names (\cref{composite-name
 
 \subsection{Constraining Type}\label{constraining-type}
 
-In a replaceable declaration the optional \productionref{constraining-clause} defines a constraining type.
+In a replaceable declaration, the optional \productionref{constraining-clause}\indexinline{constrainedby} in the grammar defines a constraining type.
 Any modifications following the constraining type name are applied both for the purpose of defining the actual constraining type and they are automatically applied in the declaration and in any subsequent redeclaration.
 The precedence order is that declaration modifiers override constraining type modifiers.
 
@@ -887,12 +887,6 @@ If the \productionref{constraining-clause} is not present in the original declar
 \item
   If modifiers are present in the original declaration, they also become modifiers on the constraining type.
 \end{itemize}
-
-The syntax of a \productionref{constraining-clause}\indexinline{constrainedby} is as follows:
-\begin{lstlisting}[language=grammar]
-constraining-clause :
-   constrainedby name [ class-modification ]
-\end{lstlisting}
 
 \begin{example}
 Merging of modifiers:

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -14,15 +14,10 @@ The converse relation is then expressed as \lstinline!B! being a \firstuse{deriv
 This relation is specified by an \lstinline!extends!-clause in \lstinline!B! or in one of \lstinline!B!'s base classes.
 A class inherits all elements from its base classes, and may modify all non-final elements inherited from base classes, as explained below.
 
-The \lstinline!extends!-clause is used to specify inheritance from a base class into an (enclosing) class containing the \lstinline!extends!-clause.
+The \lstinline!extends!-clause\indexinline{extends} is used to specify inheritance from a base class into an (enclosing) class containing the \lstinline!extends!-clause.
 It is an unnamed element of a class definition that uses a name and an optional modification to specify a base class of the class defined using the class definition.
-The syntax of the \lstinline!extends!-clause is as follows:
-\begin{lstlisting}[language=grammar]
-extends-clause :
-   extends name [ class-or-inheritance-modification ] [ annotation-clause ]
-\end{lstlisting}%
-\indexinline{extends}
 The name of the base class is looked up in the partially flattened enclosing class (\cref{enclosing-classes}) of the \lstinline!extends!-clause.
+The syntax of the \lstinline!extends!-clause is given by \productionref{extends-clause} in the grammar.
 If the optional \productionref{class-or-inheritance-modification} contains any \productionref{inheritance-modification} the base class is then modified as described in \cref{selective-model-extension}.
 The possibly modified found base class is flattened with a new environment and the partially flattened enclosing class of the \lstinline!extends!-clause.
 The new environment is the result of merging

--- a/chapters/inheritance.tex
+++ b/chapters/inheritance.tex
@@ -775,33 +775,11 @@ Since the rule about applying the optional class-modification implies that all d
 For \lstinline!redeclare class extends B($\ldots$)! the inherited class is subject to the same restrictions as a redeclare of the inherited element, and the original class \lstinline!B! should be \firstuse{replaceable}, and the new element is only replaceable if the new definition is replaceable.
 In contrast to normal extends it is not subject to the restriction that \lstinline!B! should be transitively non-replaceable (since \lstinline!B! should be replaceable).
 
-The syntax rule for \lstinline!class extends! construct is in the definition of \productionref{class-specifier} in the grammar (see also class declarations in \cref{class-declarations}):
-\begin{lstlisting}[language=grammar]
-class-definition :
-   [ encapsulated ] class-prefixes
-   class-specifier
+The syntax of the \lstinline!class extends! construct is part of \productionref{long-class-specifier} in the grammar (see also class declarations in \cref{class-declarations}), where \productionref{long-class-specifier} is reached from \productionref{class-definition}.
+The \lstinline!redeclare! before the \productionref{class-definition} comes from \productionref{element} in the grammar.
 
-class-specifier : long-class-specifier | $\ldots$
-
-long-class-specifier : $\ldots$
-    | extends IDENT [ class-modification ] description-string
-      composition end IDENT
-\end{lstlisting}
-The \productionref{class-definition} is referenced in several places in the grammar, including the following case which is used in some examples below, including \lstinline!package extends! and \lstinline!model extends!:
-\begin{lstlisting}[language=grammar]
-element :
-   import-clause |
-   extends-clause |
-   [ redeclare ]
-   [ final ]
-   [ inner ] [ outer ]
-   ( ( class-definition | component-clause) |
-      replaceable ( class-definition | component-clause)
-        [constraining-clause comment])
-\end{lstlisting}
-
-\begin{nonnormative}
-Example to extend from existing packages:
+\begin{example}
+Extending from existing packages.
 \begin{lstlisting}[language=modelica]
 package PowerTrain // library from someone else
   replaceable package GearBoxes
@@ -816,8 +794,10 @@ package MyPowerTrain
   end GearBoxes;
 end MyPowerTrain;
 \end{lstlisting}
+\end{example}
 
-Example for an advanced type of package structuring with constraining types:
+\begin{example}
+Advanced type of package structuring with constraining types.
 \begin{lstlisting}[language=modelica]
 partial package PartialMedium "Generic medium interface"
   constant Integer nX "number of substances";
@@ -891,7 +871,7 @@ With this construction, all constant definitions have to be repeated whenever th
 For larger models this is not practical and therefore the only practically useful definition is the complicated construction in the previous example with \lstinline!redeclare model extends BaseProperties!.
 
 To detect this issue the rule on lookup of composite names (\cref{composite-name-lookup}) ensures that \lstinline!PartialMedium.dynamicViscosity! is incorrect in a simulation model.
-\end{nonnormative}
+\end{example}
 
 
 \subsection{Constraining Type}\label{constraining-type}

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -158,14 +158,18 @@ To fix the type mismatch above, the number has to be replaced by a \lstinline!St
 
 Other code listings in the document include specification of lexical units and grammatical structure, both using metasymbols of the extended BNF-grammar defined in~\cref{lexical-conventions}.
 Lexical units are named with all upper-case letters and introduced with the `\lstinline[language=grammar]!=!' sign:
-\begin{lstlisting}[language=grammar]
-SOME-TOKEN = NON-DIGIT { DIGIT | NON-DIGIT }
+\begin{lexicalunit*}{SOME-TOKEN}
+\begin{lstlisting}
+NON-DIGIT { DIGIT | NON-DIGIT }
 \end{lstlisting}
+\end{lexicalunit*}
+
 Grammatical structure is recognized by production rules being named with lower-case letters and introduced with the `\lstinline[language=grammar]!:!' sign (also note appearance of the Modelica keyword \lstinline!der!):
-\begin{lstlisting}[language=grammar]
-differentiated-expression :
-    der "(" SOME-TOKEN ")"
-    | "(" differentiated-expression "+" differentiated-expression ")"
+\begin{production*}{differentiated-expression}
+\begin{lstlisting}
+der "(" SOME-TOKEN ")"
+| "(" differentiated-expression "+" differentiated-expression ")"
 \end{lstlisting}
+\end{production*}
 
 Annotations are defined using the syntactic forms of Modelica record definitions and component declarations, but with special semantics given in \cref{notation-for-annotation-definitions}.

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -60,11 +60,11 @@ Explanations of many terms can be found using the document index in \cref{docume
 Some important terms are defined below.
 
 \begin{definition}[Component]\index{component}
-An element defined by the production \lstinline[language=grammar]!component-clause! in the Modelica grammar (basically a variable or an instance of a class)
+An element defined by the production \productionref{component-clause} in the Modelica grammar (basically a variable or an instance of a class)
 \end{definition}
 
 \begin{definition}[Element]\index{element}
-Class definition, \lstinline!extends!-clause, or \lstinline[language=grammar]!component-clause! declared in a class (basically a class reference or a component in a declaration).
+Class definition, \lstinline!extends!-clause, or \productionref{component-clause} declared in a class (basically a class reference or a component in a declaration).
 \end{definition}
 
 \begin{definition}[Flattening]\index{flattening}

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -69,6 +69,7 @@ Certain combinations of letters are \willintroduce{keywords} represented as \emp
 \subsection{Identifiers}\label{identifiers}
 
 Modelica \firstuse[identifier]{identifiers}, used for naming classes, variables, constants, and other items, are of two forms.
+The syntax is given by \lexicalunitref{IDENT} in the lexical conventions.
 The first form always starts with a letter or underscore (`\_'), followed by any number of letters, digits, or underscores.
 Case is significant, i.e., the identifiers \lstinline!Inductor! and \lstinline!inductor! are different.
 The second form (\lexicalunitref{Q-IDENT}) starts with a single quote, followed by a sequence of any printable ASCII character, where single-quote must be preceded by backslash, and terminated by a single quote, e.g., \lstinline!'12H'!, \lstinline!'13\'H'!, \lstinline!'+foo'!.
@@ -76,19 +77,6 @@ Control characters in quoted identifiers have to use string escapes.
 The single quotes are part of the identifier, i.e., \lstinline!'x'! and \lstinline!x! are distinct identifiers.
 The redundant escapes (\lstinline!'\?'! and \lstinline!'\"'!) are the same as the corresponding non-escaped variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica source code.
 A full BNF definition of the Modelica syntax and lexical units is available in \cref{modelica-concrete-syntax}.
-
-% For easy maintenance, the lexing rules below should be a substring of the full lexing rules in \cref{lexical-conventions}.
-\begin{lstlisting}[language=grammar]
-IDENT = NON-DIGIT { DIGIT | NON-DIGIT } | Q-IDENT
-Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
-NON-DIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
-DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
-Q-CHAR = NON-DIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")"
-   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
-   | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
-S-ESCAPE = "\'" | "\"" | "\?" | "\\"
-   | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
-\end{lstlisting}
 
 
 \subsection{Names}\label{names}

--- a/chapters/lexicalstructure.tex
+++ b/chapters/lexicalstructure.tex
@@ -71,7 +71,7 @@ Certain combinations of letters are \willintroduce{keywords} represented as \emp
 Modelica \firstuse[identifier]{identifiers}, used for naming classes, variables, constants, and other items, are of two forms.
 The first form always starts with a letter or underscore (`\_'), followed by any number of letters, digits, or underscores.
 Case is significant, i.e., the identifiers \lstinline!Inductor! and \lstinline!inductor! are different.
-The second form (\lstinline[language=grammar]!Q-IDENT!) starts with a single quote, followed by a sequence of any printable ASCII character, where single-quote must be preceded by backslash, and terminated by a single quote, e.g., \lstinline!'12H'!, \lstinline!'13\'H'!, \lstinline!'+foo'!.
+The second form (\lexicalunitref{Q-IDENT}) starts with a single quote, followed by a sequence of any printable ASCII character, where single-quote must be preceded by backslash, and terminated by a single quote, e.g., \lstinline!'12H'!, \lstinline!'13\'H'!, \lstinline!'+foo'!.
 Control characters in quoted identifiers have to use string escapes.
 The single quotes are part of the identifier, i.e., \lstinline!'x'! and \lstinline!x! are distinct identifiers.
 The redundant escapes (\lstinline!'\?'! and \lstinline!'\"'!) are the same as the corresponding non-escaped variants (\lstinline!'?'! and \lstinline!'"'!), but are only for use in Modelica source code.
@@ -114,7 +114,7 @@ A component reference: \lstinline!Ele.Resistor.u[21].r!
 
 \subsection{Modelica Keywords}\label{modelica-keywords}
 
-The following Modelica \firstuse[keyword]{keywords} are reserved words that cannot be used where \lstinline[language=grammar]!IDENT! is expected in the language grammar (\cref{modelica-concrete-syntax}):
+The following Modelica \firstuse[keyword]{keywords} are reserved words that cannot be used where \lexicalunitref{IDENT} is expected in the language grammar (\cref{modelica-concrete-syntax}):
 \begin{center}
 \begin{tabular}{l l l l l}
 {\lstinline!algorithm!} & {\lstinline!each!} & {\lstinline!final!} & {\lstinline!model!} & {\lstinline!record!}\\ \hline
@@ -157,7 +157,7 @@ Additionally, array literals and record literals can be expressed.
 \subsection{Floating Point Numbers}\label{floating-point-numbers}
 
 A floating point number is expressed as a decimal number in the form of a sequence of decimal digits followed by a decimal point, followed by decimal digits, followed by an exponent indicated by \lstinline!E! or \lstinline!e! followed by a sign and one or more decimal digits.
-The various parts can be omitted, see \lstinline[language=grammar]!UNSIGNED-REAL! in~\cref{lexical-conventions} for details and also the examples below.
+The various parts can be omitted, see \lexicalunitref{UNSIGNED-REAL} in~\cref{lexical-conventions} for details and also the examples below.
 The minimal recommended range is that of IEEE double precision floating point numbers, for which the largest representable positive number is $1.7976931348623157\times10^{308}$ and the smallest positive number is $2.2250738585072014\times 10^{-308}$.
 For example, the following are floating point number literals:
 \begin{lstlisting}[language=modelica]

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -217,7 +217,10 @@ For arrays this explains both the matrix algebra operators and the element-wise 
 
 The syntax of these operators is defined by Modelica grammar in \cref{expressions1}, under the \productionref{arithmetic-expression} rule.
 
+
 \section{Equality, Relational, and Logical Operators}\label{equality-relational-and-logical-operators}
+
+The syntax of relational and logical expressions is given by \productionref{logical-expression} in the grammar.
 
 Modelica supports the standard set of relational and logical operators, all of which produce the standard boolean values \lstinline!true! or \lstinline!false!:
 \begin{center}
@@ -249,24 +252,6 @@ The following logical operators are defined:
 \hline
 \end{tabular}
 \end{center}
-
-The grammar rules define the syntax of the relational and logical operators.
-\begin{lstlisting}[language=grammar]
-logical-expression :
-   logical-term { or logical-term }
-
-logical-term :
-   logical-factor { and logical-factor }
-
-logical-factor :
-   [ not ] relation
-
-relation :
-   arithmetic-expression [ relational-operator arithmetic-expression ]
-
-relational-operator :
-   "<" | "<=" | ">" | ">=" | "==" | "<>"
-\end{lstlisting}
 
 The following holds for relational operators:
 \begin{itemize}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1,6 +1,6 @@
 \chapter{Operators and Expressions}\label{operators-and-expressions}
 
-The lexical units are combined to form even larger building blocks such as \firstuse[expression]{expressions} according to the rules given by the \lstinline[language=grammar]!expression! part of the Modelica grammar in \cref{modelica-concrete-syntax}.
+The lexical units are combined to form even larger building blocks such as \firstuse[expression]{expressions} according to the rules given by the \productionref{expression} part of the Modelica grammar in \cref{modelica-concrete-syntax}.
 For example, they can be built from operators, function references, components, or component references (referring to components) and literals.
 Each expression has a type and a variability.
 
@@ -104,8 +104,8 @@ Named argument & none & {\lstinline!$\mathit{ident}$ = $\mathit{expr}$!} & {\lst
 \end{center}
 \end{table}
 
-The array index and member access operators can both be part of a \lstinline[language=grammar]!component-reference! (one of the alternative productions for \lstinline[language=grammar]!primary! in the grammar) and be applied to general expressions when the left operand is parenthesized.
-Directly using both member access and array index in a \lstinline[language=grammar]!component-reference! has a special intuitive meaning.
+The array index and member access operators can both be part of a \productionref{component-reference} (one of the alternative productions for \productionref{primary} in the grammar) and be applied to general expressions when the left operand is parenthesized.
+Directly using both member access and array index in a \productionref{component-reference} has a special intuitive meaning.
 See \cref{indexing} and \cref{member-access-operator}.
 
 \begin{example}
@@ -215,7 +215,7 @@ Modelica supports five binary arithmetic operators that operate on any numerical
 The semantics of these operators are given in \cref{scalar-vector-matrix-and-array-operator-functions} (both when applied to scalar operands and when one or both operands are of array type).
 For arrays this explains both the matrix algebra operators and the element-wise operators that start with a dot.
 
-The syntax of these operators is defined by Modelica grammar in \cref{expressions1}, under the \lstinline[language=grammar]!arithmetic-expression! rule.
+The syntax of these operators is defined by Modelica grammar in \cref{expressions1}, under the \productionref{arithmetic-expression} rule.
 
 \section{Equality, Relational, and Logical Operators}\label{equality-relational-and-logical-operators}
 
@@ -345,7 +345,7 @@ Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 
 It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
 It is also possible to select a record member of a general expression by enclosing it in parentheses.
-Note that while the selection is applied to an \lstinline[language=grammar]!output-expression-list! in the grammar, it is only semantically valid when the \lstinline[language=grammar]!output-expression-list! represents an expression.
+Note that while the selection is applied to an \productionref{output-expression-list} in the grammar, it is only semantically valid when the \productionref{output-expression-list} represents an expression.
 
 In case the first operand is an array it is seen as a slicing operation, see \cref{slice-operation}.
 

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -234,11 +234,7 @@ The filename shall have the extension \filename{mo}.
 
 \subsection{The within Clause}\label{the-within-clause}
 
-A \lstinline!within!-clause has the following syntax:
-\begin{lstlisting}[language=grammar]
-  within [ name ] ";"
-\end{lstlisting}%
-\indexinline{within}
+The syntax of a \lstinline!within!-clause\indexinline{within} is given by \productionref{within-clause} in the grammar.
 A non-top-level entity shall begin with a \lstinline!within!-clause which for the class defined in the entity specifies the location in the Modelica class hierarchy.
 A top-level class may contain a \lstinline!within!-clause with no \productionref{name}.
 For a sub-entity of an enclosing structured entity, the \lstinline!within!-clause shall designate the class of the enclosing entity; and this class must exist and must not have been defined using a short class definition.

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -241,7 +241,7 @@ For a sub-entity of an enclosing structured entity, the \lstinline!within!-claus
 See \cref{stored-definitions-containing-multiple-class-definitions} regarding the use of \lstinline!within!-clause when a \productionref{stored-definition} does not hold exactly one class definition.
 
 \begin{example}
-The subpackage \lstinline!Rotational! declared within \lstinline!Modelica.Mechanics! has the fully qualified name \lstinline!Modelica.Mechanics.Rotational!, which is formed by concatenating the \productionref{name} with the short name of the package.
+The subpackage \lstinline!Rotational! declared within \lstinline!Modelica.Mechanics! has the fully qualified name \lstinline!Modelica.Mechanics.Rotational!, which is formed by concatenating the \productionref{name} of the \productionref{within-clause} with the short name of the package.
 The declaration of \lstinline!Rotational! could be given as below:
 \begin{lstlisting}[language=modelica]
 within Modelica.Mechanics;

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -201,7 +201,7 @@ Tools may also store classes in data-base systems, but that is not standardized.
 \subsection{Directory Hierarchy Mapping}\label{mapping-a-package-class-hierarchy-into-a-directory-hierarchy-structured-entity}\label{directory-hierarchy-mapping}
 
 A directory shall contain a node, the file \filename{package.mo}.
-The node shall contain a \lstinline[language=grammar]!stored-definition! that defines a class \lstinline!A! with a name matching the name of the structured entity.
+The node shall contain a \productionref{stored-definition} that defines a class \lstinline!A! with a name matching the name of the structured entity.
 
 \begin{nonnormative}
 The node typically contains documentation and graphical information for a package, but may also contain additional elements of the class \lstinline!A!.
@@ -227,8 +227,8 @@ Classes and constants that are stored in \filename{package.mo} are also present 
 
 \subsection{Single File Mapping}\label{mapping-a-package-class-hierarchy-into-a-single-file-nonstructured-entity}\label{single-file-mapping}
 
-When mapping a package or class hierarchy to a file (e.g., the file \filename{A.mo}), the file content shall match \lstinline[language=grammar]!stored-definition! in the grammar.
-In this case, the \lstinline[language=grammar]!stored-definition! shall only define a single class whose name (here, \lstinline!A!) matches the name of the nonstructured entity.
+When mapping a package or class hierarchy to a file (e.g., the file \filename{A.mo}), the file content shall match \productionref{stored-definition} in the grammar.
+In this case, the \productionref{stored-definition} shall only define a single class whose name (here, \lstinline!A!) matches the name of the nonstructured entity.
 The filename shall have the extension \filename{mo}.
 
 
@@ -236,16 +236,16 @@ The filename shall have the extension \filename{mo}.
 
 A \lstinline!within!-clause has the following syntax:
 \begin{lstlisting}[language=grammar]
-  within [ packageprefixname ] ";"
+  within [ name ] ";"
 \end{lstlisting}%
 \indexinline{within}
 A non-top-level entity shall begin with a \lstinline!within!-clause which for the class defined in the entity specifies the location in the Modelica class hierarchy.
-A top-level class may contain a \lstinline!within!-clause with no name.
+A top-level class may contain a \lstinline!within!-clause with no \productionref{name}.
 For a sub-entity of an enclosing structured entity, the \lstinline!within!-clause shall designate the class of the enclosing entity; and this class must exist and must not have been defined using a short class definition.
-See \cref{stored-definitions-containing-multiple-class-definitions} regarding the use of \lstinline!within!-clause when a \lstinline[language=grammar]!stored-definition! does not hold exactly one class definition.
+See \cref{stored-definitions-containing-multiple-class-definitions} regarding the use of \lstinline!within!-clause when a \productionref{stored-definition} does not hold exactly one class definition.
 
 \begin{example}
-The subpackage \lstinline!Rotational! declared within \lstinline!Modelica.Mechanics! has the fully qualified name \lstinline!Modelica.Mechanics.Rotational!, which is formed by concatenating the \lstinline[language=grammar]!packageprefixname! with the short name of the package.
+The subpackage \lstinline!Rotational! declared within \lstinline!Modelica.Mechanics! has the fully qualified name \lstinline!Modelica.Mechanics.Rotational!, which is formed by concatenating the \productionref{name} with the short name of the package.
 The declaration of \lstinline!Rotational! could be given as below:
 \begin{lstlisting}[language=modelica]
 within Modelica.Mechanics;
@@ -257,8 +257,8 @@ package Rotational // Modelica.Mechanics.Rotational
 
 \section{Stored Definitions Containing Multiple Class Definitions}\label{stored-definitions-containing-multiple-class-definitions}
 
-The \lstinline[language=grammar]!stored-definition! in the grammar allows for zero or more class definitions, but a \lstinline[language=grammar]!stored-definition! not containing exactly one class definition can only be used to define top-level classes, cannot be used for file system mapping of packages or class-hierarchies (\cref{file-system-mapping-of-package-class}), and shall be ignored when searching the \lstinline!MODELICAPATH! (\cref{the-modelica-library-path-modelicapath}).
-It follows that any \lstinline!within!-clause (\cref{the-within-clause}) in such a \lstinline[language=grammar]!stored-definition! shall not contain a \lstinline[language=grammar]!packageprefixname!.
+The \productionref{stored-definition} in the grammar allows for zero or more class definitions, but a \productionref{stored-definition} not containing exactly one class definition can only be used to define top-level classes, cannot be used for file system mapping of packages or class-hierarchies (\cref{file-system-mapping-of-package-class}), and shall be ignored when searching the \lstinline!MODELICAPATH! (\cref{the-modelica-library-path-modelicapath}).
+It follows that any \lstinline!within!-clause (\cref{the-within-clause}) in such a \productionref{stored-definition} shall not contain a \productionref{name}.
 
 
 \section{External Resources}\label{external-resources}

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -55,7 +55,7 @@ The reason to ignore the implicitly defined names is that a record and the impli
 \subsection{Simple Name Lookup}\label{simple-name-lookup}
 
 % Not adding 'encapsulated' as normal word to index; the keyword variant seems sufficient
-A class declared with the keyword \lstinline!encapsulated!\indexinline{encapsulated} (see \lstinline[language=grammar]!class-definition! in the grammar) is called an \firstuse[---]{encapsulated} class.
+A class declared with the keyword \lstinline!encapsulated!\indexinline{encapsulated} (see \productionref{class-definition} in the grammar) is called an \firstuse[---]{encapsulated} class.
 By restricting name lookup inside a restricted class in ways defined in this chapter, the meaning of the class is made independent of where it is placed in a package hierarchy.
 
 When an element, equation, or section is flattened, any simple name (not composed using dot notation) is first looked up sequentially among iteration variables (if any; see below), and then looked up sequentially in each member of the ordered set \emph{of instance scopes (see \cref{the-class-tree}) corresponding to lexically enclosing classes} until a match is found or an enclosing class is encapsulated.
@@ -108,7 +108,7 @@ For a composite name of the form \lstinline!A.B! or \lstinline!A.B.C!, etc.\ loo
 \end{itemize}
 
 \begin{nonnormative}
-The temporary class flattening performed for composite names follow the same rules as class flattening of the base class in an \lstinline!extends!-clause, local classes and the type in a \lstinline[language=grammar]!component-clause!, except that the environment is empty.
+The temporary class flattening performed for composite names follow the same rules as class flattening of the base class in an \lstinline!extends!-clause, local classes and the type in a \productionref{component-clause}, except that the environment is empty.
 See also \lstinline!MoistAir2! example in \cref{redeclaration} for further explanations regarding looking inside partial packages.
 \end{nonnormative}
 \begin{example}
@@ -389,7 +389,7 @@ This tree can be seen as the abstract syntax tree (AST) of the loaded libraries.
 
 The output of the instantiation process is an \firstuse{instance tree}.
 The instance tree consists of nodes representing the elements of a class definition from the class tree.
-For a component the subtree of a particular node is created using the information from the class of the \lstinline[language=grammar]!component-clause! and a new modification environment as result of merging the current modification environment with the modifications from the current element declaration (see \cref{merging-of-modifications}).
+For a component the subtree of a particular node is created using the information from the class of the \productionref{component-clause} and a new modification environment as result of merging the current modification environment with the modifications from the current element declaration (see \cref{merging-of-modifications}).
 
 The instance tree has the following properties:
 \begin{itemize}

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -142,24 +142,15 @@ This applies both to simple assignment statements, and the parenthesized, comma-
 
 \subsection{For-Statement}\label{for-statement}
 
-The syntax of a \lstinline!for!-statement\index{for@\robustinline{for}!statement}\index{loop@\robustinline{loop}!for-statement@\robustinline{for}-statement} is as follows:
-\begin{lstlisting}[language=grammar]
-for for-indices loop
-  { statement ";" }
-end for
-\end{lstlisting}
-A \lstinline!for!-statement may optionally use several iterators (\lstinline!for-indices!), see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information:
-\begin{lstlisting}[language=grammar]
-for-indices:
-   for-index { "," for-index }
+The syntax of a \lstinline!for!-statement\index{for@\robustinline{for}!statement}\index{loop@\robustinline{loop}!for-statement@\robustinline{for}-statement} is given by \productionref{for-statement} in the grammar.
+A \lstinline!for!-statement may optionally use several iterators (\lstinline!for-indices!), see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information.
 
-for-index:
-   IDENT [ in  expression ]
-\end{lstlisting}
+% FIXME: It is weird to give an example in the form of grammar like this:
 The following is an example of a prefix of a \lstinline!for!-statement:
-\begin{lstlisting}[language=modelica]
+\begin{lstlisting}[language=grammar]
 for IDENT in expression loop
 \end{lstlisting}
+
 The rules for \lstinline!for!-statements are the same as for \lstinline!for!-expressions in \cref{explicit-iteration-ranges-of-for-equations} -- except that the \lstinline!expression! of a \lstinline!for!-statement is not restricted to a parameter-expression.
 
 If the \lstinline!for!-statement contains event-generating expressions, any expression in \productionref{for-index} shall be evaluable.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -109,8 +109,8 @@ The syntax of \firstuse[assignment statement!simple]{simple assignment statement
 component-reference ":=" expression
 \end{lstlisting}
 
-The \lstinline[language=grammar]!expression! is evaluated.
-The resulting value is stored into the variable denoted by \lstinline[language=grammar]!component-reference!.
+The \productionref{expression} is evaluated.
+The resulting value is stored into the variable denoted by \productionref{component-reference}.
 
 The \lstinline!expression! must not have higher variability than the assigned component, see \cref{variability-of-expressions}.
 
@@ -180,7 +180,7 @@ for IDENT in expression loop
 \end{lstlisting}
 The rules for \lstinline!for!-statements are the same as for \lstinline!for!-expressions in \cref{explicit-iteration-ranges-of-for-equations} -- except that the \lstinline!expression! of a \lstinline!for!-statement is not restricted to a parameter-expression.
 
-If the \lstinline!for!-statement contains event-generating expressions, any expression in \lstinline[language=grammar]!for-index! shall be evaluable.
+If the \lstinline!for!-statement contains event-generating expressions, any expression in \productionref{for-index} shall be evaluable.
 
 \begin{nonnormative}
 In general, the same event-generating expression requires distinct crossing functions for different iterations of the \lstinline!for!-loop, and the restriction ensures that the number of crossing functions is known during translation time.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -264,13 +264,8 @@ algorithm
 
 \subsection{While-Statement}\label{while-statement}
 
-The \lstinline!while!-statement\index{while@\robustinline{while}!statement}\index{loop@\robustinline{loop}!while-statement@\robustinline{while}-statement} has the following syntax:
-\begin{lstlisting}[language=grammar]
-while expression loop
-  { statement ";" }
-end while
-\end{lstlisting}
-The \lstinline!expression! of a \lstinline!while!-statement shall be a scalar \lstinline!Boolean! expression.
+The syntax of a \lstinline!while!-statement\index{while@\robustinline{while}!statement}\index{loop@\robustinline{loop}!while-statement@\robustinline{while}-statement} is given by \productionref{while-statement} in the grammar.
+The \productionref!expression! of a \lstinline!while!-statement shall be a scalar \lstinline!Boolean! expression.
 
 The \lstinline!while!-statement corresponds to while-statements in other programming languages, and is formally defined as follows:
 \begin{enumerate}

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -286,7 +286,7 @@ A deprecated feature is that all expressions in a \lstinline!while!-statement ar
 The \lstinline!break!-statement\index{break@\robustinline{break}} breaks the execution of the innermost \lstinline!while!- or \lstinline!for!-loop enclosing the \lstinline!break!-statement and continues execution after the \lstinline!while!- or \lstinline!for!-loop.
 It can only be used in a \lstinline!while!- or \lstinline!for!-loop in an algorithm section.
 It has the following syntax:
-\begin{lstlisting}[language=modelica]
+\begin{lstlisting}[language=grammar]
 break;
 \end{lstlisting}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -151,12 +151,6 @@ This applies both to simple assignment statements, and the parenthesized, comma-
 The syntax of a \lstinline!for!-statement\index{for@\robustinline{for}!statement}\index{loop@\robustinline{loop}!for-statement@\robustinline{for}-statement} is given by \productionref{for-statement} in the grammar.
 A \lstinline!for!-statement may optionally use several iterators (\lstinline!for-indices!), see \cref{nested-for-loops-and-reduction-expressions-with-multiple-iterators} for more information.
 
-% FIXME: It is weird to give an example in the form of grammar like this:
-The following is an example of a prefix of a \lstinline!for!-statement:
-\begin{lstlisting}[language=grammar]
-for IDENT in expression loop
-\end{lstlisting}
-
 The rules for \lstinline!for!-statements are the same as for \lstinline!for!-expressions in \cref{explicit-iteration-ranges-of-for-equations} -- except that the \lstinline!expression! of a \lstinline!for!-statement is not restricted to a parameter-expression.
 
 If the \lstinline!for!-statement contains event-generating expressions, any expression in \productionref{for-index} shall be evaluable.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -89,15 +89,14 @@ Names in statements are found as follows:
 
 \subsection{Simple Assignment Statements}\label{simple-assignment-statements}
 
-The syntax of \firstuse[assignment statement!simple]{simple assignment statement} is as follows:
-\begin{lstlisting}[language=grammar]
-component-reference ":=" expression
+The following is a \firstuse[assignment statement!simple]{simple assignment statement}, matching \productionref{simple-assignment} in the grammar:
+\begin{lstlisting}[language=modelica]
+$\mathit{component}$ := $\mathit{expr}$
 \end{lstlisting}
 
-The \productionref{expression} is evaluated.
-The resulting value is stored into the variable denoted by \productionref{component-reference}.
+The $\mathit{expr}$ is evaluated, and the resulting value is stored into $\mathit{component}$.
 
-The \lstinline!expression! must not have higher variability than the assigned component, see \cref{variability-of-expressions}.
+The $\mathit{expr}$ must not have higher variability than $\mathit{component}$, see \cref{variability-of-expressions}.
 
 Assignment to array variables with subscripts is described in \cref{array-indexing}.
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -128,7 +128,7 @@ For that case the following will give the same result:
 
 The syntax of an assignment statement with a call to a function with multiple results is as follows:
 \begin{lstlisting}[language=grammar]
-"(" output-expression-list ")" ":=" component-reference function-call-args
+"(" output-expression-list ")" ":=" function-call
 \end{lstlisting}
 
 \begin{nonnormative}

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -5,21 +5,18 @@ In this chapter we describe the algorithmic constructs that are available in Mod
 
 Statements are imperative constructs allowed in algorithm sections.
 
+
 \section{Algorithm Sections}\label{algorithm-sections}
 
 An \firstuse[algorithm!section]{algorithm section} is a part of a class definition comprised of the keyword \lstinline!algorithm!\index{algorithm@\robustinline{algorithm}} followed by a sequence of statements.
-The formal syntax is as follows:
-\begin{lstlisting}[language=grammar]
-algorithm-section :
-   [ initial ] algorithm { statement ";" }
-\end{lstlisting}
-
+The syntax is given by \productionref{algorithm-section} in the grammar, and the different kinds of equatins that may occur within are given by \productionref{statement}.
 Like an equation, an algorithm section relates variables, i.e., constrains the values that these variables can take simultaneously.
 In contrast to an equation section, an algorithm section distinguishes inputs from outputs:
 An algorithm section specifies how to compute output variables as a function of given input variables.
 A Modelica tool may actually invert an algorithm section, i.e., compute inputs from given outputs, e.g., by search (generate and test), or by deriving an inverse algorithm symbolically.
 
 Equation equality \lstinline!=! or any other kind of equation (see \cref{equations}) shall not be used in an algorithm section.
+
 
 \subsection{Initial Algorithm Sections}\label{initial-algorithm-sections}
 
@@ -86,21 +83,6 @@ Names in statements are found as follows:
   Names in a statement shall be found by looking up in the partially flattened enclosing class of the algorithm section.
 \end{itemize}
 
-The syntax of statements is as follows:
-\begin{lstlisting}[language=grammar]
-statement :
-   ( component-reference ( ":=" expression | function-call-args )
-     | "(" output-expression-list ")" ":="
-       component-reference function-call-args
-     | break
-     | return
-     | if-statement
-     | for-statement
-     | while-statement
-     | when-statement
-   )
-   description
-\end{lstlisting}
 
 \subsection{Simple Assignment Statements}\label{simple-assignment-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -9,7 +9,7 @@ Statements are imperative constructs allowed in algorithm sections.
 \section{Algorithm Sections}\label{algorithm-sections}
 
 An \firstuse[algorithm!section]{algorithm section} is a part of a class definition comprised of the keyword \lstinline!algorithm!\index{algorithm@\robustinline{algorithm}} followed by a sequence of statements.
-The syntax is given by \productionref{algorithm-section} in the grammar, and the different kinds of equatins that may occur within are given by \productionref{statement}.
+The syntax is given by \productionref{algorithm-section} in the grammar, and the different kinds of equations that may occur within are given by \productionref{statement}.
 Like an equation, an algorithm section relates variables, i.e., constrains the values that these variables can take simultaneously.
 In contrast to an equation section, an algorithm section distinguishes inputs from outputs:
 An algorithm section specifies how to compute output variables as a function of given input variables.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -22,6 +22,7 @@ Equation equality \lstinline!=! or any other kind of equation (see \cref{equatio
 
 See \cref{initialization-initial-equation-and-initial-algorithm} for a description of both initial algorithm sections and initial equation sections.
 
+
 \subsection{An Algorithm in a Model}\label{execution-of-an-algorithm-in-a-model}\label{an-algorithm-in-a-model}
 
 An algorithm section is conceptually a code fragment that remains together and the statements of an algorithm section are executed in the order of appearance.
@@ -64,9 +65,11 @@ The conceptual part indicate that if the variable is assigned unconditionally in
 This is usually the case, except for algorithms with \lstinline!when!-statements, and especially for initial algorithms.
 \end{nonnormative}
 
+
 \subsection{The Algorithm in a Function}\label{execution-of-the-algorithm-in-a-function}\label{the-algorithm-in-a-function}
 
 See \crefnameref{initialization-and-binding-equations-of-components-in-functions}.
+
 
 \section{Statements}\label{statements}
 
@@ -97,6 +100,7 @@ The resulting value is stored into the variable denoted by \productionref{compon
 The \lstinline!expression! must not have higher variability than the assigned component, see \cref{variability-of-expressions}.
 
 Assignment to array variables with subscripts is described in \cref{array-indexing}.
+
 
 \subsubsection{Assignments from Called Functions with Multiple Results}\label{assignments-from-called-functions-with-multiple-results}
 
@@ -135,10 +139,12 @@ The syntax of an assignment statement with a call to a function with multiple re
 Also see \cref{simple-equality-equations} regarding calling functions with multiple results within equations.
 \end{nonnormative}
 
+
 \subsubsection{Assigned Variables - Restrictions}\label{restrictions-on-assigned-variables}\label{assigned-variables-restrictions}
 
 Only components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!connector! may appear as left-hand-side in algorithms.
 This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple results.
+
 
 \subsection{For-Statement}\label{for-statement}
 
@@ -178,6 +184,7 @@ equation
   end for;
 \end{lstlisting}
 \end{example}
+
 
 \subsubsection{Implicit Iteration Ranges}\label{implicit-iteration-ranges}
 
@@ -225,6 +232,7 @@ Real xsquared5[FourEnums] = {x[i] * x[i] for i};
 \end{lstlisting}
 \end{example}
 
+
 \subsubsection{Types as Iteration Ranges}\label{types-as-iteration-ranges}
 
 The iteration range can be specified as \lstinline!Boolean! or as an enumeration type.
@@ -244,6 +252,7 @@ equation
 \end{lstlisting}
 \end{example}
 
+
 \subsubsection{Nested For-Loops and Reduction Expressions with Multiple Iterators}\label{nested-for-loops-and-reduction-expressions-with-multiple-iterators}
 
 The notation with several iterators is a shorthand notation for nested \lstinline!for!-statements or \lstinline!for!-equations (or reduction expressions).
@@ -261,6 +270,7 @@ algorithm
   end for;
 \end{lstlisting}
 \end{example}
+
 
 \subsection{While-Statement}\label{while-statement}
 
@@ -280,6 +290,7 @@ The \lstinline!while!-statement corresponds to while-statements in other program
 
 Event-generating expressions are neither allowed in the \lstinline!expression! nor in the loop body statements.
 A deprecated feature is that all expressions in a \lstinline!while!-statement are implicitly inside \lstinline!noEvent!.
+
 
 \subsection{Break-Statement}\label{break-statement}
 
@@ -309,6 +320,7 @@ algorithm
 end findValue;
 \end{lstlisting}
 \end{example}
+
 
 \subsection{Return-Statements}\label{return-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -129,10 +129,7 @@ For that case the following will give the same result:
 \end{lstlisting}
 \end{example}
 
-The syntax of an assignment statement with a call to a function with multiple results is as follows:
-\begin{lstlisting}[language=grammar]
-"(" output-expression-list ")" ":=" function-call
-\end{lstlisting}
+The syntax of an assignment statement with a call to a function with multiple results is given by the case of \productionref{statement} in the grammar where a parenthesized \productionref{output-expression-list} is on the left-hand side of \lstinline!:=!.
 
 \begin{nonnormative}
 Also see \cref{simple-equality-equations} regarding calling functions with multiple results within equations.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -325,19 +325,11 @@ If none of the conditions evaluate to true the body of the \lstinline!else!-clau
 In an algorithm section, the selected body is then executed.
 The bodies that are not selected have no effect on that model evaluation.
 
+
 \subsection{When-Statements}\label{when-statements}
 
-A \lstinline!when!-statement\index{when@\robustinline{when}!statement}\index{then@\robustinline{then}!when-statement@\robustinline{when}-statement}\index{elsewhen@\robustinline{elsewhen}!when-statement@\robustinline{when}-statement} has the following syntax:
-\begin{lstlisting}[language=grammar]
-when expression then
-  { statement ";" }
-{ elsewhen expression then
-  { statement ";" }
-}
-end when
-\end{lstlisting}
-
-The \lstinline!expression! of a \lstinline!when!-statement shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
+The syntax of a \lstinline!when!-statement\index{when@\robustinline{when}!statement}\index{then@\robustinline{then}!when-statement@\robustinline{when}-statement}\index{elsewhen@\robustinline{elsewhen}!when-statement@\robustinline{when}-statement} is given by \productionref{when-statement} in the grammar.
+Here, each \productionref{expression} in the grammar (representing one or more triggering conditions of a branch) shall be a discrete-time \lstinline!Boolean! scalar or vector expression.
 The statements within a \lstinline!when!-statement are activated only at the instant when the scalar or any one of the elements of the vector expression becomes true.
 
 A \lstinline!when!-\emph{clause}\index{when@\robustinline{when}!clause} (without the \emph{clocked} qualification) may refer to either a \lstinline!when!-equation (\cref{when-equations}) or a \lstinline!when!-statement, but not to a clocked \lstinline!when!-clause.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -286,8 +286,8 @@ A deprecated feature is that all expressions in a \lstinline!while!-statement ar
 
 The \lstinline!break!-statement\index{break@\robustinline{break}} breaks the execution of the innermost \lstinline!while!- or \lstinline!for!-loop enclosing the \lstinline!break!-statement and continues execution after the \lstinline!while!- or \lstinline!for!-loop.
 It can only be used in a \lstinline!while!- or \lstinline!for!-loop in an algorithm section.
-It has the following syntax:
-\begin{lstlisting}[language=grammar]
+It has the following form:
+\begin{lstlisting}[language=modelica]
 break;
 \end{lstlisting}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -314,22 +314,11 @@ end findValue;
 
 Can only be used inside functions, see \cref{function-return-statements}.
 
+
 \subsection{If-Statement}\label{if-statement}
 
-The \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} have the following syntax:
-\begin{lstlisting}[language=grammar]
-if expression then
-  { statement ";" }
-{ elseif expression then
-  { statement ";" }
-}
-[ else
-  { statement ";" }
-]
-end if
-\end{lstlisting}
-
-The \lstinline!expression! of an \lstinline!if!- or \lstinline!elseif!-clause must be scalar \lstinline!Boolean! expression.
+The syntax of an \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
+Here, each \productionref{expression} in the grammar (representing the condition of an \lstinline!if!- or \lstinline!elseif!-clause) must be a scalar \lstinline!Boolean! expression.
 One \lstinline!if!-clause, and zero or more \lstinline!elseif!-clauses, and an optional \lstinline!else!-clause together form a list of branches.
 One or zero of the bodies of these \lstinline!if!-, \lstinline!elseif!- and \lstinline!else!-clauses is selected, by evaluating the conditions of the \lstinline!if!- and \lstinline!elseif!-clauses sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the body of the \lstinline!else!-clause is selected (if an \lstinline!else!-clause exists, otherwise no body is selected).

--- a/chapters/synchronous.tex
+++ b/chapters/synchronous.tex
@@ -236,7 +236,7 @@ The built-in operators (with function syntax) defined in the following sections 
 To define the restrictions, the following term is used.
 
 \begin{definition}[Component expression]\label{def:component-expression}\index{component!expression (argument restriction)}
-A component expression is a \lstinline[language=grammar]!component-reference! which is a valid expression, i.e., not referring to models or blocks with equations.
+A component expression is a \productionref{component-reference} which is a valid expression, i.e., not referring to models or blocks with equations.
 % "an element of records" below looks strange:
 In detail, it is an instance of a (a) base type, (b) derived type, (c) record, (d) an array of such an instance (a-c), (e) one or more elements of such an array (d) defined by index expressions which are evaluable (see below), or (f) an element of records.
 \begin{nonnormative}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -454,8 +454,14 @@ description
 
 \begin{production}{equation-or-procedure}
 \begin{lstlisting}
-simple-expression "=" expression
+simple-equation
 | function-call
+\end{lstlisting}
+\end{production}
+
+\begin{production}{simple-equation}
+\begin{lstlisting}
+simple-expression "=" expression
 \end{lstlisting}
 \end{production}
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -19,26 +19,75 @@ The following syntactic metasymbols are used (extended BNF):
 
 The following lexical units are defined:
 % Beware that the first lines of the lexing rules below are duplicated in \cref{identifiers}, and must be kept in sync.
-\begin{lstlisting}[language=grammar]
-IDENT = NON-DIGIT { DIGIT | NON-DIGIT } | Q-IDENT
-Q-IDENT = "'" { Q-CHAR | S-ESCAPE } "'"
-NON-DIGIT = "_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
-DIGIT = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
-Q-CHAR = NON-DIGIT | DIGIT | "!" | "#" | "$\mbox{\textdollar}$" | "%" | "&" | "(" | ")"
-   | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | ">" | "="
-   | "?" | "@" | "[" | "]" | "^" | "{" | "}" | "|" | "~" | " " | """
-S-ESCAPE = "\'" | "\"" | "\?" | "\\"
-   | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
-STRING = """ { S-CHAR | S-ESCAPE } """
-S-CHAR = see below
-UNSIGNED-INTEGER = DIGIT { DIGIT }
-UNSIGNED-REAL =
-   UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
-   | UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ]
-     ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
-   | "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
+
+\begin{lexicalunit}{IDENT}
+\begin{lstlisting}
+NON-DIGIT { DIGIT | NON-DIGIT } | Q-IDENT
 \end{lstlisting}
-\lstinline[language=grammar]!S-CHAR! is any member of the Unicode character set (\url{https://unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote `"', and backslash `\textbackslash{}'.
+\end{lexicalunit}
+
+\begin{lexicalunit}{Q-IDENT}
+\begin{lstlisting}
+"'" { Q-CHAR | S-ESCAPE } "'"
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{NON-DIGIT}
+\begin{lstlisting}
+"_" | letters "a" $\ldots$ "z" | letters "A" $\ldots$ "Z"
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{DIGIT}
+\begin{lstlisting}
+"0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{Q-CHAR}
+\begin{lstlisting}
+NON-DIGIT | DIGIT
+| " " | """ | "." | "," | ":" | ";" | "!" | "?" | "@" | "#" | "$\mbox{\textdollar}$"
+| "+" | "-" | "*" | "/" | "^" | "=" | "&" | "|" | "~" | "%"
+| "<" | ">" | "(" | ")" | "[" | "]" | "{" | "}"
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{S-ESCAPE}
+\begin{lstlisting}
+"\'" | "\"" | "\?" | "\\"
+| "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{STRING}
+\begin{lstlisting}
+""" { S-CHAR | S-ESCAPE } """
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{S-CHAR}
+\begin{lstlisting}
+see below
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{UNSIGNED-INTEGER}
+\begin{lstlisting}
+DIGIT { DIGIT }
+\end{lstlisting}
+\end{lexicalunit}
+
+\begin{lexicalunit}{UNSIGNED-REAL}
+\begin{lstlisting}
+UNSIGNED-INTEGER  "." [ UNSIGNED-INTEGER ]
+| UNSIGNED_INTEGER [ "." [ UNSIGNED_INTEGER ] ]
+  ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER
+| "."  UNSIGNED-INTEGER [ ( "e" | "E" ) [ "+" | "-" ] UNSIGNED-INTEGER ]
+\end{lstlisting}
+\end{lexicalunit}
+
+\lexicalunitref{S-CHAR} is any member of the Unicode character set (\url{https://unicode.org}; see \cref{mapping-package-class-structures-to-a-hierarchical-file-system} for storing as UTF-8 on files) except double-quote `"', and backslash `\textbackslash{}'.
 
 For identifiers the redundant escapes (`\lstinline!\?!' and `\lstinline!\"!') are the same as the corresponding non-escaped variants (`\lstinline!?!' and '\lstinline!"!').
 The single quotes are part of an identifier.
@@ -49,7 +98,7 @@ Note:
 \item
   White-space and comments can be used between separate lexical units and/or symbols, and also separates them.
   Each lexical unit will consume the maximum number of characters from the input stream.
-  White-space and comments cannot be used inside other lexical units, except for \lstinline[language=grammar]!STRING! and \lstinline[language=grammar]!Q-IDENT! where they are treated as part of the \lstinline[language=grammar]!STRING! or \lstinline[language=grammar]!Q-IDENT! lexical unit.
+  White-space and comments cannot be used inside other lexical units, except for \lexicalunitref{STRING} and \lexicalunitref{Q-IDENT} where they are treated as part of the \lexicalunitref{STRING} or \lexicalunitref{Q-IDENT} lexical unit.
 \item
   Concatenation of string literals requires a binary expression.
   For example, \lstinline!"a" + "b"! evaluates to \lstinline!"ab"!.

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -455,7 +455,7 @@ description
 \begin{production}{equation-or-procedure}
 \begin{lstlisting}
 simple-expression "=" expression
-| component-reference function-call-args
+| function-call
 \end{lstlisting}
 \end{production}
 
@@ -463,7 +463,7 @@ simple-expression "=" expression
 \begin{lstlisting}
 ( statement-or-procedure
   | "(" output-expression-list ")" ":="
-    component-reference function-call-args
+    function-call
   | break
   | return
   | if-statement
@@ -478,7 +478,13 @@ description
 \begin{production}{statement-or-procedure}
 \begin{lstlisting}
 component-reference ":=" expression
-| component-reference function-call-args
+| function-call
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-call}
+\begin{lstlisting}
+component-reference function-call-args
 \end{lstlisting}
 \end{production}
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -124,8 +124,14 @@ HTML encoded content may contain links in the same way as class documentation, s
 
 \begin{production}{stored-definition}
 \begin{lstlisting}
-[ within [ name ] ";" ]
+[ within-clause ]
 { [ final ] class-definition ";" }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{within-clause}
+\begin{lstlisting}
+within [ name ] ";"
 \end{lstlisting}
 \end{production}
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -604,7 +604,7 @@ primary [ ( "^" | ".^" ) primary ]
 
 \begin{production}{primary}
 \begin{lstlisting}
-UNSIGNED-NUMBER
+unsigned-number
 | STRING
 | false
 | true
@@ -618,7 +618,7 @@ UNSIGNED-NUMBER
 \end{lstlisting}
 \end{production}
 
-\begin{production}{UNSIGNED-NUMBER}
+\begin{production}{unsigned-number}
 \begin{lstlisting}
 UNSIGNED-INTEGER | UNSIGNED-REAL
 \end{lstlisting}

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -520,8 +520,8 @@ connect "(" component-reference "," component-reference ")"
 \end{production}
 
 \begin{nonnormative}
-The productions \lstinline[language=grammar]!equation-or-procedure! and \lstinline[language=grammar]!statement-or-procedure! are not suitable for recursive descent parsers.
-A work-around is to left-factor them and for \lstinline[language=grammar]!equation-or-procedure! introduce semantic checks to ensure that only the grammar above is accepted.
+The productions \productionref{equation-or-procedure} and \productionref{statement-or-procedure} are not suitable for recursive descent parsers.
+A work-around is to left-factor them and for \productionref{equation-or-procedure} introduce semantic checks to ensure that only the grammar above is accepted.
 \end{nonnormative}
 
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -483,8 +483,14 @@ description
 
 \begin{production}{statement-or-procedure}
 \begin{lstlisting}
-component-reference ":=" expression
+simple-assignment
 | function-call
+\end{lstlisting}
+\end{production}
+
+\begin{production}{simple-assignment}
+\begin{lstlisting}
+component-reference ":=" expression
 \end{lstlisting}
 \end{production}
 

--- a/chapters/syntax.tex
+++ b/chapters/syntax.tex
@@ -73,415 +73,678 @@ HTML encoded content may contain links in the same way as class documentation, s
 
 \subsection{Stored Definition -- Within}\label{stored-definition-within}
 
-\begin{lstlisting}[language=grammar]
-stored-definition :
-   [ within [ name ] ";" ]
-   { [ final ] class-definition ";" }
+\begin{production}{stored-definition}
+\begin{lstlisting}
+[ within [ name ] ";" ]
+{ [ final ] class-definition ";" }
 \end{lstlisting}
+\end{production}
+
 
 \subsection{Class Definition}\label{class-definition}
 
-\begin{lstlisting}[language=grammar]
-class-definition :
-   [ encapsulated ] class-prefixes class-specifier
-
-class-prefixes :
-   [ partial ]
-   ( class
-     | model
-     | [ operator ] record
-     | block
-     | [ expandable ] connector
-     | type
-     | package
-     | [ pure | impure ] [ operator ] function
-     | operator
-   )
-
-class-specifier :
-   long-class-specifier | short-class-specifier | der-class-specifier
-
-long-class-specifier :
-   IDENT description-string composition end IDENT
-   | extends IDENT [ class-modification ] description-string composition
-     end IDENT
-
-short-class-specifier :
-   IDENT "=" base-prefix type-specifier [ array-subscripts ]
-   [ class-modification ] description
-   | IDENT "=" enumeration "(" ( [ enum-list ] | ":" ) ")" description
-
-der-class-specifier :
-   IDENT "=" der "(" type-specifier "," IDENT { "," IDENT } ")" description
-
-base-prefix :
-   [ input | output ]
-
-enum-list :
-   enumeration-literal { "," enumeration-literal }
-
-enumeration-literal :
-   IDENT description
-
-composition :
-   element-list
-   { public element-list
-     | protected element-list
-     | equation-section
-     | algorithm-section
-   }
-   [ external [ language-specification ]
-     [ external-function-call ] [ annotation-clause ] ";"
-   ]
-   [ annotation-clause ";" ]
-
-language-specification :
-   STRING
-
-external-function-call :
-   [ component-reference "=" ]
-   IDENT "(" [ expression-list ] ")"
-
-element-list :
-   { element ";" }
-
-element :
-   import-clause
-   | extends-clause
-   | [ redeclare ]
-     [ final ]
-     [ inner ] [ outer ]
-     ( class-definition
-       | component-clause
-       | replaceable ( class-definition | component-clause )
-         [ constraining-clause description ]
-     )
-
-import-clause :
-   import
-   ( IDENT "=" name
-     | name [ ".*" | "." ( "*" | "{" import-list "}" ) ]
-   )
-   description
-
-import-list :
-   IDENT { "," IDENT }
+\begin{production}{class-definition}
+\begin{lstlisting}
+[ encapsulated ] class-prefixes class-specifier
 \end{lstlisting}
+\end{production}
+
+\begin{production}{class-prefixes}
+\begin{lstlisting}
+[ partial ]
+( class
+  | model
+  | [ operator ] record
+  | block
+  | [ expandable ] connector
+  | type
+  | package
+  | [ pure | impure ] [ operator ] function
+  | operator
+)
+\end{lstlisting}
+\end{production}
+
+\begin{production}{class-specifier}
+\begin{lstlisting}
+long-class-specifier | short-class-specifier | der-class-specifier
+\end{lstlisting}
+\end{production}
+
+\begin{production}{long-class-specifier}
+\begin{lstlisting}
+IDENT description-string composition end IDENT
+| extends IDENT [ class-modification ] description-string composition
+  end IDENT
+\end{lstlisting}
+\end{production}
+
+\begin{production}{short-class-specifier}
+\begin{lstlisting}
+IDENT "=" base-prefix type-specifier [ array-subscripts ]
+[ class-modification ] description
+| IDENT "=" enumeration "(" ( [ enum-list ] | ":" ) ")" description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{der-class-specifier}
+\begin{lstlisting}
+IDENT "=" der "(" type-specifier "," IDENT { "," IDENT } ")" description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{base-prefix}
+\begin{lstlisting}
+[ input | output ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{enum-list}
+\begin{lstlisting}
+enumeration-literal { "," enumeration-literal }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{enumeration-literal}
+\begin{lstlisting}
+IDENT description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{composition}
+\begin{lstlisting}
+element-list
+{ public element-list
+  | protected element-list
+  | equation-section
+  | algorithm-section
+}
+[ external [ language-specification ]
+  [ external-function-call ] [ annotation-clause ] ";"
+]
+[ annotation-clause ";" ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{language-specification}
+\begin{lstlisting}
+STRING
+\end{lstlisting}
+\end{production}
+
+\begin{production}{external-function-call}
+\begin{lstlisting}
+[ component-reference "=" ]
+IDENT "(" [ expression-list ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element-list}
+\begin{lstlisting}
+{ element ";" }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element}
+\begin{lstlisting}
+import-clause
+| extends-clause
+| [ redeclare ]
+  [ final ]
+  [ inner ] [ outer ]
+  ( class-definition
+    | component-clause
+    | replaceable ( class-definition | component-clause )
+      [ constraining-clause description ]
+  )
+\end{lstlisting}
+\end{production}
+
+\begin{production}{import-clause}
+\begin{lstlisting}
+import
+( IDENT "=" name
+  | name [ ".*" | "." ( "*" | "{" import-list "}" ) ]
+)
+description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{import-list}
+\begin{lstlisting}
+IDENT { "," IDENT }
+\end{lstlisting}
+\end{production}
+
 
 \subsection{Extends}\label{extends}
 
-\begin{lstlisting}[language=grammar]
-extends-clause :
-   extends type-specifier [ class-or-inheritance-modification ] [ annotation-clause ]
-
-constraining-clause :
-   constrainedby type-specifier [ class-modification ]
-
-class-or-inheritance-modification :
-   "(" [ argument-or-inheritance-modification-list ] ")"
-
-argument-or-inheritance-modification-list :
-    ( argument | inheritance-modification ) { "," ( argument | inheritance-modification ) }
-
-inheritance-modification :
-    break ( connect-equation | IDENT )
+\begin{production}{extends-clause}
+\begin{lstlisting}
+extends type-specifier [ class-or-inheritance-modification ] [ annotation-clause ]
 \end{lstlisting}
+\end{production}
+
+\begin{production}{constraining-clause}
+\begin{lstlisting}
+constrainedby type-specifier [ class-modification ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{class-or-inheritance-modification}
+\begin{lstlisting}
+"(" [ argument-or-inheritance-modification-list ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{argument-or-inheritance-modification-list}
+\begin{lstlisting}
+ ( argument | inheritance-modification ) { "," ( argument | inheritance-modification ) }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{inheritance-modification}
+\begin{lstlisting}
+ break ( connect-equation | IDENT )
+\end{lstlisting}
+\end{production}
+
 
 \subsection{Component Clause}\label{component-clause}
 
-\begin{lstlisting}[language=grammar]
-component-clause :
-   type-prefix type-specifier [ array-subscripts ] component-list
-
-type-prefix :
-   [ flow | stream ]
-   [ discrete | parameter | constant ]
-   [ input | output ]
-
-component-list :
-   component-declaration { "," component-declaration }
-
-component-declaration :
-   declaration [ condition-attribute ] description
-
-condition-attribute :
-   if expression
-
-declaration :
-   IDENT [ array-subscripts ] [ modification ]
+\begin{production}{component-clause}
+\begin{lstlisting}
+type-prefix type-specifier [ array-subscripts ] component-list
 \end{lstlisting}
+\end{production}
+
+\begin{production}{type-prefix}
+\begin{lstlisting}
+[ flow | stream ]
+[ discrete | parameter | constant ]
+[ input | output ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{component-list}
+\begin{lstlisting}
+component-declaration { "," component-declaration }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{component-declaration}
+\begin{lstlisting}
+declaration [ condition-attribute ] description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{condition-attribute}
+\begin{lstlisting}
+if expression
+\end{lstlisting}
+\end{production}
+
+\begin{production}{declaration}
+\begin{lstlisting}
+IDENT [ array-subscripts ] [ modification ]
+\end{lstlisting}
+\end{production}
+
 
 \subsection{Modification}\label{modification}
 
-\begin{lstlisting}[language=grammar]
-modification :
-   class-modification [ "=" modification-expression ]
-   | "=" modification-expression
-
-modification-expression :
-   expression
-   | break
-
-class-modification :
-   "(" [ argument-list ] ")"
-
-argument-list :
-   argument { "," argument }
-
-argument :
-   element-modification-or-replaceable
-   | element-redeclaration
-
-element-modification-or-replaceable :
-   [ each ] [ final ] ( element-modification | element-replaceable )
-
-element-modification :
-   name [ modification ] description-string
-
-element-redeclaration :
-   redeclare [ each ] [ final ]
-   ( short-class-definition | component-clause1 | element-replaceable )
-
-element-replaceable :
-   replaceable ( short-class-definition | component-clause1 )
-   [ constraining-clause ]
-
-component-clause1 :
-   type-prefix type-specifier component-declaration1
-
-component-declaration1 :
-   declaration description
-
-short-class-definition :
-   class-prefixes short-class-specifier
+\begin{production}{modification}
+\begin{lstlisting}
+class-modification [ "=" modification-expression ]
+| "=" modification-expression
 \end{lstlisting}
+\end{production}
+
+\begin{production}{modification-expression}
+\begin{lstlisting}
+expression
+| break
+\end{lstlisting}
+\end{production}
+
+\begin{production}{class-modification}
+\begin{lstlisting}
+"(" [ argument-list ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{argument-list}
+\begin{lstlisting}
+argument { "," argument }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{argument}
+\begin{lstlisting}
+element-modification-or-replaceable
+| element-redeclaration
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element-modification-or-replaceable}
+\begin{lstlisting}
+[ each ] [ final ] ( element-modification | element-replaceable )
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element-modification}
+\begin{lstlisting}
+name [ modification ] description-string
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element-redeclaration}
+\begin{lstlisting}
+redeclare [ each ] [ final ]
+( short-class-definition | component-clause1 | element-replaceable )
+\end{lstlisting}
+\end{production}
+
+\begin{production}{element-replaceable}
+\begin{lstlisting}
+replaceable ( short-class-definition | component-clause1 )
+[ constraining-clause ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{component-clause1}
+\begin{lstlisting}
+type-prefix type-specifier component-declaration1
+\end{lstlisting}
+\end{production}
+
+\begin{production}{component-declaration1}
+\begin{lstlisting}
+declaration description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{short-class-definition}
+\begin{lstlisting}
+class-prefixes short-class-specifier
+\end{lstlisting}
+\end{production}
 
 
 \subsection{Equations}\label{equations1}
 
-\begin{lstlisting}[language=grammar]
-equation-section :
-   [ initial ] equation { some-equation ";" }
-
-algorithm-section :
-   [ initial ] algorithm { statement ";" }
-
-some-equation :
-   ( equation-or-procedure
-     | if-equation
-     | for-equation
-     | connect-equation
-     | when-equation
-   )
-   description
-
-equation-or-procedure :
-   simple-expression "=" expression
-   | component-reference function-call-args
-
-statement :
-   ( statement-or-procedure
-     | "(" output-expression-list ")" ":="
-       component-reference function-call-args
-     | break
-     | return
-     | if-statement
-     | for-statement
-     | while-statement
-     | when-statement
-   )
-   description
-
-statement-or-procedure :
-   component-reference ":=" expression
-   | component-reference function-call-args
-
-if-equation :
-   if expression then
-     { some-equation ";" }
-   { elseif expression then
-     { some-equation ";" }
-   }
-   [ else
-     { some-equation ";" }
-   ]
-   end if
-
-if-statement :
-   if expression then
-     { statement ";" }
-   { elseif expression then
-     { statement ";" }
-   }
-   [ else
-     { statement ";" }
-   ]
-   end if
-
-for-equation :
-   for for-indices loop
-     { some-equation ";" }
-   end for
-
-for-statement :
-   for for-indices loop
-     { statement ";" }
-   end for
-
-for-indices :
-   for-index { "," for-index }
-
-for-index :
-   IDENT [ in expression ]
-
-while-statement :
-   while expression loop
-     { statement ";" }
-   end while
-
-when-equation :
-   when expression then
-     { some-equation ";" }
-   { elsewhen expression then
-     { some-equation ";" }
-   }
-   end when
-
-when-statement :
-   when expression then
-     { statement ";" }
-   { elsewhen expression then
-     { statement ";" }
-   }
-   end when
-
-connect-equation :
-   connect "(" component-reference "," component-reference ")"
+\begin{production}{equation-section}
+\begin{lstlisting}
+[ initial ] equation { some-equation ";" }
 \end{lstlisting}
+\end{production}
+
+\begin{production}{algorithm-section}
+\begin{lstlisting}
+[ initial ] algorithm { statement ";" }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{some-equation}
+\begin{lstlisting}
+( equation-or-procedure
+  | if-equation
+  | for-equation
+  | connect-equation
+  | when-equation
+)
+description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{equation-or-procedure}
+\begin{lstlisting}
+simple-expression "=" expression
+| component-reference function-call-args
+\end{lstlisting}
+\end{production}
+
+\begin{production}{statement}
+\begin{lstlisting}
+( statement-or-procedure
+  | "(" output-expression-list ")" ":="
+    component-reference function-call-args
+  | break
+  | return
+  | if-statement
+  | for-statement
+  | while-statement
+  | when-statement
+)
+description
+\end{lstlisting}
+\end{production}
+
+\begin{production}{statement-or-procedure}
+\begin{lstlisting}
+component-reference ":=" expression
+| component-reference function-call-args
+\end{lstlisting}
+\end{production}
+
+\begin{production}{if-equation}
+\begin{lstlisting}
+if expression then
+  { some-equation ";" }
+{ elseif expression then
+  { some-equation ";" }
+}
+[ else
+  { some-equation ";" }
+]
+end if
+\end{lstlisting}
+\end{production}
+
+\begin{production}{if-statement}
+\begin{lstlisting}
+if expression then
+  { statement ";" }
+{ elseif expression then
+  { statement ";" }
+}
+[ else
+  { statement ";" }
+]
+end if
+\end{lstlisting}
+\end{production}
+
+\begin{production}{for-equation}
+\begin{lstlisting}
+for for-indices loop
+  { some-equation ";" }
+end for
+\end{lstlisting}
+\end{production}
+
+\begin{production}{for-statement}
+\begin{lstlisting}
+for for-indices loop
+  { statement ";" }
+end for
+\end{lstlisting}
+\end{production}
+
+\begin{production}{for-indices}
+\begin{lstlisting}
+for-index { "," for-index }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{for-index}
+\begin{lstlisting}
+IDENT [ in expression ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{while-statement}
+\begin{lstlisting}
+while expression loop
+  { statement ";" }
+end while
+\end{lstlisting}
+\end{production}
+
+\begin{production}{when-equation}
+\begin{lstlisting}
+when expression then
+  { some-equation ";" }
+{ elsewhen expression then
+  { some-equation ";" }
+}
+end when
+\end{lstlisting}
+\end{production}
+
+\begin{production}{when-statement}
+\begin{lstlisting}
+when expression then
+  { statement ";" }
+{ elsewhen expression then
+  { statement ";" }
+}
+end when
+\end{lstlisting}
+\end{production}
+
+\begin{production}{connect-equation}
+\begin{lstlisting}
+connect "(" component-reference "," component-reference ")"
+\end{lstlisting}
+\end{production}
 
 \begin{nonnormative}
 The productions \lstinline[language=grammar]!equation-or-procedure! and \lstinline[language=grammar]!statement-or-procedure! are not suitable for recursive descent parsers.
 A work-around is to left-factor them and for \lstinline[language=grammar]!equation-or-procedure! introduce semantic checks to ensure that only the grammar above is accepted.
 \end{nonnormative}
 
+
 \subsection{Expressions}\label{expressions1}
 
-\begin{lstlisting}[language=grammar]
-expression :
-   simple-expression
-   | if expression then expression
-     { elseif expression then expression }
-     else expression
-
-simple-expression :
-   logical-expression [ ":" logical-expression [ ":" logical-expression ] ]
-
-logical-expression :
-   logical-term { or logical-term }
-
-logical-term :
-   logical-factor { and logical-factor }
-
-logical-factor :
-   [ not ] relation
-
-relation :
-   arithmetic-expression [ relational-operator arithmetic-expression ]
-
-relational-operator :
-   "<" | "<=" | ">" | ">=" | "==" | "<>"
-
-arithmetic-expression :
-   [ add-operator ] term { add-operator term }
-
-add-operator :
-   "+" | "-" | ".+" | ".-"
-
-term :
-   factor { mul-operator factor }
-
-mul-operator :
-   "*" | "/" | ".*" | "./"
-
-factor :
-   primary [ ( "^" | ".^" ) primary ]
-
-primary :
-   UNSIGNED-NUMBER
-   | STRING
-   | false
-   | true
-   | time
-   | ( component-reference | der | initial | pure ) function-call-args
-   | component-reference
-   | "(" output-expression-list ")" [ ( array-subscripts | "." IDENT ) ]
-   | "[" expression-list { ";" expression-list } "]"
-   | "{" array-arguments "}"
-   | end
-
-UNSIGNED-NUMBER :
-   UNSIGNED-INTEGER | UNSIGNED-REAL
-
-type-specifier :
-   ["."] name
-
-name :
-   IDENT { "." IDENT }
-
-component-reference :
-   [ "." ] IDENT [ array-subscripts ] { "." IDENT [ array-subscripts ] }
-
-result-reference :
-   component-reference
-   | time
-   | der "(" ( component-reference | time ) [ "," UNSIGNED-INTEGER ] ")"
-
-function-call-args :
-   "(" [ function-arguments ] ")"
-
-function-arguments :
-   expression [ "," function-arguments-non-first | for for-indices ]
-   | function-partial-application [ "," function-arguments-non-first ]
-   | named-arguments
-
-function-arguments-non-first :
-   function-argument [ "," function-arguments-non-first ]
-   | named-arguments
-
-array-arguments :
-   expression [ "," array-arguments-non-first | for for-indices ]
-
-array-arguments-non-first :
-   expression [ "," array-arguments-non-first ]
-
-named-arguments: named-argument [ "," named-arguments ]
-
-named-argument: IDENT "=" function-argument
-
-function-argument :
-   function-partial-application | expression
-
-function-partial-application :
-   function type-specifier "(" [ named-arguments ] ")"
-
-output-expression-list :
-   [ expression ] { "," [ expression ] }
-
-expression-list :
-   expression { "," expression }
-
-array-subscripts :
-   "[" subscript { "," subscript } "]"
-
-subscript :
-   ":" | expression
-
-description :
-   description-string [ annotation-clause ]
-
-description-string :
-   [ STRING { "+" STRING } ]
-
-annotation-clause :
-   annotation class-modification
+\begin{production}{expression}
+\begin{lstlisting}
+simple-expression
+| if expression then expression
+  { elseif expression then expression }
+  else expression
 \end{lstlisting}
+\end{production}
+
+\begin{production}{simple-expression}
+\begin{lstlisting}
+logical-expression [ ":" logical-expression [ ":" logical-expression ] ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{logical-expression}
+\begin{lstlisting}
+logical-term { or logical-term }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{logical-term}
+\begin{lstlisting}
+logical-factor { and logical-factor }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{logical-factor}
+\begin{lstlisting}
+[ not ] relation
+\end{lstlisting}
+\end{production}
+
+\begin{production}{relation}
+\begin{lstlisting}
+arithmetic-expression [ relational-operator arithmetic-expression ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{relational-operator}
+\begin{lstlisting}
+"<" | "<=" | ">" | ">=" | "==" | "<>"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{arithmetic-expression}
+\begin{lstlisting}
+[ add-operator ] term { add-operator term }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{add-operator}
+\begin{lstlisting}
+"+" | "-" | ".+" | ".-"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{term}
+\begin{lstlisting}
+factor { mul-operator factor }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{mul-operator}
+\begin{lstlisting}
+"*" | "/" | ".*" | "./"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{factor}
+\begin{lstlisting}
+primary [ ( "^" | ".^" ) primary ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{primary}
+\begin{lstlisting}
+UNSIGNED-NUMBER
+| STRING
+| false
+| true
+| time
+| ( component-reference | der | initial | pure ) function-call-args
+| component-reference
+| "(" output-expression-list ")" [ ( array-subscripts | "." IDENT ) ]
+| "[" expression-list { ";" expression-list } "]"
+| "{" array-arguments "}"
+| end
+\end{lstlisting}
+\end{production}
+
+\begin{production}{UNSIGNED-NUMBER}
+\begin{lstlisting}
+UNSIGNED-INTEGER | UNSIGNED-REAL
+\end{lstlisting}
+\end{production}
+
+\begin{production}{type-specifier}
+\begin{lstlisting}
+["."] name
+\end{lstlisting}
+\end{production}
+
+\begin{production}{name}
+\begin{lstlisting}
+IDENT { "." IDENT }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{component-reference}
+\begin{lstlisting}
+[ "." ] IDENT [ array-subscripts ] { "." IDENT [ array-subscripts ] }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{result-reference}
+\begin{lstlisting}
+component-reference
+| time
+| der "(" ( component-reference | time ) [ "," UNSIGNED-INTEGER ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-call-args}
+\begin{lstlisting}
+"(" [ function-arguments ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-arguments}
+\begin{lstlisting}
+expression [ "," function-arguments-non-first | for for-indices ]
+| function-partial-application [ "," function-arguments-non-first ]
+| named-arguments
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-arguments-non-first}
+\begin{lstlisting}
+function-argument [ "," function-arguments-non-first ]
+| named-arguments
+\end{lstlisting}
+\end{production}
+
+\begin{production}{array-arguments}
+\begin{lstlisting}
+expression [ "," array-arguments-non-first | for for-indices ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{array-arguments-non-first}
+\begin{lstlisting}
+expression [ "," array-arguments-non-first ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{named-arguments}
+\begin{lstlisting}
+named-argument [ "," named-arguments ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{named-argument}
+\begin{lstlisting}
+IDENT "=" function-argument
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-argument}
+\begin{lstlisting}
+function-partial-application | expression
+\end{lstlisting}
+\end{production}
+
+\begin{production}{function-partial-application}
+\begin{lstlisting}
+function type-specifier "(" [ named-arguments ] ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{output-expression-list}
+\begin{lstlisting}
+[ expression ] { "," [ expression ] }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{expression-list}
+\begin{lstlisting}
+expression { "," expression }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{array-subscripts}
+\begin{lstlisting}
+"[" subscript { "," subscript } "]"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{subscript}
+\begin{lstlisting}
+":" | expression
+\end{lstlisting}
+\end{production}
+
+\begin{production}{description}
+\begin{lstlisting}
+description-string [ annotation-clause ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{description-string}
+\begin{lstlisting}
+[ STRING { "+" STRING } ]
+\end{lstlisting}
+\end{production}
+
+\begin{production}{annotation-clause}
+\begin{lstlisting}
+annotation class-modification
+\end{lstlisting}
+\end{production}

--- a/chapters/unitexpressions.tex
+++ b/chapters/unitexpressions.tex
@@ -11,25 +11,34 @@ Examples for the syntax of unit expressions used in Modelica: \lstinline!"N.m"!,
 \section{The Syntax of Unit Expressions}\label{the-syntax-of-unit-expressions}
 
 The Modelica unit string syntax allows neither comments nor white-space, and a unit string shall match the \lstinline[language=grammar]!unit-expression! rule:
-\begin{lstlisting}[language=grammar]
-unit-expression :
-   unit-numerator [ "/" unit-denominator ]
 
-unit-numerator :
-   "1" | unit-factors | "(" unit-expression ")"
-
-unit-denominator:
-   unit-factor | "(" unit-expression ")"
+\begin{production}{unit-expression}
+\begin{lstlisting}
+unit-numerator [ "/" unit-denominator ]
 \end{lstlisting}
+\end{production}
+
+\begin{production}{unit-numerator}
+\begin{lstlisting}
+"1" | unit-factors | "(" unit-expression ")"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{unit-denominator}
+\begin{lstlisting}
+unit-factor | "(" unit-expression ")"
+\end{lstlisting}
+\end{production}
 
 The unit of measure of a dimension free quantity is denoted by \lstinline!"1"!.
 The SI standard does not define any precedence between multiplications and divisions.
 The SI standard does not allow multiple units to the right of the division-symbol (\lstinline!/!) since the result is ambiguous; either the divisor shall be enclosed in parentheses, or negative exponents used instead of division, for example, \lstinline!"J/(kg.K)"! may be written as \lstinline!"J.kg-1.K-1"!.
 
-\begin{lstlisting}[language=grammar]
-unit-factors :
-   unit-factor [ "." unit-factors ]
+\begin{production}{unit-factors}
+\begin{lstlisting}
+unit-factor [ "." unit-factors ]
 \end{lstlisting}
+\end{production}
 
 The SI standard specifies that a multiplication operator symbol is written as space or as a dot.
 The SI standard requires that this \emph{dot} is a bit above the base line: `·', which is not part of ASCII.
@@ -37,33 +46,47 @@ The ISO standard also prefers `·', but Modelica supports the ISO alternative `.
 
 For example, Modelica does not support \lstinline!"Nm"! for newton-meter, but requires it to be written as \lstinline!"N.m"!.
 
-\begin{lstlisting}[language=grammar]
-unit-factor :
-  unit-operand [ unit-exponent ]
-
-unit-exponent :
-   [ "+" | "-" ] ( UNSIGNED-INTEGER | "(" UNSIGNED-INTEGER "/" UNSIGNED-INTEGER ")" )
+\begin{production}{unit-factor}
+\begin{lstlisting}
+unit-operand [ unit-exponent ]
 \end{lstlisting}
+\end{production}
+
+\begin{production}{unit-exponent}
+\begin{lstlisting}
+[ "+" | "-" ] ( UNSIGNED-INTEGER | "(" UNSIGNED-INTEGER "/" UNSIGNED-INTEGER ")" )
+\end{lstlisting}
+\end{production}
 
 The SI standard uses super-script for the exponentation, and does thus not define any operator symbol for exponentiation.
 A \lstinline[language=grammar]!unit-factor! consists of a \lstinline[language=grammar]!unit-operand! possibly suffixed by a possibly signed integer or rational number, which is interpreted as an exponent.
 There must be no spacing between the \lstinline[language=grammar]!unit-operand! and a possible \lstinline[language=grammar]!unit-exponent!.
 It is recommended to use the simplest representation of exponents, meaning that the explicit \lstinline!+! sign should be avoided, that leading zeros should be avoided, that rational exponents are reduced to not have common factors in the numerator and denominator, that rational exponents with denominator 1 should be avoided in favor of plain integer exponents, that the exponent 1 is omitted, and that entire factors with exponent 0 are omitted.
 
-\begin{lstlisting}[language=grammar]
-unit-operand :
-   unit-symbol | unit-prefix unit-symbol
-
-unit-prefix :
-   "Q" | "R" | "Y" | "Z" | "E" | "P" | "T" | "G" | "M" | "k" | "h" | "da"
-   | "d" | "c" | "m" | "u" | "n" | "p" | "f" | "a" | "z" | "y" | "r" | "q"
-
-unit-symbol :
-   unit-char { unit-char }
-
-unit-char :
-   NON-DIGIT
+\begin{production}{unit-operand}
+\begin{lstlisting}
+unit-symbol | unit-prefix unit-symbol
 \end{lstlisting}
+\end{production}
+
+\begin{production}{unit-prefix}
+\begin{lstlisting}
+"Q" | "R" | "Y" | "Z" | "E" | "P" | "T" | "G" | "M" | "k" | "h" | "da"
+| "d" | "c" | "m" | "u" | "n" | "p" | "f" | "a" | "z" | "y" | "r" | "q"
+\end{lstlisting}
+\end{production}
+
+\begin{production}{unit-symbol}
+\begin{lstlisting}
+unit-char { unit-char }
+\end{lstlisting}
+\end{production}
+
+\begin{production}{unit-char}
+\begin{lstlisting}
+NON-DIGIT
+\end{lstlisting}
+\end{production}
 
 The units required to be recognized are the basic and derived units of the SI system, as well as some units compatible with the SI system listed below, but tools are allowed to additionally support user-defined unit symbols.
 The required unit symbols do not make use of Greek letters, but a unit such as $\Omega$ is spelled out as \lstinline!"Ohm"!.

--- a/chapters/unitexpressions.tex
+++ b/chapters/unitexpressions.tex
@@ -10,7 +10,7 @@ Examples for the syntax of unit expressions used in Modelica: \lstinline!"N.m"!,
 
 \section{The Syntax of Unit Expressions}\label{the-syntax-of-unit-expressions}
 
-The Modelica unit string syntax allows neither comments nor white-space, and a unit string shall match the \lstinline[language=grammar]!unit-expression! rule:
+The Modelica unit string syntax allows neither comments nor white-space, and a unit string shall match the \productionref{unit-expression} rule:
 
 \begin{production}{unit-expression}
 \begin{lstlisting}
@@ -59,8 +59,8 @@ unit-operand [ unit-exponent ]
 \end{production}
 
 The SI standard uses super-script for the exponentation, and does thus not define any operator symbol for exponentiation.
-A \lstinline[language=grammar]!unit-factor! consists of a \lstinline[language=grammar]!unit-operand! possibly suffixed by a possibly signed integer or rational number, which is interpreted as an exponent.
-There must be no spacing between the \lstinline[language=grammar]!unit-operand! and a possible \lstinline[language=grammar]!unit-exponent!.
+A \productionref{unit-factor} consists of a \productionref{unit-operand} possibly suffixed by a possibly signed integer or rational number, which is interpreted as an exponent.
+There must be no spacing between the \productionref{unit-operand} and a possible \productionref{unit-exponent}.
 It is recommended to use the simplest representation of exponents, meaning that the explicit \lstinline!+! sign should be avoided, that leading zeros should be avoided, that rational exponents are reduced to not have common factors in the numerator and denominator, that rational exponents with denominator 1 should be avoided in favor of plain integer exponents, that the exponent 1 is omitted, and that entire factors with exponent 0 are omitted.
 
 \begin{production}{unit-operand}
@@ -106,8 +106,8 @@ The following are the units required to be recognized in addition to the SI syst
 \end{itemize}
 The first 7 are listed in the SI standard as non-SI units that are acceptable to use with the SI system.
 
-A \lstinline[language=grammar]!unit-operand! should first be interpreted as a \lstinline[language=grammar]!unit-symbol! and only if not successful the second alternative assuming a prefixed operand should be exploited.
-There must be no spacing between the \lstinline[language=grammar]!unit-symbol! and a possible \lstinline[language=grammar]!unit-prefix!.
+A \productionref{unit-operand} should first be interpreted as a \productionref{unit-symbol} and only if not successful the second alternative assuming a prefixed operand should be exploited.
+There must be no spacing between the \productionref{unit-symbol} and a possible \productionref{unit-prefix}.
 The values of the prefixes are according to the ISO standard.
 The letter \lstinline!u! is used as a symbol for the prefix \emph{micro}.
 

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -94,3 +94,14 @@ a:hover { text-decoration: underline; }
 
 .ltx_page_header *[rel~="up"],
 .ltx_page_footer *[rel~="up"] { display: table; margin: 0 auto; text-align: center; }
+
+/* Special spacing for grammar production rules.
+ */
+div.ltx_lst_language_production {
+  margin-top: -1em;
+  padding-left: 1em;
+}
+
+div.ltx_lst_language_production div.ltx_listing_data {
+  display: none;
+}

--- a/css/MLS.css
+++ b/css/MLS.css
@@ -79,7 +79,7 @@ a:hover { text-decoration: underline; }
 
 /* Remove indentation of index terms at the top level.
  */
- .ltx_index > .ltx_indexlist {
+.ltx_index > .ltx_indexlist {
   margin-left: 0px;
   padding-left: 0px;
 }

--- a/mlslistings.sty
+++ b/mlslistings.sty
@@ -106,6 +106,7 @@
     alsodigit={-},
     breaklines=true,
     breakatwhitespace=true,
+    columns=spaceflexible,
     morekeywords=[1]{%
         % Keywords corresponding to morekeywords=[1] for language=modelica
         der,connect,assert,terminate,break,return,%

--- a/preamble.tex
+++ b/preamble.tex
@@ -343,6 +343,23 @@
 \endlist
 }
 
+\lstdefinelanguage{production}[]{grammar}{% Language for use only inside the 'production' environment, giving us an easily identifiable element for CSS styling.
+  frame=none,
+  xleftmargin=1em,
+  aboveskip=0pt,
+}
+
+% Don't use ':' as separator in the hypertarget key; it doesn't work with LaTeXML
+\newenvironment{production}[1]{%
+\lstset{language=production}%
+\hypertarget{production_#1}{\lstinline!#1 :!}%
+}{%
+}
+
+\newcommand{\productionref}[1]{%
+\hyperlink{production_#1}{{\lstinline[language=production]!#1!}}%
+}
+
 % Change all \cref and \Cref variants below chapter to use "section"
 \crefname{subsection}{section}{sections}
 \Crefname{subsection}{Section}{Sections}

--- a/preamble.tex
+++ b/preamble.tex
@@ -352,7 +352,14 @@
 % Don't use ':' as separator in the hypertarget key; it doesn't work with LaTeXML
 \newenvironment{production}[1]{%
 \lstset{language=production}%
-\hypertarget{production_#1}{\lstinline!#1 :!}%
+\par\noindent\hypertarget{production_#1}{\lstinline!#1 :!}%
+}{%
+}
+
+% Variant of 'production' for use in Notation section.
+\newenvironment{production*}[1]{%
+\lstset{language=production}%
+\par\noindent\lstinline!#1 :!%
 }{%
 }
 
@@ -363,7 +370,14 @@
 % Similar to 'production', but for lexical units.
 \newenvironment{lexicalunit}[1]{%
 \lstset{language=production}%
-\hypertarget{lexicalunit_#1}{\lstinline!#1 =!}%
+\par\noindent\hypertarget{lexicalunit_#1}{\lstinline!#1 =!}%
+}{%
+}
+
+% Variant of 'lexicalunit' for use in Notation section.
+\newenvironment{lexicalunit*}[1]{%
+\lstset{language=production}%
+\par\noindent\lstinline!#1 =!%
 }{%
 }
 

--- a/preamble.tex
+++ b/preamble.tex
@@ -360,6 +360,17 @@
 \hyperlink{production_#1}{{\lstinline[language=production]!#1!}}%
 }
 
+% Similar to 'production', but for lexical units.
+\newenvironment{lexicalunit}[1]{%
+\lstset{language=production}%
+\hypertarget{lexicalunit_#1}{\lstinline!#1 =!}%
+}{%
+}
+
+\newcommand{\lexicalunitref}[1]{%
+\hyperlink{lexicalunit_#1}{{\lstinline[language=production]!#1!}}%
+}
+
 % Change all \cref and \Cref variants below chapter to use "section"
 \crefname{subsection}{section}{sections}
 \Crefname{subsection}{Section}{Sections}


### PR DESCRIPTION
This is a follow-up to https://github.com/modelica/ModelicaSpecification/pull/3838#discussion_r2924519521.

Opening in draft state since there are still things to do:
- Reduce/avoid duplicated grammar listings, relying on linked references to production rules instead.
- ~Fix the LaTeXML build.  The current solution was verified to work with cross references within the same generated HTML document, but it seems to break when crossing document borders.~
