### PR TITLE
Correct hyphenation of left-hand side

### DIFF
--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -43,7 +43,7 @@ No statements are allowed in equation sections, including the assignment stateme
 Simple equality equations are the traditional kinds of equations known from mathematics that express an equality relation between two expressions.
 The syntax is given by \productionref{simple-equation} in the grammar, and can be divided into two cases depending on the form of the left-hand side \productionref{simple-expression}.
 If the left-hand side is a parenthesized non-trivial \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with multiple outputs.
-Here, \firstuse[---]{non-trivial} means that the \productionref{output-expression-list} is empty or contains at least one comma, making it distinguishable from a parenthesized expression.
+Here, \firstuse[---]{non-trivial} means that the \productionref{output-expression-list} is empty or contains at least one comma, making the left-hand side distinguishable from a parenthesized expression.
 Otherwise, the equation expresses a single equality between the left-hand side and right-hand side expressions.
 The types of the left-hand side and the right-hand side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -45,7 +45,7 @@ The syntax is given by \productionref{simple-equation} in the grammar, and can b
 If the left-hand side is a parenthesized non-trivial \productionref{output-expression-list}, the equation expresses equalities between the expressions in the left-hand side list and the corresponding results of calling a function with multiple outputs.
 Here, \firstuse[---]{non-trivial} means that the \productionref{output-expression-list} is empty or contains at least one comma, making it distinguishable from a parenthesized expression.
 Otherwise, the equation expresses a single equality between the left-hand side and right-hand side expressions.
-The types of the left-hand-side and the right-hand-side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
+The types of the left-hand side and the right-hand side of an equation need to be compatible in the same way as two arguments of binary operators (\cref{type-compatible-expressions}).
 
 Three examples:
 \begin{itemize}
@@ -140,7 +140,7 @@ The \lstinline!if!-equations which do not have exclusively evaluable expressions
   Have the same number of equations in each branch, where the number of equations is defined as in \cref{local-equation-size}.
   Absence of an \lstinline!else!-branch is treated as having a branch with zero equations.
 \item
-  Non-\lstinline!Real! simple equality equations (see \cref{simple-equality-equations}) in the \lstinline!if!-equation branches shall have component-references (or a list of them) as their left-hand-side.
+  Non-\lstinline!Real! simple equality equations (see \cref{simple-equality-equations}) in the \lstinline!if!-equation branches shall have component-references (or a list of them) as their left-hand side.
   Any subscripts for such component-references must be evaluable.
   Any \lstinline!for!- and \lstinline!if!-equations in the \lstinline!if!-equation branches shall have evaluable controlling conditions, and contain equations which fullfil these requirements recursively.
   All branches shall have the same set of variables in the non-\lstinline!Real! equations.

--- a/chapters/interface.tex
+++ b/chapters/interface.tex
@@ -543,7 +543,7 @@ The type of the full expression (e.g., \lstinline!if x then A else B!) is also d
   If \lstinline!A! is an \lstinline!Integer! expression:
   \begin{itemize}
   \item
-    In simple equality equations with non-trivial \productionref{output-expression-list} and assignment statements, and where \lstinline!A! is part of the left-hand-side and \lstinline!B! the corresponding part of the right-hand-side, \lstinline!B! must be an \lstinline!Integer! expression.
+    In simple equality equations with non-trivial \productionref{output-expression-list} and assignment statements, and where \lstinline!A! is part of the left-hand side and \lstinline!B! the corresponding part of the right-hand side, \lstinline!B! must be an \lstinline!Integer! expression.
   \item
     Otherwise \lstinline!B! must be a \lstinline!Real! or \lstinline!Integer! expression.
     For exponentiation and division the type of the full expression is \lstinline!Real! (even if both \lstinline!A! and \lstinline!B! are \lstinline!Integer!) see \cref{element-wise-exponentiation} and \cref{division-by-numeric-scalars}, for relational operators the type of the full expression is \lstinline!Boolean!.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -137,7 +137,7 @@ Also see \cref{simple-equality-equations} regarding calling functions with multi
 
 \subsubsection{Assigned Variables - Restrictions}\label{restrictions-on-assigned-variables}\label{assigned-variables-restrictions}
 
-Only components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!connector! may appear as left-hand-side in algorithms.
+Only components of the specialized classes \lstinline!type!, \lstinline!record!, \lstinline!operator record!, and \lstinline!connector! may appear as left-hand side in algorithms.
 This applies both to simple assignment statements, and the parenthesized, comma-separated list of variables for functions with multiple outputs.
 
 
@@ -398,7 +398,7 @@ In contrast to \lstinline!when!-equations, \cref{restrictions-on-equations-withi
 \item
   In algorithms, all assignment statements are already restricted to left-hand-side variables.
 \item
-  If at least one element of an array appears on the left-hand-side of the assignment operator inside a \lstinline!when!-statement, it is as if the entire array appears in the left-hand-side according to \cref{execution-of-an-algorithm-in-a-model}.
+  If at least one element of an array appears on the left-hand side of the assignment operator inside a \lstinline!when!-statement, it is as if the entire array appears in the left-hand side according to \cref{execution-of-an-algorithm-in-a-model}.
   Thus, there is no need to restrict the indices to parameter-expressions.
 \item
   The \lstinline!for!-loops and \lstinline!if!-statements are not problematic inside \lstinline!when!-statements in algorithms, since all left-hand-side variables inside \lstinline!when!-statements are assigned to their pre-values before the start of the algorithm, according to \cref{execution-of-an-algorithm-in-a-model}.


### PR DESCRIPTION
When preparing a minor clarification for #3888, I noticed that _(left|right)-hand side_ was often hyphenated incorrectly.  This PR does the cleanup and provides the minor clarification (which is formulated in terms of a left-hand side).
