### PR TITLE
Clarity standard type coercion for function calls with multiple outputs

### DIFF
--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1446,9 +1446,7 @@ See \cref{scalar-functions-applied-to-array-arguments}.
 In all contexts that require an expression which is a subtype of \lstinline!Real!, an expression which is a subtype of \lstinline!Integer! can also be used;
 the \lstinline!Integer! expression is automatically converted to \lstinline!Real!.
 
-This also applies to arrays of \lstinline!Real!, and for fields of record expressions.
-For equations and statements for receiving multiple outputs of a function call, it applies in the sense that a \lstinline!Real! variable in the left-hand side may receive the value of an \lstinline!Integer! function output.
-
+This also applies to arrays of \lstinline!Real!, for fields of record expressions, and separately for each output of a function call.
 There is no similar rule for sub-typing.
 
 \begin{example}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1447,6 +1447,8 @@ In all contexts that require an expression which is a subtype of \lstinline!Real
 the \lstinline!Integer! expression is automatically converted to \lstinline!Real!.
 
 This also applies to arrays of \lstinline!Real!, and for fields of record expressions.
+For equations and statements for receiving multiple outputs of a function call, it applies in the sense that a \lstinline!Real! variable in the left-hand side may receive the value of an \lstinline!Integer! function output.
+
 There is no similar rule for sub-typing.
 
 \begin{example}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1447,7 +1447,7 @@ In all contexts that require an expression which is a subtype of \lstinline!Real
 the \lstinline!Integer! expression is automatically converted to \lstinline!Real!.
 
 This also applies to arrays of \lstinline!Real!, for fields of record expressions, and separately for each output of a function call.
-Standard type coercion does not apply to the left-hand sides of assignments (\cref{simple-assignment-statements}) or the left-hand sides of simple equality equations receiving multiple outputs of a function call (\cref{simple-equality-equations}).
+Standard type coercion does not apply to the left-hand sides of assignments (\cref{simple-assignment-statements}) or the left-hand sides of simple equality equations with non-trivial \productionref{output-expression-list} (\cref{simple-equality-equations}).
 There is no similar rule for sub-typing.
 
 \begin{example}

--- a/chapters/arrays.tex
+++ b/chapters/arrays.tex
@@ -1447,6 +1447,7 @@ In all contexts that require an expression which is a subtype of \lstinline!Real
 the \lstinline!Integer! expression is automatically converted to \lstinline!Real!.
 
 This also applies to arrays of \lstinline!Real!, for fields of record expressions, and separately for each output of a function call.
+Standard type coercion does not apply to the left-hand sides of assignments (\cref{simple-assignment-statements}) or the left-hand sides of simple equality equations receiving multiple outputs of a function call (\cref{simple-equality-equations}).
 There is no similar rule for sub-typing.
 
 \begin{example}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -42,7 +42,7 @@ No statements are allowed in equation sections, including the assignment stateme
 
 Simple equality equations are the traditional kinds of equations known from mathematics that express an equality relation between two expressions.
 The syntax is given by \productionref{simple-equation} in the grammar, and can be divided into two cases depending on the form of the left-hand side \productionref{simple-expression}.
-If the left-hand side is a parenthesized \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with several outputs.
+If the left-hand side is a parenthesized \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with multiple outputs.
 Otherwise, the equation expresses a single equality between the left-hand side and right-hand side expressions.
 The types of the left-hand-side and the right-hand-side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 
@@ -55,7 +55,7 @@ Three examples:
 
 \begin{nonnormative}
 Note: According to the grammar the if-then-else expression in the second example needs to be enclosed in parentheses to avoid parsing ambiguities.
-Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling functions with several results in assignment statements.
+Also compare with \cref{assignments-from-called-functions-with-multiple-results} about calling functions with multiple outputs in assignment statements.
 \end{nonnormative}
 
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -42,7 +42,8 @@ No statements are allowed in equation sections, including the assignment stateme
 
 Simple equality equations are the traditional kinds of equations known from mathematics that express an equality relation between two expressions.
 The syntax is given by \productionref{simple-equation} in the grammar, and can be divided into two cases depending on the form of the left-hand side \productionref{simple-expression}.
-If the left-hand side is a parenthesized \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with multiple outputs.
+If the left-hand side is a parenthesized non-trivial \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with multiple outputs.
+Here, \firstuse[---]{non-trivial} means that the \productionref{output-expression-list} is empty or contains at least one comma, making it distinguishable from a parenthesized expression.
 Otherwise, the equation expresses a single equality between the left-hand side and right-hand side expressions.
 The types of the left-hand-side and the right-hand-side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 

