### PR TITLE
Try to clean up clause-meaning.

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -426,7 +426,7 @@ The reason can intuitively be explained as follows:
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.
 The \lstinline!Real! variables declared with the prefix \lstinline!discrete! is a subset of the discrete-time \lstinline!Real! variables.
 For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in a \lstinline!when!-clause body.
-A variable used as argument to \lstinline!pre! outside any \lstinline!when!-clause body must be discrete-time.
+A variable used as argument to \lstinline!pre! outside a \lstinline!when!-clause body must be discrete-time.
 
 \begin{lstlisting}[language=modelica]
 model PiecewiseConstantReals

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -425,8 +425,9 @@ The reason can intuitively be explained as follows:
 
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.
 The \lstinline!Real! variables declared with the prefix \lstinline!discrete! is a subset of the discrete-time \lstinline!Real! variables.
-For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in a \lstinline!when!-clause.
-A variable used as argument to \lstinline!pre! outside a \lstinline!when!-clause must be discrete-time.
+For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in (the body of) a \lstinline!when!-clause.
+% The (the body of) is redundant (as assignments cannot be placed anywhere else in when-clauses). Might reformulate
+A variable used as argument to \lstinline!pre! outside the body of any \lstinline!when!-clause must be discrete-time.
 
 \begin{lstlisting}[language=modelica]
 model PiecewiseConstantReals

--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -425,9 +425,8 @@ The reason can intuitively be explained as follows:
 
 For \lstinline!Real! variables we can distinguish two subtly different categories: discrete-time and piecewise constant, where the discrete-time variables are a subset of all piecewise constant variables.
 The \lstinline!Real! variables declared with the prefix \lstinline!discrete! is a subset of the discrete-time \lstinline!Real! variables.
