### PR TITLE
Avoid speaking of 'instance hierarchy'

### DIFF
--- a/chapters/connectors.tex
+++ b/chapters/connectors.tex
@@ -377,7 +377,7 @@ CylinderBus cylinder_bus[4];
 
 \section{Generation of Connection Equations}\label{generation-of-connection-equations}
 
-When generating \firstuse[connection equation]{connection equations}, \lstinline!outer! elements are resolved to the corresponding \lstinline!inner! elements in the instance hierarchy (see instance hierarchy name lookup \cref{instance-hierarchy-name-lookup-of-inner-declarations}).
+When generating \firstuse[connection equation]{connection equations}, \lstinline!outer! elements are resolved to the corresponding \lstinline!inner! elements in the instance tree (see instance tree name lookup \cref{instance-hierarchy-name-lookup-of-inner-declarations}).
 The arguments to each \lstinline!connect!-equation are resolved to two connector elements.
 
 For every use of the \lstinline!connect!-equation

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -162,7 +162,7 @@ The package-restriction ensures that global name lookup of component references 
 See \cref{lookup-of-imported-names}.
 
 
-\section{Inner Declarations - Instance Tree Name Lookup}\label{instance-hierarchy-name-lookup-of-inner-declarations}\label{inner-declarations-instance-hierarchy-name-lookup}
+\section{Inner Declarations - Instance Tree Name Lookup}\label{instance-hierarchy-name-lookup-of-inner-declarations}\label{inner-declarations-instance-tree-name-lookup}
 
 An element declared with the prefix \lstinline!outer!\indexinline{outer} references an element instance with the same name but using the prefix \lstinline!inner!\indexinline{inner}.
 The \indexinline{inner} element shall be a child of an ancestor of the \lstinline!outer! element in the instance tree, and the match nearest to the \lstinline!outer! element is selected.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -188,7 +188,7 @@ An \lstinline!outer! element reference in a simulation model requires that one c
 An \lstinline!outer! element component may be of a partial class (but the referenced \lstinline!inner! component must be of a non-partial class).
 
 \begin{nonnormative}
-\lstinline!inner!/\lstinline!outer! components may be used to model simple fields, where some physical quantities, such as gravity vector, environment temperature or environment pressure, are accessible from all components in a specific instance tree.
+\lstinline!inner!/\lstinline!outer! components may be used to model simple fields, where some physical quantities, such as gravity vector, environment temperature or environment pressure, are accessible from all components in a part of the instance tree.
 Inner components are accessible throughout the model, if they are not ``shadowed'' by a corresponding \lstinline!inner! declaration in a more deeply nested level of the instance tree.
 \end{nonnormative}
 

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -164,7 +164,8 @@ See \cref{lookup-of-imported-names}.
 
 \section{Inner Declarations - Instance Tree Name Lookup}\label{instance-hierarchy-name-lookup-of-inner-declarations}\label{inner-declarations-instance-hierarchy-name-lookup}
 
-An element declared with the prefix \lstinline!outer!\indexinline{outer} references an element instance with the same name but using the prefix \lstinline!inner!\indexinline{inner} which is nearest in the enclosing instance tree of the \lstinline!outer! element declaration.
+An element declared with the prefix \lstinline!outer!\indexinline{outer} references an element instance with the same name but using the prefix \lstinline!inner!\indexinline{inner}.
+The \indexinline{inner} element shall be a child of an ancestor of the \lstinline!outer! element in the instance tree, and the match nearest to the \lstinline!outer! element is selected.
 
 Outer component declarations shall not have modifications (including binding equations).
 Outer class declarations should be defined using short-class definitions without modifications.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -162,9 +162,9 @@ The package-restriction ensures that global name lookup of component references 
 See \cref{lookup-of-imported-names}.
 
 
-\section{Inner Declarations - Instance Hierarchy Name Lookup}\label{instance-hierarchy-name-lookup-of-inner-declarations}\label{inner-declarations-instance-hierarchy-name-lookup}
+\section{Inner Declarations - Instance Tree Name Lookup}\label{instance-hierarchy-name-lookup-of-inner-declarations}\label{inner-declarations-instance-hierarchy-name-lookup}
 
-An element declared with the prefix \lstinline!outer!\indexinline{outer} references an element instance with the same name but using the prefix \lstinline!inner!\indexinline{inner} which is nearest in the enclosing instance hierarchy of the \lstinline!outer! element declaration.
+An element declared with the prefix \lstinline!outer!\indexinline{outer} references an element instance with the same name but using the prefix \lstinline!inner!\indexinline{inner} which is nearest in the enclosing instance tree of the \lstinline!outer! element declaration.
 
 Outer component declarations shall not have modifications (including binding equations).
 Outer class declarations should be defined using short-class definitions without modifications.
@@ -188,8 +188,8 @@ An \lstinline!outer! element reference in a simulation model requires that one c
 An \lstinline!outer! element component may be of a partial class (but the referenced \lstinline!inner! component must be of a non-partial class).
 
 \begin{nonnormative}
-\lstinline!inner!/\lstinline!outer! components may be used to model simple fields, where some physical quantities, such as gravity vector, environment temperature or environment pressure, are accessible from all components in a specific model hierarchy.
-Inner components are accessible throughout the model, if they are not ``shadowed'' by a corresponding \lstinline!inner! declaration in a more deeply nested level of the model hierarchy.
+\lstinline!inner!/\lstinline!outer! components may be used to model simple fields, where some physical quantities, such as gravity vector, environment temperature or environment pressure, are accessible from all components in a specific instance tree.
+Inner components are accessible throughout the model, if they are not ``shadowed'' by a corresponding \lstinline!inner! declaration in a more deeply nested level of the instance tree.
 \end{nonnormative}
 
 \begin{example}


### PR DESCRIPTION
Fixing a few places where the term _instance hierarchy_ was used, and where I believe the correct term to use is _instance tree_.
