### PR TITLE
Introduce 'nullCombination' and 'affineCombination'

### DIFF
--- a/chapters/operatorsandexpressions.tex
+++ b/chapters/operatorsandexpressions.tex
@@ -947,6 +947,8 @@ The operators listed below include the derivative operator and special purpose o
 {\lstinline!der($\mathit{expr}$)!} & Time derivative & \Cref{modelica:der} \\
 {\lstinline!cardinality($c$)!} & Number of occurrences in {\lstinline!connect!}-equations & \Cref{modelica:cardinality} \\
 {\lstinline!homotopy($\mathit{actual}$, $\mathit{simplified}$)!} & Homotopy initialization & \Cref{modelica:homotopy} \\
+{\lstinline!nullCombination($\mathit{weights}$, $\mathit{items}$)!} & Null combination & \Cref{modelica:nullCombination} \\
+{\lstinline!affineCombination($\mathit{weights}$, $\mathit{items}$)!} & Affine combination & \Cref{modelica:affineCombination} \\
 {\lstinline!semiLinear($x$, $k^{+}$, $k^{-}$)!} & Sign-dependent slope & \Cref{modelica:semiLinear} \\
 {\lstinline!inStream($v$)!} & Stream variable flow into component & \Cref{modelica:inStream} \\
 {\lstinline!actualStream($v$)!} & Actual value of stream variable & \Cref{modelica:actualStream} \\
@@ -1050,6 +1052,102 @@ A Modelica translator should map this operator into either of the two forms:
 \end{enumerate}
 For non-scalar arguments the function is vectorized according to \cref{scalar-functions-applied-to-array-arguments}.
 For further details, see \cref{homotopy}.
+\end{semantics}
+\end{operatordefinition}
+
+\begin{operatordefinition}[nullCombination]
+\begin{synopsis}\begin{lstlisting}
+nullCombination($\mathit{weights}$, $\mathit{items}$)
+\end{lstlisting}\end{synopsis}
+\begin{semantics}
+Compute a null combination of an array of items.
+The $\mathit{weights}$ shall be a \lstinline!Real! vector of size \lstinline!size($\mathit{items}$, 1)!.
+It is not required that the size is non-zero, but the weights must add up to zero.
+This is a requirement on the mathematical values of the weights; as these can be the result of numeric computations, verification of the requirement shall be made with a tolerance accommodating numeric error.
+The result type is the same as the $\mathit{items}$ element type (stripping its first array dimension), and shall be a \lstinline!Real! scalar or array type.
+The result is the null combination of the $\mathit{items}$ based on the $\mathit{weights}$.
+All elements of $\mathit{items}$ must agree on being either absolute or relative quantities, and the result is always a relative quantity, compare \cref{modelica:absoluteValue}.
+
+\begin{nonnormative}
+When the $\mathit{items}$ are relative quantities, a null combination is just a linear combination.
+The interesting case is when the $\mathit{items}$ are absolute quantities, when null combinations generalize the fact that a difference between two absolute quantities is a relative quantity.
+
+For relative items the requirement that the weights add up to zero is not needed for the result to be well defined; it is what makes the operator express a null combination rather than an arbitrary linear combination.
+Requiring it regardless of the nature of the items also keeps the rule independent of whether the \lstinline!absoluteValue! status of the items has been determined.
+
+The weights of a null combination are often constant, and the requirement that they add up to zero can then be verified at translation time.
+\end{nonnormative}
+
+\begin{nonnormative}
+If the number of items is zero, the null combination is the zero of the element type.
+
+For a non-zero number of items, writing $w$ for the weights and $x$ for the items, the null combination $\text{\lstinline!nullCombination!}(w,\, x)$ can conceptually be computed as follows using an arbitrary element $y$ of the $x$ element type.
+The null combination is formed using differences relative to $y$ (it can be shown that the result does not depend on the choice of $y$):
+\begin{equation*}
+\text{\lstinline!nullCombination!}(w,\, x) = \sum_{i} w_{i} (x_{i} - y)
+\end{equation*}
+\end{nonnormative}
+
+\begin{example}
+Finite difference approximation of a second-order derivative.
+Three temperatures are sampled with a time difference of \lstinline!h!.
+The approximation is a null combination of the temperatures, also when the temperatures are expressed in non-coherent units:
+\begin{lstlisting}[language=modelica]
+constant Real h = 0.01's';
+Real tPrev = 10'degC' annotation(absoluteValue = true);
+Real tMid = 12'degC' annotation(absoluteValue = true);
+Real tNext = 18'degC' annotation(absoluteValue = true);
+Real d2t = nullCombination({1, -2, 1} / h^2, {tPrev, tMid, tNext});
+\end{lstlisting}
+The use of \lstinline!nullCombination! avoids intermediate ill-formed expressions such as \lstinline!-tMid! or \lstinline!2 * tMid! -- a Celsius temperature cannot be negated or multiplied.
+A rewrite where only the Celsius differences such as \lstinline!tPrev - tMid! get multiplied is possible, but would lack the symmetry and clarity of the \lstinline!nullCombination! form.
+\end{example}
+\end{semantics}
+\end{operatordefinition}
+
+\begin{operatordefinition}[affineCombination]
+\begin{synopsis}\begin{lstlisting}
+affineCombination($\mathit{weights}$, $\mathit{items}$)
+\end{lstlisting}\end{synopsis}
+\begin{semantics}
+Compute an affine combination of an array of items.
+The $\mathit{weights}$ shall be a \lstinline!Real! vector of size \lstinline!size($\mathit{items}$, 1)!.
+The size must be non-zero, and the weights must add up to a value which is not close to zero.
+Since the weights can be the result of numeric computations, the requirement is deliberately approximate: it shall be verified with a tolerance, rejecting a sum so close to zero that the normalization would be dominated by numeric error.
+The result type is the same as the $\mathit{items}$ element type (stripping its first array dimension), and shall be a \lstinline!Real! scalar or array type.
+The result is the affine combination of the $\mathit{items}$ based on the normalized $\mathit{weights}$.
+All elements of $\mathit{items}$ must agree on being either absolute or relative quantities, and the result is a quantity of the same nature, compare \cref{modelica:absoluteValue}.
+
+\begin{nonnormative}
+When the $\mathit{items}$ are relative quantities, an affine combination is just a linear combination.
+The interesting case is when the $\mathit{items}$ are absolute quantities, due to the ability to clearly state that a new absolute quantity is produced.
+\end{nonnormative}
+
+\begin{nonnormative}
+Writing $w$ for the weights and $x$ for the items, the affine combination $\text{\lstinline!affineCombination!}(w,\, x)$ can conceptually be computed as follows using an arbitrary element $y$ of the $x$ element type.
+Define the normalized weights $\hat{w}_{i}$ such that $\sum_{i} \hat{w}_{i} = 1$:
+\begin{equation*}
+\hat{w}_{i} = \frac{w_{i}}{\sum_{j} w_{j}}
+\end{equation*}
+Then form the affine combination using differences relative to $y$ (it can be shown that the result does not depend on the choice of $y$):
+\begin{equation*}
+\text{\lstinline!affineCombination!}(w,\, x) = y + \sum_{i} \hat{w}_{i} (x_{i} - y)
+\end{equation*}
+\end{nonnormative}
+
+\begin{example}
+2~kilograms of water at 10~degrees Celsius are mixed with 5~kilograms of water at 20~degrees Celsius.
+The resulting temperature is an affine combination of the temperatures, also when the temperatures are expressed in non-coherent units:
+\begin{lstlisting}[language=modelica]
+Real m1 = 2'kg';
+Real t1 = 10'degC' annotation(absoluteValue = true);
+Real m2 = 5'kg';
+Real t2 = 20'degC' annotation(absoluteValue = true);
+Real tMix = affineCombination({m1, m2}, {t1, t2});
+\end{lstlisting}
+The use of \lstinline!affineCombination! avoids intermediate ill-formed expressions such as \lstinline!m1 * t1! -- a Celsius temperature cannot be multiplied.
+A rewrite where only the Celsius difference \lstinline!t2 - t1! gets multiplied is possible, but would lack the symmetry and clarity of the \lstinline!affineCombination! form.
+\end{example}
 \end{semantics}
 \end{operatordefinition}
 

