### PR TITLE
See if we can just remove the MathJax.

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
       sh 'mkdir -p /tmp/jenkins'
       sh 'latexmk -pdf MLS.tex'
       sh 'latexml MLS.tex --includestyles --path=media --dest MLS.xml'
-      sh 'latexmlpost MLS.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --javascript=LaTeXML-maybeMathjax.js --navigationtoc=context --css=css/MLS.css --css=css/MLS-navbar-left.css --dest index.html'
+      sh 'latexmlpost MLS.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --navigationtoc=context --css=css/MLS.css --css=css/MLS-navbar-left.css --dest index.html'
       sh '.scripts/patch-viewport.sh'
       sh '.scripts/patch-body-ios-hover.sh'
       sh 'ln -s index.html MLS.html'

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -61,10 +61,10 @@ pipeline {
       sh 'ln -s bib.html A6.html'
       sh 'ln -s bib.html literature.html'
       sh script: '! (find . -type l -xtype l | egrep \'.*\')', label: 'Verify symbolic links work'
-      sh 'tar czf MLS.tar.gz *.html *.css *.js media/ css/'
+      sh 'tar czf MLS.tar.gz *.html *.css media/ css/'
       archiveArtifacts artifacts: 'MLS.tar.gz', fingerprint: true
       archiveArtifacts artifacts: 'MLS.pdf', fingerprint: true
-      stash name: 'MLS', includes: '*.html,*.css,*.js,MLS.pdf,media/**,css/**,MLS.tar.gz'
+      stash name: 'MLS', includes: '*.html,*.css,MLS.pdf,media/**,css/**,MLS.tar.gz'
     }
   }
   stage('upload') {

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ MLS.pdf: *.tex chapters/*.tex
 # - https://github.com/brucemiller/LaTeXML/issues/2553 -- fixed on 'master' as of 2025-05-07
 index.html: MLS.tex chapters/*.tex
 	$(LATEXMLPREFIX)latexml MLS.tex --preload=[nobreakuntex]latexml.sty --includestyles --path=media --dest MLS.xml
-	$(LATEXMLPREFIX)latexmlpost MLS.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --javascript=LaTeXML-maybeMathjax.js --navigationtoc=context --css=css/MLS.css --css=css/MLS-navbar-left.css --dest $@
+	$(LATEXMLPREFIX)latexmlpost MLS.xml -format html -pmml --splitat=chapter --splitnaming=labelrelative --navigationtoc=context --css=css/MLS.css --css=css/MLS-navbar-left.css --dest $@
 	.scripts/patch-viewport.sh
 	.scripts/patch-body-ios-hover.sh


### PR DESCRIPTION
Basically we currently:
- Mathematics rely on MathJax to generate CHTML (you can then switch to SVG) unless you use some specific browsers like Firefox.

The replacement disables this and instead relies on MathML support in modern browsers, see https://caniuse.com/mathml
- Firefox (as before)
- Safari
- Chrome
- Microsoft Edge  

The alternative would be to improve the logic as most browsers now are MathML capable (and use SVG as a better default).

Closes #3868 


