### PR TITLE
Clarify that transitions also use the connection-annotations.

### DIFF
--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -169,7 +169,8 @@ equation
   \label{fig:state-machine-layout}
 \end{figure}
 
-The annotation for graphics of \lstinline!transition! has the following structure: \lstinline!annotation(Line($\ldots$), Text($\ldots$))!; and for \lstinline!initialState()!: \emph{graphical-primitives}\lstinline!(Line($\ldots$))!; with \lstinline!Line! and \lstinline!Text! annotations for connections defined in \cref{connections1}.
+Similar to \lstinline!connect!-equations, a \lstinline!transition! may have both a \lstinline!Line! and a \lstinline!Text! annotation, see \cref{connections1}.
+An \lstinline!initialState! equation may use any graphical primitive (including \lstinline!Line!) as annotation, see \cref{graphical-primitives}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]

--- a/chapters/statemachines.tex
+++ b/chapters/statemachines.tex
@@ -169,7 +169,7 @@ equation
   \label{fig:state-machine-layout}
 \end{figure}
 
-The annotation for graphics of \lstinline!transition! has the following structure: \lstinline!annotation(Line($\ldots$), Text($\ldots$))!; and for \lstinline!initialState()!: \emph{graphical-primitives}\lstinline!(Line($\ldots$))!; with \lstinline!Line! and \lstinline!Text! annotations defined in \cref{annotations}.
+The annotation for graphics of \lstinline!transition! has the following structure: \lstinline!annotation(Line($\ldots$), Text($\ldots$))!; and for \lstinline!initialState()!: \emph{graphical-primitives}\lstinline!(Line($\ldots$))!; with \lstinline!Line! and \lstinline!Text! annotations for connections defined in \cref{connections1}.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]


### PR DESCRIPTION
This is getting more and more important the more they diverge.
Since the example uses `Text(string=...)` it is closer to this one (so similar handling of text alignment).

Technically it may be that it should be yet another one, since `index` isn't used.