### PR TITLE
A class has elements, not members

### DIFF
--- a/chapters/classes.tex
+++ b/chapters/classes.tex
@@ -10,7 +10,7 @@ Declarations are the syntactic constructs needed to introduce classes and object
 
 \section{Access Control -- Public and Protected Elements}\label{access-control-public-and-protected-elements}
 
-Members of a Modelica class can have two levels of visibility: \lstinline!public!\indexinline{public} or \lstinline!protected!\indexinline{protected}.
+Elements of a class can have two levels of visibility: \lstinline!public!\indexinline{public} or \lstinline!protected!\indexinline{protected}.
 The default is \lstinline!public! if nothing else is specified.
 
 A protected element, \lstinline!P!, in classes and components shall not be accessed via dot notation (e.g., \lstinline!A.P!, \lstinline!a.P!, \lstinline!a[1].P!, \lstinline!a.b.P!, \lstinline!.A.P!; but there is no restriction on using \lstinline!P! or \lstinline!P.x! for a protected element \lstinline!P!).

--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -328,7 +328,7 @@ Integer sign_of_i2 = if i < 0 then -1 else if i == 0 then 0 else 1;
 
 \subsection{Member Access Operator}\label{member-access-operator}
 
-It is possible to access members of a class instance using dot notation, i.e., the \lstinline!.! operator.
+It is possible to access elements of a class instance using dot notation, i.e., the \lstinline!.! operator.
 It is also possible to select a record member of a general expression by enclosing it in parentheses.
 Note that while the selection is applied to an \productionref{output-expression-list} in the grammar, it is only semantically valid when the \productionref{output-expression-list} represents an expression.
 
@@ -337,7 +337,7 @@ In case the first operand is an array it is seen as a slicing operation, see \cr
 \begin{example}
 The component reference \lstinline!R1.R! accesses the resistance component \lstinline!R! of resistor \lstinline!R1!.
 
-The qualified class name \lstinline!A.B! is a reference to the local class \lstinline!B! which is a member of the class \lstinline!A!.
+The qualified class name \lstinline!A.B! is a reference to the local class \lstinline!B! which is an element of the class \lstinline!A!.
 Note that the left operand in this case is a class, not an instance of the class.
 
 \lstinline!(Complex(2, 3)).re! constructs the record \lstinline!Complex(2, 3)! and then selects the \lstinline!re! component in it.

--- a/chapters/scoping.tex
+++ b/chapters/scoping.tex
@@ -75,7 +75,7 @@ This lookup in each \emph{instance} scope is performed as follows:
   Among the import names of qualified \lstinline!import!-clauses in the \emph{instance} scope.
   The \firstuse{import name} of \lstinline!import A.B.C!; is \lstinline!C! and the import name of \lstinline!import D = A.B.C;! is \lstinline!D!.
 \item
-  Among the public members of packages imported via unqualified \lstinline!import!-clauses in the \emph{instance} scope.
+  Among the public elements of packages imported via unqualified \lstinline!import!-clauses in the \emph{instance} scope.
   It is an error if this step produces matches from several unqualified imports.
 \end{itemize}
 


### PR DESCRIPTION
This is a cleanup of the use of the term _member_.

To start with, this PR only addresses the issue of calling the elements of a class its _members_ in a couple of places, when the established language to use is to call them _elements_.

Should we keep calling the elements of a record _members_?
