### PR TITLE
Consistently call it "Modelica Language Specification", and consistent subtitle for Tutorial

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -1,4 +1,5 @@
-# Modelica™ - A Unified Object-Oriented Language for Physical Systems Modeling Tutorial
+# Modelica® Tutorial
+**A Unified Object-Oriented Language for Physical Systems Modeling**
 
 ## Abstract:
 

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -1,5 +1,5 @@
 # Modelica® Tutorial
-**A Unified Object-Oriented Language for Physical Systems Modeling**
+**A Unified Object-Oriented Language for Systems Modeling**
 
 ## Abstract:
 

--- a/chapters/titlepage.tex
+++ b/chapters/titlepage.tex
@@ -12,15 +12,15 @@
 \vspace{1cm}
 
 \huge
-Modelica\textsuperscript{\textregistered} -- A Unified Object-Oriented Language for~Systems Modeling
+Modelica\textsuperscript{\textregistered} Language Specification
 
-Language Specification
+\Large
+A Unified Object-Oriented Language for~Systems Modeling
 
 Version \mlsversion
 
 \vspace{1cm}% This has no effect in the generated HTML.
 
-\Large
 \makeatletter
 \@date
 

--- a/chapters/titlepage.tex
+++ b/chapters/titlepage.tex
@@ -15,7 +15,7 @@
 Modelica\textsuperscript{\textregistered} Language Specification
 
 \Large
-A Unified Object-Oriented Language for~Systems Modeling
+A Unified Object-Oriented Language for Systems Modeling
 
 Version \mlsversion
 


### PR DESCRIPTION
Change title to the simpler "Modelica Language Specification" and split off the rest ("A Unified Object-Oriented Language for Systems Modeling") as a subtitle.

Tutorial is also updated:
* Same subtitle instead of the earlier one (originally the subtitle stated that it was for "Physical Systems Modeling" but with clock semantics the "Physical" was dropped to indicate that it is more general).
* Registered trademark.