### PR TITLE
Be explicit about the struct being tagged

### DIFF
--- a/chapters/functions.tex
+++ b/chapters/functions.tex
@@ -2120,7 +2120,7 @@ Mapping of record types is only supported for C.
 A Modelica record class is mapped as follows:
 \begin{itemize}
 \item
-  The record class is represented by a struct in C.
+  The record class is represented by a tagged struct in C.
   A definition of the struct may be specified using the annnotations in \cref{annotations-for-c-mapping-of-records}.
 \item
   Each component of the Modelica record is mapped to its corresponding C representation.


### PR DESCRIPTION
The rest of the text makes more sense if we make it explicit from the beginning that the struct (to which a record is mapped) is tagged.  Since this already follows from text in other places, there is no urgency to include this (completely trivial) change in 3.7, in case it would slow down the release process.
