### PR TITLE
Tunable parameter relation to events

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -559,11 +559,11 @@ Here, a good error message for the variability error can include the information
 
 \begin{nonnormative}
 A variant of parameter component variability which is in use, but with tool-dependent meaning, is \firstuse{tunable parameter}.
-Despite the rule that a parameter (evaluable or not) does not change during transient analysis, the idea is that some parameters still would be possible to change at events during transient analysis.
+Despite the rule that a parameter (evaluable or not) does not change during transient analysis, the idea is that some parameters still would be possible to change during transient analysis.
 When a tool identifies such a parameter, it is often referred to as a \emph{tunable parameter}.
 Both evaluable and non-evaluable parameters can be tunable.
-Similar to other parameter component variabilities, some of the tunable parameters may be directly assigned at the events, whereas other tunable parameters will only be updated as a consequence of the direct assignments.
-Note that the criterion of being possible to change at an event, as well as the related semantics of making a change (deviating from the mathematical formalism given in \cref{modelica-dae-representation}), are tool-dependent.
+Similar to other parameter component variabilities, some of the tunable parameters may be directly assigned, whereas other tunable parameters will only be updated as a consequence of the direct assignments.
+Note that the criterion of being possible to change, as well as the related semantics of making a change (deviating from the mathematical formalism given in \cref{modelica-dae-representation}), are tool-dependent.
 Possible reasons for a parameter not being tunable include that changes would cause significant non-physical transients, require a complicated re-evaluation of parameter expressions, or make no difference after initialization.
 Tunable parameters are also mentioned informally for the \lstinline!interaction! annotation, see \cref{modelica:interaction}.
 \end{nonnormative}


### PR DESCRIPTION
This is a small follow-up to #3867, including the outcome of discussions at the language meeting which happened after #3867 was merged.

Quoting https://github.com/modelica/ModelicaSpecification/pull/3867#issuecomment-4266635370:
> Based on the discussion at the language meeting, I have now removed the assumption that tunable parameters may only change at events. If I remember correctly, we also decided to not say anything regarding the potential need for event handling when a tunable parameter changes, but to just leave that as one (unmentioned) aspect of the tool-dependent semantics.
