### PR TITLE
Try to fix annotation numbering as seen in #3908 item 4

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -304,9 +304,16 @@
 \newtheorem{functiondefinition*}[functiondefinition]{Function}
 \crefname{functiondefinition*}{function}{functions}
 \Crefname{functiondefinition*}{Function}{Functions}
-\newtheorem{annotationdefinition*}[annotationdefinition]{chapter}
+\newtheorem{annotationdefinition*}[annotationdefinition]{Annotation}
 \crefname{annotationdefinition*}{annotation}{annotations}
 \Crefname{annotationdefinition*}{Annotation}{Annotations}
+
+% Explanation of newtheorem syntax:
+% The \newtheorem{annotationdefinition}{Annotation}[chapter]
+%   Mean that they are called Annotation and numbered within chapter
+% \newtheorem{annotationdefinition*}[annotationdefinition]{Annotation}
+%   Mean that they are called Annotation and re-using the annotationdefinition-numbering
+
 
 \lstdefinelanguage[synopsis]{modelica}[]{modelica}{% Language for use inside the 'synopsis' environment.
   basicstyle=\upshape\ttfamily,              % Same size as \lstinline

--- a/preamble.tex
+++ b/preamble.tex
@@ -264,6 +264,13 @@
 % Note: Toc changed for appendex
 \setcounter{tocdepth}{1}
 
+% Explanation of newtheorem syntax - see https://ctan.net/macros/latex/required/amscls/doc/amsthdoc.pdf
+% The \newtheorem{annotationdefinition}{Annotation}[chapter]
+%   Mean that these "theorems" are called Annotation and numbered within chapter
+% \newtheorem{annotationdefinition*}[annotationdefinition]{Annotation}
+%   Mean that these "theorems" are called Annotation and re-using the annotationdefinition-numbering
+% Note the subtle syntax difference
+
 % Warning: The way of adding \label inside the theoremstyle below is currently working at LaTeXML version 0.8.4,
 % but was broken for a while on their master branch, see
 % - https://github.com/brucemiller/LaTeXML/issues/1351
@@ -307,13 +314,6 @@
 \newtheorem{annotationdefinition*}[annotationdefinition]{Annotation}
 \crefname{annotationdefinition*}{annotation}{annotations}
 \Crefname{annotationdefinition*}{Annotation}{Annotations}
-
-% Explanation of newtheorem syntax:
-% The \newtheorem{annotationdefinition}{Annotation}[chapter]
-%   Mean that they are called Annotation and numbered within chapter
-% \newtheorem{annotationdefinition*}[annotationdefinition]{Annotation}
-%   Mean that they are called Annotation and re-using the annotationdefinition-numbering
-
 
 \lstdefinelanguage[synopsis]{modelica}[]{modelica}{% Language for use inside the 'synopsis' environment.
   basicstyle=\upshape\ttfamily,              % Same size as \lstinline

--- a/preamble.tex
+++ b/preamble.tex
@@ -304,7 +304,7 @@
 \newtheorem{functiondefinition*}[functiondefinition]{Function}
 \crefname{functiondefinition*}{function}{functions}
 \Crefname{functiondefinition*}{Function}{Functions}
-\newtheorem{annotationdefinition*}{Annotation}[chapter]
+\newtheorem{annotationdefinition*}[annotationdefinition]{chapter}
 \crefname{annotationdefinition*}{annotation}{annotations}
 \Crefname{annotationdefinition*}{Annotation}{Annotations}
 


### PR DESCRIPTION
This seems to correct item 4 in #3908 
It is also similar to the other definitions at the same place. I don't know why it was so different before.

If this isn't the correct solution there should be more comments.

