### PR TITLE
Work around issue with cleveref and hyperref

### DIFF
--- a/MLS.tex
+++ b/MLS.tex
@@ -130,6 +130,14 @@
 \include{chapters/library}
 
 \appendix
+
+% Work around cleveref 0.21.4 + modern hyperref not retyping chapter labels as appendix, see:
+% - https://github.com/latex3/hyperref/issues/361
+% - https://github.com/latex3/hyperref/issues/362
+\crefalias{chapter}{appendix}
+\crefalias{section}{subappendix}
+\crefalias{subsection}{subsubappendix}
+
 % https://tex.stackexchange.com/questions/370384/change-toc-depth-mid-document
 \addtocontents{toc}{\setcounter{tocdepth}{0}}
 


### PR DESCRIPTION
This is a workaround for the bug that a reference to appendix B looks like _chapter B_.