-For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in (the body of) a \lstinline!when!-clause.
-% The (the body of) is redundant (as assignments cannot be placed anywhere else in when-clauses). Might reformulate
-A variable used as argument to \lstinline!pre! outside the body of any \lstinline!when!-clause must be discrete-time.
+For a \lstinline!Real! variable, being discrete-time is equivalent to being assigned in a \lstinline!when!-clause body.
+A variable used as argument to \lstinline!pre! outside any \lstinline!when!-clause body must be discrete-time.
 
 \begin{lstlisting}[language=modelica]
 model PiecewiseConstantReals

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -418,7 +418,7 @@ In case of \lstinline!reinit! active during initialization (due to \lstinline!wh
 
 \begin{example}
 If a higher index system is present, i.e., constraints between state variables, some state variables need to be redefined to non-state variables.
-During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding \lstinline!when!-clause bodies become active.
+During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least during the events when the \lstinline!reinit!-equation is active.
 If this is not possible, an error occurs, since otherwise \lstinline!reinit! would be applied to a non-state variable.
 
 Example for the usage of \lstinline!reinit! (bouncing ball):

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -127,10 +127,10 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 \subsection{If-Equations}\label{if-equations}
 
 The syntax of an \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
-Here, each \productionref{expression} in the grammar (representing the condition of an \lstinline!if!- or \lstinline!elseif!-clause) must be a scalar \lstinline!Boolean! expression.
-One \lstinline!if!-clause, and zero or more \lstinline!elseif!-clauses, and an optional \lstinline!else!-clause together form a list of branches.
-One or zero of the bodies of these \lstinline!if!-, \lstinline!elseif!- and \lstinline!else!-clauses is selected, by evaluating the conditions of the \lstinline!if!- and \lstinline!elseif!-clauses sequentially until a condition that evaluates to true is found.
-If none of the conditions evaluate to true the body of the \lstinline!else!-clause is selected (if an \lstinline!else!-clause exists, otherwise no body is selected).
+Here, each \productionref{expression} in the grammar (representing the condition of any branch of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
+An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
+One or zero of the bodies of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
+If none of the conditions evaluate to true the body of the \lstinline!else!-branch is selected if it exists, otherwise no body is selected.
 In an equation section, the equations in the body are seen as equations that must be satisfied.
 The bodies that are not selected have no effect on that model evaluation.
 
@@ -196,7 +196,7 @@ equation
 \end{lstlisting}
 
 \begin{nonnormative}
-The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause.
+The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within the body of a \lstinline!when!-clause.
 Example:
 \begin{lstlisting}[language=modelica]
   /* discrete */ Real x;
@@ -211,7 +211,7 @@ equation
 
 Here, \lstinline!x! is a discrete-time variable (whether it is declared with the \lstinline!discrete! prefix or not), but \lstinline!u! and \lstinline!y! cannot be discrete-time variables
 (since they are not assigned in \lstinline!when!-clauses).
-However, \lstinline!pre(u)! is legal within the \lstinline!when!-clause, since the body of the \lstinline!when!-clause is only evaluated at events, and thus all expressions are discrete-time expressions.
+However, \lstinline!pre(u)! is legal within the body of the \lstinline!when!-clause, since the body is only evaluated at events, and thus all expressions are discrete-time expressions.
 \end{nonnormative}
 
 The start values of the introduced \lstinline!Boolean! variables are defined by the taking the start value of the when-condition, as above where \lstinline!b! is a parameter variable.
@@ -409,15 +409,15 @@ reinit(x, expr);
 The operator reinitializes \lstinline!x! with \lstinline!expr! at an event instant.
 \lstinline!x! is a component-reference (where any subscripts are evaluable) referring to a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e., \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
 \lstinline!expr! needs to be type-compatible with \lstinline!x!.
-For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-equation (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-clauses of the same \lstinline!when!-equation is allowed).
-If there are multiple \lstinline!reinit! for a variable inside the same \lstinline!when!- or \lstinline!elsewhen!-clause, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
+For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-clause (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-branches of the same \lstinline!when!-equation is allowed).
+If there are multiple \lstinline!reinit! for a variable inside one body of a \lstinline!when!-clause, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
 In case of \lstinline!reinit! active during initialization (due to \lstinline!when initial()!), see \cref{initialization-initial-equation-and-initial-algorithm}.
 
 \lstinline!reinit! does not break the single assignment rule, because \lstinline!reinit(x, expr)! in equations evaluates \lstinline!expr! to a value, then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is done after all other evaluations of the model and before copying \lstinline!x! to \lstinline!pre(x)!).
 
 \begin{example}
 If a higher index system is present, i.e., constraints between state variables, some state variables need to be redefined to non-state variables.
-During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding \lstinline!when!-clauses become active.
+During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding bodies of the \lstinline!when!-clauses become active.
 If this is not possible, an error occurs, since otherwise \lstinline!reinit! would be applied to a non-state variable.
 
 Example for the usage of \lstinline!reinit! (bouncing ball):
@@ -643,7 +643,7 @@ All equations and assignment statements within \lstinline!when!-clauses and all 
 Clocked discrete-time partitions are also treated this way, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 
 \begin{nonnormative}
-Using state events in \lstinline!when!-clauses is unnecessary because the body of a \lstinline!when!-clause is not evaluated during continuous integration.
+Using state events in the body of a \lstinline!when!-clause is unnecessary because the body of a \lstinline!when!-clause is not evaluated during continuous integration.
 \end{nonnormative}
 
 \begin{example}
@@ -715,7 +715,7 @@ algorithm
   end when;
 \end{lstlisting}
 
-The \lstinline!slowSample! \lstinline!when!-clause is evaluated at every 5th occurrence of the \lstinline!fastSample! \lstinline!when!-clause.
+The body of the \lstinline!slowSample! \lstinline!when!-clause is evaluated at every 5th occurrence of the evaluating the body of the \lstinline!fastSample! \lstinline!when!-clause.
 \end{nonnormative}
 
 \begin{nonnormative}
@@ -744,7 +744,7 @@ If the condition of the \lstinline!when!-clause contains \lstinline!initial()!, 
 The algorithmic statements within a \lstinline!when!-statement are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the \lstinline!when!-statement remain active during the whole initialization phase.
 
-An active \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
+An active condition of a branch of a \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 
 \begin{nonnormative}
 That means that any subsequent \lstinline!elsewhen initial()! has no effect, similarly to \lstinline!when false then!.
@@ -946,7 +946,7 @@ equation
 \end{lstlisting}
 After solving the initialization problem, both \lstinline!b! and \lstinline!pre(b)! are false.
 During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from falso to true during the first round of the initial event iteration.
-This triggers the \lstinline!when!-clause, and \lstinline!x! gets reinitialized.
+This triggers the body of the \lstinline!when!-clause, and \lstinline!x! gets reinitialized.
 \end{example}
 
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -196,7 +196,7 @@ equation
 \end{lstlisting}
 
 \begin{nonnormative}
-The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause body.
+The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non-discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause body.
 Example:
 \begin{lstlisting}[language=modelica]
   /* discrete */ Real x;

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -410,7 +410,7 @@ reinit(x, expr);
 The operator reinitializes \lstinline!x! with \lstinline!expr! at an event instant.
 \lstinline!x! is a component-reference (where any subscripts are evaluable) referring to a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e., \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
 \lstinline!expr! needs to be type-compatible with \lstinline!x!.
-For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-equation (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-branches of the same \lstinline!when!-equation is allowed).
+For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-equation (applying \lstinline!reinit! to a variable in several branches of the same \lstinline!when!-equation is allowed).
 If there are multiple \lstinline!reinit! for a variable inside one \lstinline!when!-clause body, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
 In case of \lstinline!reinit! active during initialization (due to \lstinline!when initial()!), see \cref{initialization-initial-equation-and-initial-algorithm}.
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -716,7 +716,7 @@ algorithm
   end when;
 \end{lstlisting}
 
-The \lstinline!slowSample! \lstinline!when!-clause body is evaluated at every 5th occurrence of the evaluating the \lstinline!fastSample! \lstinline!when!-clause body.
+The \lstinline!slowSample! \lstinline!when!-clause body is evaluated at every 5th evaluation of the \lstinline!fastSample! \lstinline!when!-clause body.
 \end{nonnormative}
 
 \begin{nonnormative}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -745,7 +745,7 @@ If the condition of the \lstinline!when!-clause contains \lstinline!initial()!, 
 The algorithmic statements within a \lstinline!when!-statement are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the \lstinline!when!-statement remain active during the whole initialization phase.
 
-An active condition of a branch of a \lstinline!when!-clause inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
+An active \lstinline!when!-clause branch condition inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 
 \begin{nonnormative}
 That means that any subsequent \lstinline!elsewhen initial()! has no effect, similarly to \lstinline!when false then!.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -128,7 +128,7 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 
 The syntax of an \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
 Here, each \productionref{expression} in the grammar (representing the condition of any branch of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
-An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
+An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of the branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
 In an equation section, the equations in the body of the selected branch are seen as equations that must be satisfied.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -227,6 +227,7 @@ The start value of the special functions \lstinline!initial!, \lstinline!termina
   \lstinline!when!-equations cannot be nested.
 \item
   \lstinline!when!-equations can only occur within \lstinline!if!-equations and \lstinline!for!-equations if the controlling expressions are exclusively evaluable expressions.
+  For \lstinline!if!-equations this requires that the condition of the branch containing the \lstinline!when!-equation and the conditions of all preceding branches are evaluable.
 \end{itemize}
 
 \begin{example}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -74,7 +74,7 @@ It is evaluated once for each \lstinline!for!-equation, and is evaluated in the 
 The expression of a \lstinline!for!-equation shall be evaluable.
 The iteration range of a \lstinline!for!-equation can also be specified as \lstinline!Boolean! or as an enumeration type, see \cref{types-as-iteration-ranges} for more information.
 The loop-variable (\lstinline!IDENT!) is in scope inside the loop-construct and shall not be assigned to.
-For each element of the evaluated vector expression, in the normal order, the loop-variable gets the value of that element and that is used to evaluate the body of the \lstinline!for!-loop.
+For each element of the evaluated vector expression, in the normal order, the loop-variable gets the value of that element and that is used to evaluate the \lstinline!for!-loop body.
 
 \begin{example}
 \begin{lstlisting}[language=modelica]
@@ -196,7 +196,7 @@ equation
 \end{lstlisting}
 
 \begin{nonnormative}
-The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within the body of a \lstinline!when!-clause.
+The equivalence is conceptual since \lstinline!pre($\ldots$)! of a non discrete-time \lstinline!Real! variable or expression can only be used within a \lstinline!when!-clause body.
 Example:
 \begin{lstlisting}[language=modelica]
   /* discrete */ Real x;
@@ -211,7 +211,7 @@ equation
 
 Here, \lstinline!x! is a discrete-time variable (whether it is declared with the \lstinline!discrete! prefix or not), but \lstinline!u! and \lstinline!y! cannot be discrete-time variables
 (since they are not assigned in \lstinline!when!-clauses).
-However, \lstinline!pre(u)! is legal within the body of the \lstinline!when!-clause, since the body is only evaluated at events, and thus all expressions are discrete-time expressions.
+However, \lstinline!pre(u)! is legal within the \lstinline!when!-clause body, since the body is only evaluated at events, and thus all expressions are discrete-time expressions.
 \end{nonnormative}
 
 The start values of the introduced \lstinline!Boolean! variables are defined by the taking the start value of the when-condition, as above where \lstinline!b! is a parameter variable.
@@ -401,7 +401,7 @@ end WhenPriorityAlg;
 
 \subsection{reinit}\label{reinit}
 
-\lstinline!reinit! can only be used in the body of a \lstinline!when!-equation.
+\lstinline!reinit! can only be used in a \lstinline!when!-equation body.
 It has the following syntax:
 \begin{lstlisting}[language=modelica]
 reinit(x, expr);
@@ -411,14 +411,14 @@ The operator reinitializes \lstinline!x! with \lstinline!expr! at an event insta
 \lstinline!x! is a component-reference (where any subscripts are evaluable) referring to a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e., \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
 \lstinline!expr! needs to be type-compatible with \lstinline!x!.
 For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-clause (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-branches of the same \lstinline!when!-equation is allowed).
-If there are multiple \lstinline!reinit! for a variable inside one body of a \lstinline!when!-clause, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
+If there are multiple \lstinline!reinit! for a variable inside one \lstinline!when!-clause body, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
 In case of \lstinline!reinit! active during initialization (due to \lstinline!when initial()!), see \cref{initialization-initial-equation-and-initial-algorithm}.
 
 \lstinline!reinit! does not break the single assignment rule, because \lstinline!reinit(x, expr)! in equations evaluates \lstinline!expr! to a value, then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is done after all other evaluations of the model and before copying \lstinline!x! to \lstinline!pre(x)!).
 
 \begin{example}
 If a higher index system is present, i.e., constraints between state variables, some state variables need to be redefined to non-state variables.
-During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding bodies of the \lstinline!when!-clauses become active.
+During simulation, non-state variables should be chosen in such a way that variables with an applied \lstinline!reinit! are selected as states at least when the corresponding \lstinline!when!-clause bodies become active.
 If this is not possible, an error occurs, since otherwise \lstinline!reinit! would be applied to a non-state variable.
 
 Example for the usage of \lstinline!reinit! (bouncing ball):
@@ -644,7 +644,7 @@ All equations and assignment statements within \lstinline!when!-clauses and all 
 Clocked discrete-time partitions are also treated this way, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 
 \begin{nonnormative}
-Using state events in the body of a \lstinline!when!-clause is unnecessary because the body of a \lstinline!when!-clause is not evaluated during continuous integration.
+Using state events in a \lstinline!when!-clause body is unnecessary because the \lstinline!when!-clause body is not evaluated during continuous integration.
 \end{nonnormative}
 
 \begin{example}
@@ -716,7 +716,7 @@ algorithm
   end when;
 \end{lstlisting}
 
-The body of the \lstinline!slowSample! \lstinline!when!-clause is evaluated at every 5th occurrence of the evaluating the body of the \lstinline!fastSample! \lstinline!when!-clause.
+The \lstinline!slowSample! \lstinline!when!-clause body is evaluated at every 5th occurrence of the evaluating the \lstinline!fastSample! \lstinline!when!-clause body.
 \end{nonnormative}
 
 \begin{nonnormative}
@@ -947,7 +947,7 @@ equation
 \end{lstlisting}
 After solving the initialization problem, both \lstinline!b! and \lstinline!pre(b)! are false.
 During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from falso to true during the first round of the initial event iteration.
-This triggers the body of the \lstinline!when!-clause, and \lstinline!x! gets reinitialized.
+This triggers the \lstinline!when!-clause body, and \lstinline!x! gets reinitialized.
 \end{example}
 
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -410,7 +410,7 @@ reinit(x, expr);
 The operator reinitializes \lstinline!x! with \lstinline!expr! at an event instant.
 \lstinline!x! is a component-reference (where any subscripts are evaluable) referring to a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e., \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
 \lstinline!expr! needs to be type-compatible with \lstinline!x!.
-For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-clause (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-branches of the same \lstinline!when!-equation is allowed).
+For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-equation (applying \lstinline!reinit! to a variable in several \lstinline!when!- or \lstinline!elsewhen!-branches of the same \lstinline!when!-equation is allowed).
 If there are multiple \lstinline!reinit! for a variable inside one \lstinline!when!-clause body, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
 In case of \lstinline!reinit! active during initialization (due to \lstinline!when initial()!), see \cref{initialization-initial-equation-and-initial-algorithm}.
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -129,10 +129,10 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 The syntax of an \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
 Here, each \productionref{expression} in the grammar (representing the condition of any branch of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
-One or zero of the bodies of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
-If none of the conditions evaluate to true the body of the \lstinline!else!-branch is selected if it exists, otherwise no body is selected.
-In an equation section, the equations in the body are seen as equations that must be satisfied.
-The bodies that are not selected have no effect on that model evaluation.
+One or zero of the branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
+If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
+In an equation section, the equations in the body of the selected branch are seen as equations that must be satisfied.
+The bodies of the branches that are not selected have no effect on that model evaluation.
 
 The \lstinline!if!-equations which do not have exclusively evaluable expressions as switching conditions shall satisfy the following:
 \begin{itemize}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -127,12 +127,12 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 \subsection{If-Equations}\label{if-equations}
 
 The syntax of an \lstinline!if!-equation\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
-Here, each \productionref{expression} in the grammar (representing the condition of any branch of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of the branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
 In an equation section, the equations in the body of the selected branch are seen as equations that must be satisfied.
 The bodies of the branches that are not selected have no effect on that model evaluation.
+Each branch condition (represented by \productionref{expression} in the grammar) must be a scalar \lstinline!Boolean! expression.
 
 The \lstinline!if!-equations which do not have exclusively evaluable expressions as switching conditions shall satisfy the following:
 \begin{itemize}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -947,7 +947,7 @@ equation
 \end{lstlisting}
 After solving the initialization problem, both \lstinline!b! and \lstinline!pre(b)! are false.
 During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from false to true during the first round of the initial event iteration.
-This triggers the \lstinline!when!-clause body, and \lstinline!x! gets reinitialized.
+This activates the \lstinline!when!-clause body, and \lstinline!x! gets reinitialized.
 \end{example}
 
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -127,8 +127,8 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 \subsection{If-Equations}\label{if-equations}
 
 The syntax of an \lstinline!if!-equation\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
-An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
-One or zero of the branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
+An \lstinline!if!-equation is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
+One or zero of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
 In an equation section, the equations in the body of the selected branch are seen as equations that must be satisfied.
 The bodies of the branches that are not selected have no effect on that model evaluation.
@@ -227,7 +227,7 @@ The start value of the special functions \lstinline!initial!, \lstinline!termina
   \lstinline!when!-equations cannot be nested.
 \item
   \lstinline!when!-equations can only occur within \lstinline!if!-equations and \lstinline!for!-equations if the controlling expressions are exclusively evaluable expressions.
-  For \lstinline!if!-equations this requires that the condition of the branch containing the \lstinline!when!-equation and the conditions of all preceding branches are evaluable.
+  For \lstinline!if!-equations this requires that the condition (if any) of the branch containing the \lstinline!when!-equation and the conditions of all preceding branches are evaluable.
 \end{itemize}
 
 \begin{example}
@@ -411,7 +411,7 @@ The operator reinitializes \lstinline!x! with \lstinline!expr! at an event insta
 \lstinline!x! is a component-reference (where any subscripts are evaluable) referring to a \lstinline!Real! variable (or an array of \lstinline!Real! variables) that must be selected as a state (resp., states), i.e., \lstinline!reinit! on \lstinline!x! implies \lstinline!stateSelect = StateSelect.always! on \lstinline!x!.
 \lstinline!expr! needs to be type-compatible with \lstinline!x!.
 For any given variable (possibly an array variable), \lstinline!reinit! can only be applied (either to an individual variable or to a part of an array variable) in one \lstinline!when!-equation (applying \lstinline!reinit! to a variable in several branches of the same \lstinline!when!-equation is allowed).
-If there are multiple \lstinline!reinit! for a variable inside one \lstinline!when!-clause body, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
+If there are multiple \lstinline!reinit! for a variable inside one \lstinline!when!-equation body, they must appear in different branches of an \lstinline!if!-equation (in order that at most one \lstinline!reinit! for the variable is active at any event).
 In case of \lstinline!reinit! active during initialization (due to \lstinline!when initial()!), see \cref{initialization-initial-equation-and-initial-algorithm}.
 
 \lstinline!reinit! does not break the single assignment rule, because \lstinline!reinit(x, expr)! in equations evaluates \lstinline!expr! to a value, then at the end of the current event iteration step it assigns this value to \lstinline!x! (this copying from values to reinitialized state(s) is done after all other evaluations of the model and before copying \lstinline!x! to \lstinline!pre(x)!).
@@ -644,7 +644,7 @@ All equations and assignment statements within \lstinline!when!-clauses and all 
 Clocked discrete-time partitions are also treated this way, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 
 \begin{nonnormative}
-Expressions in \lstinline!when!-clause bodies do not trigger state events since they are not active during during continuous integration.
+Expressions in \lstinline!when!-clause bodies do not trigger state events since they are not active during continuous integration.
 \end{nonnormative}
 
 \begin{example}
@@ -745,7 +745,7 @@ If the condition of the \lstinline!when!-clause contains \lstinline!initial()!, 
 The algorithmic statements within a \lstinline!when!-statement are active during initialization, if and only if they are explicitly enabled with \lstinline!initial()!, and only in one of the two forms \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 In this case, the algorithmic statements within the \lstinline!when!-statement remain active during the whole initialization phase.
 
-An active \lstinline!when!-clause branch condition inactivates the following \lstinline!elsewhen! (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
+An active \lstinline!when!-clause branch condition inactivates the following \lstinline!elsewhen!-branches (similarly to \lstinline!when!-clauses during simulation), but apart from that the first \lstinline!elsewhen initial() then! or \lstinline!elsewhen {$\ldots$, initial(), $\ldots$} then! is similarly active during initialization as \lstinline!when initial() then! or \lstinline!when {$\ldots$, initial(), $\ldots$} then!.
 
 \begin{nonnormative}
 That means that any subsequent \lstinline!elsewhen initial()! has no effect, similarly to \lstinline!when false then!.

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -946,7 +946,7 @@ equation
   end when;
 \end{lstlisting}
 After solving the initialization problem, both \lstinline!b! and \lstinline!pre(b)! are false.
-During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from falso to true during the first round of the initial event iteration.
+During transient analysis, \lstinline!initial()! is false, so \lstinline!b! changes from false to true during the first round of the initial event iteration.
 This triggers the \lstinline!when!-clause body, and \lstinline!x! gets reinitialized.
 \end{example}
 

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -644,7 +644,7 @@ All equations and assignment statements within \lstinline!when!-clauses and all 
 Clocked discrete-time partitions are also treated this way, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 
 \begin{nonnormative}
-Using state events in a \lstinline!when!-clause body is unnecessary because the \lstinline!when!-clause body is not evaluated during continuous integration.
+Expressions in \lstinline!when!-clause bodies do not trigger state events since they are not active during during continuous integration.
 \end{nonnormative}
 
 \begin{example}

--- a/chapters/equations.tex
+++ b/chapters/equations.tex
@@ -126,7 +126,7 @@ The same restrictions apply to \lstinline!Connections.branch!, \lstinline!Connec
 
 \subsection{If-Equations}\label{if-equations}
 
-The syntax of an \lstinline!if!-equations\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
+The syntax of an \lstinline!if!-equation\index{if@\robustinline{if}!equation}\index{then@\robustinline{then}!if-equation@\robustinline{if}-equation}\index{else@\robustinline{else}!if-equation@\robustinline{if}-equation}\index{elseif@\robustinline{elseif}!if-equation@\robustinline{if}-equation} is given by \productionref{if-equation} in the grammar.
 Here, each \productionref{expression} in the grammar (representing the condition of any branch of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of the branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1513,14 +1513,14 @@ The same restrictions as for \lstinline!pre! apply (e.g., not to be used in \lst
 reinit($x$, $\mathit{expr}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-In a \lstinline!when!-clause body, reinitializes $x$ with $\mathit{expr}$ at an event instant.
+Re-initializes $x$ with $\mathit{expr}$.
+Only allowed in a \lstinline!when!-equation body, meaning that re-initialization will only occur at events.
 $x$ is a scalar or array \lstinline!Real! variable that is implicitly defined to have \lstinline!StateSelect.always!.
 \begin{nonnormative}
 It is an error if the variable cannot be selected as a state.
 \end{nonnormative}
 $\mathit{expr}$ needs to be type-compatible with $x$.
 \lstinline!reinit! can only be applied once for the same variable -- either as an individual variable or as part of an array of variables.
-It can only be applied in a \lstinline!when!-clause body in an equation section.
 See also \cref{reinit}.
 \end{semantics}
 \end{operatordefinition}
@@ -1689,7 +1689,7 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
 \item
   Expressions where all the subexpressions are discrete-time expressions.
 \item
-  Expressions in the a \lstinline!when!-clause body, \lstinline!initial equation!, or \lstinline!initial algorithm!.
+  Expressions in a \lstinline!when!-clause body, \lstinline!initial equation!, or \lstinline!initial algorithm!.
 \item
   Expressions in a clocked discrete-time partition, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 \item
@@ -1712,7 +1712,7 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
   Expressions in functions not having annotation \lstinline!GenerateEvents = true! (\cref{modelica:GenerateEvents}), behave as though they were discrete-time expressions.
 \end{itemize}
 
-Inside an \lstinline!if!-expression; or in an \lstinline!if!-clause body, a \lstinline!while!-statement, or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the \lstinline!when!-clause body, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
+Inside an \lstinline!if!-expression or in an \lstinline!if!-clause body, a \lstinline!while!-statement or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the \lstinline!when!-clause body, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
 
 \begin{nonnormative}
 The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing functions do not become active between events.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -621,7 +621,7 @@ Integer modulus of $x / y$, i.e., \lstinline!mod($x$, $y$) = $x$ - floor($x$ / $
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
@@ -636,7 +636,7 @@ Integer remainder of $x / y$, such that \lstinline!div($x$, $y$) * $y$ + rem($x$
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
@@ -650,7 +650,7 @@ ceil($x$)
 Smallest integer not less than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -663,7 +663,7 @@ floor($x$)
 Largest integer not greater than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -677,7 +677,7 @@ Largest integer not greater than $x$.
 The argument shall have type \lstinline!Real!.
 The result has type \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -1463,7 +1463,7 @@ Any subscripts in the component expression $y$ must be evaluable expressions.
 The operator is not allowed inside \lstinline!function! classes.
 \lstinline!pre! can be applied to the variable $y$ only if $y$ is a discrete-time expression and $y$ is either a subtype of a simple type or is a record component.
 \begin{nonnormative}
-This can be applied to continuous-time variables in \lstinline!when!-clauses, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
+This can be applied to continuous-time variables in the bodies of \lstinline!when!-clauses, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
 \end{nonnormative}
 The first value of \lstinline!pre($y$)! is determined in the initialization phase.
 
@@ -1473,10 +1473,10 @@ This evaluation sequence is called \emph{event iteration}.
 When no more round of model equation evaluation is triggered, the processing of the event is completed and the transient analysis may proceed forward in time.
 
 For purposes of event iteration, each scalar expression in a \lstinline!when!-clause condition is treated as an implicit variable \lstinline!v!.
-Since the \lstinline!when!-clause is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
+Since the body of a \lstinline!when!-clause is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
 
 \begin{nonnormative}
-If \lstinline!v! and \lstinline!pre(v)! are only used in \lstinline!when!-clauses, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
+If \lstinline!v! and \lstinline!pre(v)! are only used in bodies of \lstinline!when!-clauses, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
 It is a quality of implementation to find the minimal loops for event iteration, i.e., not all parts of the model need to be reevaluated.
 
 A consequence of the implicit \lstinline!when!-clause condition variables is that every time a \lstinline!when!-clause is triggered, there is a variable with \lstinline!v <> pre(v)!, meaning that another round of the iteration is triggered.
@@ -1712,7 +1712,7 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
   Expressions in functions not having annotation \lstinline!GenerateEvents = true! (\cref{modelica:GenerateEvents}), behave as though they were discrete-time expressions.
 \end{itemize}
 
-Inside an \lstinline!if!-expression, \lstinline!if!-clause, \lstinline!while!-statement or \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the body of a \lstinline!when!-clause, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
+Inside an \lstinline!if!-expression; or in the body of an \lstinline!if!-clause, a \lstinline!while!-statement, or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the body of a \lstinline!when!-clause, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
 
 \begin{nonnormative}
 The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing functions do not become active between events.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -621,7 +621,7 @@ Integer modulus of $x / y$, i.e., \lstinline!mod($x$, $y$) = $x$ - floor($x$ / $
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
+Note, outside of \lstinline!when!-clause bodies, state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
@@ -636,7 +636,7 @@ Integer remainder of $x / y$, such that \lstinline!div($x$, $y$) * $y$ + rem($x$
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
+Note, outside of \lstinline!when!-clause bodies, state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
@@ -650,7 +650,7 @@ ceil($x$)
 Smallest integer not less than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
+Note, outside of \lstinline!when!-clause bodies, state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -663,7 +663,7 @@ floor($x$)
 Largest integer not greater than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
+Note, outside of \lstinline!when!-clause bodies, state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -677,7 +677,7 @@ Largest integer not greater than $x$.
 The argument shall have type \lstinline!Real!.
 The result has type \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
+Note, outside of \lstinline!when!-clause bodies, state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -621,7 +621,7 @@ Integer modulus of $x / y$, i.e., \lstinline!mod($x$, $y$) = $x$ - floor($x$ / $
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!mod(3, 1.4) = 0.2!, \lstinline!mod(-3, 1.4) = 1.2!, \lstinline!mod(3, -1.4) = -1.2!.
 \end{nonnormative}
 \end{semantics}
@@ -636,7 +636,7 @@ Integer remainder of $x / y$, such that \lstinline!div($x$, $y$) * $y$ + rem($x$
 Result and arguments shall have type \lstinline!Real! or \lstinline!Integer!.
 If either of the arguments is \lstinline!Real! the result is \lstinline!Real! otherwise \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
 Examples: \lstinline!rem(3, 1.4) = 0.2!, \lstinline!rem(-3, 1.4) = -0.2!.
 \end{nonnormative}
 \end{semantics}
@@ -650,7 +650,7 @@ ceil($x$)
 Smallest integer not less than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -663,7 +663,7 @@ floor($x$)
 Largest integer not greater than $x$.
 Result and argument shall have type \lstinline!Real!.
 \begin{nonnormative}
-Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -677,7 +677,7 @@ Largest integer not greater than $x$.
 The argument shall have type \lstinline!Real!.
 The result has type \lstinline!Integer!.
 \begin{nonnormative}
-Note, outside of a body of a \lstinline!when!-clause state events are triggered when the return value changes discontinuously.
+Note, outside of a \lstinline!when!-clause body state events are triggered when the return value changes discontinuously.
 \end{nonnormative}
 \end{semantics}
 \end{operatordefinition}
@@ -1463,7 +1463,7 @@ Any subscripts in the component expression $y$ must be evaluable expressions.
 The operator is not allowed inside \lstinline!function! classes.
 \lstinline!pre! can be applied to the variable $y$ only if $y$ is a discrete-time expression and $y$ is either a subtype of a simple type or is a record component.
 \begin{nonnormative}
-This can be applied to continuous-time variables in the bodies of \lstinline!when!-clauses, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
+This can be applied to continuous-time variables in \lstinline!when!-clause bodies, see \cref{discrete-time-expressions} for the definition of discrete-time expression.
 \end{nonnormative}
 The first value of \lstinline!pre($y$)! is determined in the initialization phase.
 
@@ -1473,10 +1473,10 @@ This evaluation sequence is called \emph{event iteration}.
 When no more round of model equation evaluation is triggered, the processing of the event is completed and the transient analysis may proceed forward in time.
 
 For purposes of event iteration, each scalar expression in a \lstinline!when!-clause condition is treated as an implicit variable \lstinline!v!.
-Since the body of a \lstinline!when!-clause is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
+Since a \lstinline!when!-clause body is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
 
 \begin{nonnormative}
-If \lstinline!v! and \lstinline!pre(v)! are only used in bodies of \lstinline!when!-clauses, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
+If \lstinline!v! and \lstinline!pre(v)! are only used in \lstinline!when!-clause bodies, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.
 It is a quality of implementation to find the minimal loops for event iteration, i.e., not all parts of the model need to be reevaluated.
 
 A consequence of the implicit \lstinline!when!-clause condition variables is that every time a \lstinline!when!-clause is triggered, there is a variable with \lstinline!v <> pre(v)!, meaning that another round of the iteration is triggered.
@@ -1513,14 +1513,14 @@ The same restrictions as for \lstinline!pre! apply (e.g., not to be used in \lst
 reinit($x$, $\mathit{expr}$)
 \end{lstlisting}\end{synopsis}
 \begin{semantics}
-In the body of a \lstinline!when!-clause, reinitializes $x$ with $\mathit{expr}$ at an event instant.
+In a \lstinline!when!-clause body, reinitializes $x$ with $\mathit{expr}$ at an event instant.
 $x$ is a scalar or array \lstinline!Real! variable that is implicitly defined to have \lstinline!StateSelect.always!.
 \begin{nonnormative}
 It is an error if the variable cannot be selected as a state.
 \end{nonnormative}
 $\mathit{expr}$ needs to be type-compatible with $x$.
 \lstinline!reinit! can only be applied once for the same variable -- either as an individual variable or as part of an array of variables.
-It can only be applied in the body of a \lstinline!when!-clause in an equation section.
+It can only be applied in a \lstinline!when!-clause body in an equation section.
 See also \cref{reinit}.
 \end{semantics}
 \end{operatordefinition}
@@ -1689,7 +1689,7 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
 \item
   Expressions where all the subexpressions are discrete-time expressions.
 \item
-  Expressions in the body of a \lstinline!when!-clause, \lstinline!initial equation!, or \lstinline!initial algorithm!.
+  Expressions in the a \lstinline!when!-clause body, \lstinline!initial equation!, or \lstinline!initial algorithm!.
 \item
   Expressions in a clocked discrete-time partition, see \cref{clocked-discrete-time-and-clocked-discretized-continuous-time-partition}.
 \item
@@ -1712,7 +1712,7 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
   Expressions in functions not having annotation \lstinline!GenerateEvents = true! (\cref{modelica:GenerateEvents}), behave as though they were discrete-time expressions.
 \end{itemize}
 
-Inside an \lstinline!if!-expression; or in the body of an \lstinline!if!-clause, a \lstinline!while!-statement, or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the body of a \lstinline!when!-clause, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
+Inside an \lstinline!if!-expression; or in an \lstinline!if!-clause body, a \lstinline!while!-statement, or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the \lstinline!when!-clause body, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
 
 \begin{nonnormative}
 The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing functions do not become active between events.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1712,7 +1712,8 @@ Discrete-time expressions\index{discrete-time!expression}\index{expression varia
   Expressions in functions not having annotation \lstinline!GenerateEvents = true! (\cref{modelica:GenerateEvents}), behave as though they were discrete-time expressions.
 \end{itemize}
 
-Inside an \lstinline!if!-expression or in an \lstinline!if!-clause body, a \lstinline!while!-statement or a \lstinline!for!-clause, that is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression and not in the \lstinline!when!-clause body, it is not legal to have assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
+The following rule applies to \lstinline!while!-statements and \lstinline!for!-clauses inside an \lstinline!if!-clause body, except when also inside a \lstinline!when!-clause body.
+When such a \lstinline!while!-statement or \lstinline!for!-clause is controlled by a non-discrete-time (that is continuous-time, but not discrete-time) switching expression, it is not legal to contain assignments to discrete-time variables, equations between discrete-time expressions, or real elementary relations/functions that should generate events.
 
 \begin{nonnormative}
 The restriction above is necessary in order to guarantee that all equations for discrete-time variable are discrete-time expressions, and to ensure that crossing functions do not become active between events.

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -1473,7 +1473,7 @@ This evaluation sequence is called \emph{event iteration}.
 When no more round of model equation evaluation is triggered, the processing of the event is completed and the transient analysis may proceed forward in time.
 
 For purposes of event iteration, each scalar expression in a \lstinline!when!-clause condition is treated as an implicit variable \lstinline!v!.
-Since a \lstinline!when!-clause body is triggered when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
+Since a \lstinline!when!-clause branch triggers when \lstinline!v and not pre(v)!, the implicit variable is considered wrapped in \lstinline!pre($\ldots$)! and becomes part of the event iteration convergence criterion.
 
 \begin{nonnormative}
 If \lstinline!v! and \lstinline!pre(v)! are only used in \lstinline!when!-clause bodies, the translator might mask event iteration for variable \lstinline!v! since \lstinline!v! cannot change during event iteration.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -62,7 +62,7 @@ When an element, equation, or section is flattened, any simple name (not compose
 In the latter case the lookup stops except for the predefined types, functions and operators defined in this specification.
 For these cases the lookup continues in the global scope, where they are defined.
 
-The iteration variables are the implicitly declared iteration variable(s) if inside the body of a \lstinline!for!-loop, \cref{for-equations-repetitive-equation-structures} and \cref{for-statement}, or the body of a reduction expression, \cref{reduction-functions-and-operators}.
+The iteration variables are the implicitly declared iteration variable(s) if inside a \lstinline!for!-loop body, \cref{for-equations-repetitive-equation-structures} and \cref{for-statement}, or the body of a reduction expression, \cref{reduction-functions-and-operators}.
 
 Reference to variables successfully looked up in an enclosing class is only allowed for variables declared as \lstinline!constant!.
 The values of modifiers are thus resolved in the \emph{instance} scope of which the modifier appears; if the use is in a modifier on a short class definition, see \cref{short-class-definitions}.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -321,10 +321,10 @@ Can only be used inside functions, see \cref{function-return-statements}.
 The syntax of an \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
 Here, each \productionref{expression} in the grammar (representing any condition of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
-One or zero of the bodies of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
-If none of the conditions evaluate to true the body of the \lstinline!else!-branch is selected if it exists, otherwise no body is selected.
-In an algorithm section, the selected body is then executed.
-The bodies that are not selected have no effect on that model evaluation.
+One or zero of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
+If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
+In an algorithm section, the body of the selected branch is then executed.
+The bodies of the branches that are not selected have no effect on that model evaluation.
 
 \subsection{When-Statements}\label{when-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -320,7 +320,7 @@ Can only be used inside functions, see \cref{function-return-statements}.
 
 The syntax of an \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
 Here, each \productionref{expression} in the grammar (representing any condition of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
-An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
+An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
 In an algorithm section, the body of the selected branch is then executed.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -319,13 +319,12 @@ Can only be used inside functions, see \cref{function-return-statements}.
 \subsection{If-Statement}\label{if-statement}
 
 The syntax of an \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
-Here, each \productionref{expression} in the grammar (representing the condition of an \lstinline!if!- or \lstinline!elseif!-clause) must be a scalar \lstinline!Boolean! expression.
-One \lstinline!if!-clause, and zero or more \lstinline!elseif!-clauses, and an optional \lstinline!else!-clause together form a list of branches.
-One or zero of the bodies of these \lstinline!if!-, \lstinline!elseif!- and \lstinline!else!-clauses is selected, by evaluating the conditions of the \lstinline!if!- and \lstinline!elseif!-clauses sequentially until a condition that evaluates to true is found.
-If none of the conditions evaluate to true the body of the \lstinline!else!-clause is selected (if an \lstinline!else!-clause exists, otherwise no body is selected).
+Here, each \productionref{expression} in the grammar (representing any condition of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
+An \lstinline!if!-clause is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
+One or zero of the bodies of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
+If none of the conditions evaluate to true the body of the \lstinline!else!-branch is selected if it exists, otherwise no body is selected.
 In an algorithm section, the selected body is then executed.
 The bodies that are not selected have no effect on that model evaluation.
-
 
 \subsection{When-Statements}\label{when-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -429,7 +429,7 @@ algorithm
   end if;
 \end{lstlisting}
 with \lstinline!edge(A) = A and not pre(A)! and the additional guarantee, that the statements within this special \lstinline!if!-statement are only evaluated at event instants.
-The difference compared to the when-statements is that, e.g., \lstinline!pre! may only be used on continuous-time real variables inside a \lstinline!when!-clause body and not inside these if-statements.
+The difference compared to the \lstinline!when!-statements is that, e.g., \lstinline!pre! may only be used on continuous-time real variables inside a \lstinline!when!-clause body and not inside these \lstinline!if!-statements.
 
 \subsection{Special Statements}\label{special-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -326,6 +326,7 @@ If none of the conditions evaluate to true the \lstinline!else!-branch is select
 In an algorithm section, the body of the selected branch is then executed.
 The bodies of the branches that are not selected have no effect on that model evaluation.
 
+
 \subsection{When-Statements}\label{when-statements}
 
 The syntax of a \lstinline!when!-statement\index{when@\robustinline{when}!statement}\index{then@\robustinline{then}!when-statement@\robustinline{when}-statement}\index{elsewhen@\robustinline{elsewhen}!when-statement@\robustinline{when}-statement} is given by \productionref{when-statement} in the grammar.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -429,7 +429,7 @@ algorithm
   end if;
 \end{lstlisting}
 with \lstinline!edge(A) = A and not pre(A)! and the additional guarantee, that the statements within this special \lstinline!if!-statement are only evaluated at event instants.
-The difference compared to the when-statements is that, e.g., \lstinline!pre! may only be used on continuous-time real variables inside the body of a \lstinline!when!-clause and not inside these if-statements.
+The difference compared to the when-statements is that, e.g., \lstinline!pre! may only be used on continuous-time real variables inside a \lstinline!when!-clause body and not inside these if-statements.
 
 \subsection{Special Statements}\label{special-statements}
 

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -318,7 +318,7 @@ Can only be used inside functions, see \cref{function-return-statements}.
 
 \subsection{If-Statement}\label{if-statement}
 
-The syntax of an \lstinline!if!-statements\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
+The syntax of an \lstinline!if!-statement\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
 Here, each \productionref{expression} in the grammar (representing any condition of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.

--- a/chapters/statements.tex
+++ b/chapters/statements.tex
@@ -319,12 +319,12 @@ Can only be used inside functions, see \cref{function-return-statements}.
 \subsection{If-Statement}\label{if-statement}
 
 The syntax of an \lstinline!if!-statement\index{if@\robustinline{if}!statement}\index{then@\robustinline{then}!if-statement@\robustinline{if}-statement}\index{else@\robustinline{else}!if-statement@\robustinline{if}-statement}\index{elseif@\robustinline{elseif}!if-statement@\robustinline{if}-statement} is given by \productionref{if-statement} in the grammar.
-Here, each \productionref{expression} in the grammar (representing any condition of an \lstinline!if!-clause) must be a scalar \lstinline!Boolean! expression.
 An \lstinline!if!-statement is seen as a list of branches: one \lstinline!if!-branch, and zero or more \lstinline!elseif!-branches, and an optional \lstinline!else!-branch.
 One or zero of these branches is selected, by evaluating their conditions sequentially until a condition that evaluates to true is found.
 If none of the conditions evaluate to true the \lstinline!else!-branch is selected if it exists, otherwise no branch is selected.
 In an algorithm section, the body of the selected branch is then executed.
 The bodies of the branches that are not selected have no effect on that model evaluation.
+Each branch condition (represented by \productionref{expression} in the grammar) must be a scalar \lstinline!Boolean! expression.
 
 
 \subsection{When-Statements}\label{when-statements}


### PR DESCRIPTION
Closes #3840

Not sure if we should add this to 3.7; or delay it.

However, the current situation isn't good either as seen in #3840; and in particular "when-clause" sometimes previously meant "body of a when- or else-when-clause"; and is now written as "body of when-clause".

I believe it is correct, but will try to look again.