--- a/mlslistings.sty
+++ b/mlslistings.sty
@@ -71,7 +71,7 @@
     % Note: initial is in both variants - depending on context, use first variant
     morekeywords=[3]{% Selected recognized names that are not actual keywords, including:
         % 3.7.2 #derivative-and-special-purpose-operators-with-function-syntax
-        delay,cardinality,homotopy,semiLinear,inStream,actualStream,spatialDistribution,getInstanceName,%
+        delay,cardinality,homotopy,nullCombination,affineCombination,semiLinear,inStream,actualStream,spatialDistribution,getInstanceName,%
         terminal,noEvent,smooth,sample,pre,edge,change,reinit,%
         % 3.7.3 #event-related-operators-with-function-syntax (except initial)
         previous,hold,subSample,superSample,shiftSample,backSample,noClock,firstTick,interval,%


### PR DESCRIPTION
Driven by #3748, this PR introduces two new built-in functions which we are quite far from being possible to express as user-defined functions.  By having these in the language, the discussion about how to infer `absoluteValue` can avoid getting stuck on the issues that these two functions solve cleanly.

The concepts captured by these functions are well established in mathematics, and represented in several other software environments where the distinction between absolute and relative quantities is of importance.  Adding them to the language as a preparation for #3748 is similar to how we have recently added language features to prepare for good unit checking rules, such as semantics for raising to an integer power, rational exponents of units, the `nthRoot`, and unitful literals.

The examples demonstrate how the functions can be used with (non-coherent) absolute Celsius temperatures, but in principle they are equally important when working with absolute quantities of any unit, coherent or not.

When combined with future unit semantics, these functions will provide a powerful combination of features I didn't see in any of the other softwares in my survey:
- Static (translation-time) analysis of absolute vs relative.
- Possibility to consider weight variability when checking validity of the sum of the weights.
- Interplay with units in two different but meaningful ways for the two functions.

### Possible extension: homothety

The PR currently does *not* include a related operation in the same family, namely homothety, which could be defined as a syntactic sugar:
```
homothety(k, p, center = c) := affineCombination({1 - k, k}, {c, p})
```
The form of an operator where the center of the transformation is required to be given as a named argument would clarify intent when expressing things like "today the temperature is twice as warm as yesterday":
```
tToday = homothety(2, tYesterday, center = T_ice)
```
(I refuse to use the ridiculously named `Constants.T_zero`; the `T_ice` is just an alternative name which makes the expression above look more meaningful.)

In case the name `homothety` would be rejected because it sounds too similar to `homotopy`, alternative name candidates include `dilation` and `scale`.  With these less specific names, it could be argued that the operator should also allow scaling a relative quantity, and then the presence of `center` would mark the difference between operating on relative or absolute quantities.
