### PR TITLE
Update Modelica URIs used for multilingual descriptions

### DIFF
--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -347,14 +347,14 @@ In this example only \lstinline!"1st Frequency: %f1"! can be translated; the sec
 \end{example}
 
 The files to support translation must be provided along with the library.
-They must be stored in the resources directory \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/}.
+They must be stored in the resources directory \filename{modelica:/$\mathit{TopPackage}$/Resources/Language/}.
 
 Two kind of files in \textcite{GettextManual} format have to be provided:
 \begin{enumerate}
-\item Template file \filename{$\mathit{LibraryName}$.pot} (Portable Object Template), one file per library which is stored as the resource \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.pot}.
+\item Template file \filename{$\mathit{TopPackage}$.pot} (Portable Object Template), one file per library which is stored as the resource \filename{modelica:/$\mathit{TopPackage}$/Resources/Language/$\mathit{TopPackage}$.pot}.
 It describes all translatable strings in the library, but does not contain any translations.
-The pattern \filename{$\mathit{LibraryName}$} denotes the toplevel class name of the library.
-\item One file for each supported language with the name \filename{$\mathit{LibraryName}$.$\mathit{language}$.po} (Portable Object), as the resource \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.$\mathit{language}$.po}.
+The pattern \filename{$\mathit{TopPackage}$} denotes the top-level class name of the library.
+\item One file for each supported language with the name \filename{$\mathit{TopPackage}$.$\mathit{language}$.po} (Portable Object), as the resource \filename{modelica:/$\mathit{TopPackage}$/Resources/Language/$\mathit{TopPackage}$.$\mathit{language}$.po}.
 This file is a copy of the associated template file, but extended with the translations in the specified language.
 The pattern \filename{$\mathit{language}$} stands for the ISO 639-1 language code, e.g., \filename{de} or \filename{sv}.
 \end{enumerate}

--- a/chapters/packages.tex
+++ b/chapters/packages.tex
@@ -347,14 +347,14 @@ In this example only \lstinline!"1st Frequency: %f1"! can be translated; the sec
 \end{example}
 
 The files to support translation must be provided along with the library.
-They must be stored in the resources directory \filename{modelica://$\mathit{LibraryName}$/Resources/Language/}.
+They must be stored in the resources directory \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/}.
 
 Two kind of files in \textcite{GettextManual} format have to be provided:
 \begin{enumerate}
-\item Template file \filename{$\mathit{LibraryName}$.pot} (Portable Object Template), one file per library which is stored as the resource \filename{modelica://$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.pot}.
+\item Template file \filename{$\mathit{LibraryName}$.pot} (Portable Object Template), one file per library which is stored as the resource \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.pot}.
 It describes all translatable strings in the library, but does not contain any translations.
 The pattern \filename{$\mathit{LibraryName}$} denotes the toplevel class name of the library.
-\item One file for each supported language with the name \filename{$\mathit{LibraryName}$.$\mathit{language}$.po} (Portable Object), as the resource \filename{modelica://$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.$\mathit{language}$.po}.
+\item One file for each supported language with the name \filename{$\mathit{LibraryName}$.$\mathit{language}$.po} (Portable Object), as the resource \filename{modelica:/$\mathit{LibraryName}$/Resources/Language/$\mathit{LibraryName}$.$\mathit{language}$.po}.
 This file is a copy of the associated template file, but extended with the translations in the specified language.
 The pattern \filename{$\mathit{language}$} stands for the ISO 639-1 language code, e.g., \filename{de} or \filename{sv}.
 \end{enumerate}


### PR DESCRIPTION
This PR makes two simple changes:
- Address use of deprecated form of URIs.
- Align with presentation of external function annotations by denoting the top-level class _TopPackage_ instead of _LibraryName_.