--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -51,7 +51,7 @@ end $\mathit{functionname}$;
 \subsection{Ordering of Formal Parameters}\label{ordering-of-formal-parameters}
 
 The relative ordering between input formal parameter declarations is significant since that determines the matching between actual arguments and formal parameters at function calls with positional parameter passing.
-Likewise, the relative ordering between the declarations of the outputs is significant since that determines the matching with receiving variables at function calls of functions with multiple results.
+Likewise, the relative ordering between the declarations of the outputs is significant since that determines the matching with receiving variables at function calls of functions with multiple outputs.
 However, the declarations of the inputs and outputs can be intermixed as long as these internal orderings are preserved.
 
 \begin{nonnormative}

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -543,7 +543,7 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is an \lstinline!Integer! expression:
   \begin{itemize}
   \item
-    In equations receiving multiple outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+    In simple equality equations with non-trivial \productionref{output-expression-list} and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
   \item
     Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
     For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -543,7 +543,7 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is an \lstinline!Integer! expression:
   \begin{itemize}
   \item
-    For assignment statements and equations receiving several outputs of a function call, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+    In equations receiving several outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
   \item
     Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
     For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -543,7 +543,7 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is an \lstinline!Integer! expression:
   \begin{itemize}
   \item
-    In equations receiving several outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+    In equations receiving multiple outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
   \item
     Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
     For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -540,9 +540,15 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is a \lstinline!Real! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
   The type of the full expression is \lstinline!Real!, compare \cref{standard-type-coercion}, unless the operator is a relational operator (\cref{equality-relational-and-logical-operators}) where the type of the full expression is \lstinline!Boolean!.
 \item
-  If \lstinline!A! is an \lstinline!Integer! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
-  For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.
-  In other cases the type of the full expression is \lstinline!Real! or \lstinline!Integer! (same as \lstinline!B!), compare \cref{standard-type-coercion}.
+  If \lstinline!A! is an \lstinline!Integer! expression:
+  \begin{itemize}
+  \item
+    For assignment statements and equations receiving several outputs of a function call, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+  \item
+    Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
+    For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.
+    In other cases the type of the full expression is \lstinline!Real! or \lstinline!Integer! (same as \lstinline!B!), compare \cref{standard-type-coercion}.
+  \end{itemize}
 \item
   If \lstinline!A! is a \lstinline!Boolean! expression then \lstinline!B! must be a \lstinline!Boolean! expression and the type of the full expression is \lstinline!Boolean!.
 \item

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -524,17 +524,20 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   In an array expression the two records may contain elements with different sizes, but apart from that they must be type compatible.
   That generates a heterogenous array of records, see \cref{arrays}.
   The type of the full expression is a record comprised of named elements that are type compatible with the corresponding named elements of both \lstinline!A! and \lstinline!B!.
-\item The rules for array expressions depend on the operation (the rules for binary operators are given in \cref{scalar-vector-matrix-and-array-operator-functions}
-and for array concatenation in \cref{array-concatenation}).
-The rules for the remaining case of \lstinline!if!-expressions and array-expressions are:
-\begin{itemize}
- \item If \lstinline!A! is an array expression then \lstinline!B! must also be an array expression, and \lstinline!ndims(A)! = \lstinline!ndims(B)!.
-  The type of the full expression is an array expression with elements compatible with the elements of both \lstinline!A! and \lstinline!B!.
-  If both \lstinline!size(A)! and \lstinline!size(B)! are known and \lstinline!size(A)! = \lstinline!size(B)! then this defines the size of the full expression, otherwise the size of the full expression is not known until the expression is about to be evaluated.
-  In case of an \lstinline!if!-expression the size of the full expression is defined based on the branch selected, and for other cases \lstinline!size(A)! = \lstinline!size(B)! must hold at this point.
- \item  If \lstinline!A! is a scalar expression of a simple type \lstinline!B! must also be a scalar expression of a simple type.
-\end{itemize}
-\item If \lstinline!A! is a \lstinline!Real! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
+\item
+  The rules for array expressions depend on the operation (the rules for binary operators are given in \cref{scalar-vector-matrix-and-array-operator-functions} and for array concatenation in \cref{array-concatenation}).
+  The rules for the remaining case of \lstinline!if!-expressions and array-expressions are:
+  \begin{itemize}
+  \item
+    If \lstinline!A! is an array expression then \lstinline!B! must also be an array expression, and \lstinline!ndims(A)! = \lstinline!ndims(B)!.
+    The type of the full expression is an array expression with elements compatible with the elements of both \lstinline!A! and \lstinline!B!.
+    If both \lstinline!size(A)! and \lstinline!size(B)! are known and \lstinline!size(A)! = \lstinline!size(B)! then this defines the size of the full expression, otherwise the size of the full expression is not known until the expression is about to be evaluated.
+    In case of an \lstinline!if!-expression the size of the full expression is defined based on the branch selected, and for other cases \lstinline!size(A)! = \lstinline!size(B)! must hold at this point.
+  \item
+    If \lstinline!A! is a scalar expression of a simple type \lstinline!B! must also be a scalar expression of a simple type.
+  \end{itemize}
+\item
+  If \lstinline!A! is a \lstinline!Real! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
   The type of the full expression is \lstinline!Real!, compare \cref{standard-type-coercion}, unless the operator is a relational operator (\cref{equality-relational-and-logical-operators}) where the type of the full expression is \lstinline!Boolean!.
 \item
   If \lstinline!A! is an \lstinline!Integer! expression then \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -543,7 +543,7 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is an \lstinline!Integer! expression:
   \begin{itemize}
   \item
