### PR TITLE
Create 3.7 release of specfication.

### DIFF
--- a/MLS.tex
+++ b/MLS.tex
@@ -11,7 +11,7 @@
 
 % Define title for use by LaTeXML.
 % An extended title is defined separately in the 'titlepage'.
-\newcommand{\mlsversion}{3.7-dev}
+\newcommand{\mlsversion}{3.7}
 \newcommand{\mlsdate}{\today}
 \title{Modelica\textsuperscript{\textregistered} Language Specification version~\mlsversion}
 


### PR DESCRIPTION
As discussed at the Modelica Language Meeting the plan is to start the release process for version 3.7 of the Modelica Language Specification.

The plan is to freeze the version latest at the next monthly meeting May 7th, and then start the vote to accept it as soon as possible (i.e., after one week).

That means the vote to accept the specification is scheduled to start May 15th (as May 14th is a public holiday) and run for 6 work-days.

The 3.7 specification will only include:
- Features already included - https://github.com/modelica/ModelicaSpecification/pulls?q=is%3Apr+label%3AM37+is%3Aclosed
- Features under discussion -  https://github.com/modelica/ModelicaSpecification/milestone/91 (subject to approval before that date).

The vote to start the process begins today (April 16th) and ends in one week (April 23rd).

Please vote for starting this release using thumbs up or down.