### PR TITLE
Require positive delayTime

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -702,8 +702,8 @@ The expression $\mathit{expr}$ shall be a subtype of \lstinline!Real!, \lstinlin
 The time arguments, $\mathit{delayTime}$ and $\mathit{delayMax}$, shall be subtypes of \lstinline!Real!.
 The type of the result is the same as the type of $\mathit{expr}$.
 
-When provided, $\mathit{delayMax}$ shall be a parameter expression, and it shall hold that $0 \leq \mathit{delayTime} \leq \mathit{delayMax}$.
-When $\mathit{delayMax}$ is not provided, $\mathit{delayTime} \geq 0$ shall be a parameter expression.
+When provided, $\mathit{delayMax}$ shall be a parameter expression, and it shall hold that $0 < \mathit{delayTime} \leq \mathit{delayMax}$.
+When $\mathit{delayMax}$ is not provided, $\mathit{delayTime} > 0$ shall be a parameter expression.
 The operator is not allowed inside \lstinline!function! classes.
 For non-scalar arguments the function is vectorized according to \cref{vectorized-calls-of-functions}.
 

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -726,6 +726,8 @@ To avoid excessive storage requirements and to enhance efficiency, the maximum a
 This gives an upper bound on the values of the delayed signals which have to be stored.
 For real-time simulation where fixed step size integrators are used, this information is sufficient to allocate the necessary storage for the internal buffer before the simulation starts.
 For variable step size integrators, the buffer size is dynamic during integration.
+
+In order to avoid extrapolation in the delay buffer, the maximum step size of the integrator is limited by the delay time, making delay times close to zero a potential source of poor simulation performance.
 \end{nonnormative}
 
 


### PR DESCRIPTION
Fixes #3245.  This is a replacement for #3724, agreed upon today in the language group meeting.

In addition to the core fix for #3245, I also included one of the non-normative sentences proposed in #3724.
