### PR TITLE
Use scroll-padding-top to avoid top banner occlusion

### DIFF
--- a/css/MLS-navbar-left.css
+++ b/css/MLS-navbar-left.css
@@ -155,17 +155,8 @@ nav > div.ltx_TOC {
 
 /* Make current jump target appear below the page header instead of behind it.
  */
-:target:before {
-  visibility: hidden;
-  content: "X"; /* Hidden, but needs to be non-empty to work in Chrome. */
-  display: block;
-  position: relative;
-  top: calc(-(2.5rem + 2px)); /* Offset by total height of .ltx_page_header. */
-}
-
-.ltx_item :target:before {
-  display: inline-block;
-  padding-top: calc((2.5rem + 2px)); /* Pad with total height of .ltx_page_header. */
+html {
+  scroll-padding-top: calc(2.5rem + 2px); /* Total height of .ltx_page_header. */
 }
 
 .ltx_page_content {


### PR DESCRIPTION
Claude suggests this pretty trivial method to avoid the problem that the destination when following a link gets hidden behind the top banner.