-    In equations receiving several outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+    In equations receiving several outputs of a function call and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
   \item
     Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
     For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -100,11 +100,11 @@ The expression must not have higher variability than the assigned component, see
 Assignment to array variables with subscripts is described in \cref{array-indexing}.
 
 
-\subsubsection{Assignments from Called Functions with Multiple Results}\label{assignments-from-called-functions-with-multiple-results}
+\subsubsection{Assignments from Called Functions with Multiple Outputs}\label{assignments-from-called-functions-with-multiple-results}
 
-There is a special form of assignment statement that is used only when the right-hand side contains a call to a function with multiple results.
-The left-hand side contains a parenthesized, comma-separated list of variables (or derivatives) receiving the results from the function call.
-A function with $n$ results needs $m \leq n$ receiving variables on the left-hand side, and the variables are assigned from left to right.
+There is a special form of assignment statement that is used only when the right-hand side contains a call to a function with multiple outputs.
+The left-hand side contains a parenthesized, comma-separated list of variables (or derivatives) receiving the outputs from the function call.
+A function with $n$ outputs needs $m \leq n$ receiving variables on the left-hand side, and the variables are assigned from left to right.
 
 \begin{lstlisting}[language=modelica]
 (out1, out2, out3) := function_name(in1, in2, in3, in4);
@@ -116,7 +116,7 @@ It is possible to omit receiving variables from this list:
 \end{lstlisting}
 
 \begin{example}
-The function \lstinline!f! called below has three results and two inputs:
+The function \lstinline!f! called below has three outputs and two inputs:
 \begin{lstlisting}[language=modelica]
 (a, b, c) := f(1.0, 2.0);
 (x[1], x[2], x[1]) := f(3, 4);
@@ -128,17 +128,17 @@ For that case the following will give the same result:
 \end{lstlisting}
 \end{example}
 
-The syntax of an assignment statement with a call to a function with multiple results is given by the case of \productionref{statement} in the grammar where a parenthesized \productionref{output-expression-list} is on the left-hand side of \lstinline!:=!.
+The syntax of an assignment statement with a call to a function with multiple outputs is given by the case of \productionref{statement} in the grammar where a parenthesized \productionref{output-expression-list} is on the left-hand side of \lstinline!:=!.
 
 \begin{nonnormative}
-Also see \cref{simple-equality-equations} regarding calling functions with multiple results within equations.
+Also see \cref{simple-equality-equations} regarding calling functions with multiple outputs within equations.
 \end{nonnormative}
 
 
 \subsubsection{Assigned Variables - Restrictions}\label{restrictions-on-assigned-variables}\label{assigned-variables-restrictions}
 
 Only components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!connector! may appear as left-hand-side in algorithms.
-This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple results.
+This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple outputs.
 
 
 \subsection{For-Statement}\label{for-statement}


### PR DESCRIPTION
This PR clarifies that the following is valid:
```
function f
  output Integer y1 = 1;
  output Integer y2 = 2;
end f;

model MultiCoercion
  Real x1;
  Real x2;
equation
  (x1, x2) = f();
end MultiCoercion;
```

This works in System Modeler, but it would be good to know about the support in other tools before we add it to the specification.
