### PR TITLE
Use gender agnostic language

### DIFF
--- a/chapters/annotations.tex
+++ b/chapters/annotations.tex
@@ -717,7 +717,7 @@ For example, a tool is not expected to provide means to plot a variable with \ls
 If a variable is declared in a protected section, a tool might not include it in a simulation result.
 By setting \lstinline!HideResult = false!, the modeler would like to have the variable in the simulation result, even if in the protected section.
 
-\lstinline!HideResult! is for example used in the connectors of the \lstinline!Modelica.StateGraph! library to not show variables to the modeler that are of no interest to him and would confuse him.
+\lstinline!HideResult! is for example used in the connectors of the \lstinline!Modelica.StateGraph! library to not show variables to the modeler that are of no interest to them and would confuse them.
 \end{nonnormative}
 \end{semantics}
 \end{annotationdefinition}
@@ -2812,7 +2812,7 @@ end UserLicense;
 The \fmtannotationindex{License} annotation only has an effect at the top of an encrypted class and is then valid for the whole class hierarchy.
 (Usually the licensed class is a package.)
 
-The \lstinline!libraryKey! is a secret string from the library vendor and is the protection mechanism so that a user cannot generate his/her own authorization file since the \lstinline!libraryKey! is unknown to him/her.
+The \lstinline!libraryKey! is a secret string from the library vendor and is the protection mechanism so that a user cannot generate their own authorization file since the \lstinline!libraryKey! is unknown to them.
 
 In order that the protected class can be used either a tool specific license manager, or an authorization file (called \lstinline!licenseFile!) must be present.
 The authorization file is standardized.

--- a/chapters/stream.tex
+++ b/chapters/stream.tex
@@ -317,11 +317,11 @@ h_c = actualStream(c.h);                        // (2) monitoring the enthalpy a
 \end{lstlisting}
 In the case of equation (1), although \lstinline!actualStream! is discontinuous, the product with the flow variable is not, because \lstinline!actualStream! is discontinuous when the flow is zero by construction.
 Therefore, a tool might infer that the expression is \lstinline!smooth(0, $\ldots$)! automatically, and decide whether or not to generate an event.
-If a user wants to avoid events entirely, he/she may enclose the right-hand side of (1) with \lstinline!noEvent!.
+If a user wants to avoid events entirely, they may enclose the right-hand side of (1) with \lstinline!noEvent!.
 
 Equations like (2) might be used for monitoring purposes (e.g., plots), in order to inspect what the actual enthalpy of the fluid flowing through a port is.
 In this case, the user will probably want to see the change due to flow reversal at the exact instant, so an event should be generated.
-If the user doesn't bother, then he/she should enclose the right-hand side of (2) with \lstinline!noEvent!.
+If the user doesn't bother, then they should enclose the right-hand side of (2) with \lstinline!noEvent!.
 Since the output of \lstinline!actualStream! will be discontinuous, it should not be used by itself to model physical behaviour (e.g., to compute densities used in momentum balances) -- \lstinline!inStream! should be used for this purpose.
 \lstinline!actualStream! should be used to model physical behaviour only when multiplied by the corresponding flow variable (like in the above energy balance equation), because this removes the discontinuity.
 \end{nonnormative}


### PR DESCRIPTION
This is a common way in English to refer to people without implying any gender. I think it is convenient to read and it avoids accidentally referring to males only. What do you think?